### PR TITLE
Proposta Diff CPOE

### DIFF
--- a/routes/static.py
+++ b/routes/static.py
@@ -7,6 +7,8 @@ from .utils import tryCommit, strNone, getFeatures
 from datetime import date
 from random import random 
 
+from services import prescription_drug_service
+
 app_stc = Blueprint('app_stc',__name__)
 
 @app_stc.route('/static/<string:schema>/prescription/<int:idPrescription>', methods=['GET'])
@@ -46,6 +48,7 @@ def computePrescription(schema, idPrescription):
         pAgg.idPatient = p.idPatient
         pAgg.admissionNumber = p.admissionNumber
         pAgg.date = date(p.date.year, p.date.month, p.date.day)
+        pAgg.status = 0
         newPrescAgg = True
 
     outpatient = request.args.get('outpatient', None)
@@ -62,7 +65,10 @@ def computePrescription(schema, idPrescription):
     pAgg.record = p.record
     pAgg.prescriber = 'Prescrição Agregada'
     pAgg.agg = True
-    pAgg.status = 0
+
+    if prescription_drug_service.has_unchecked_drugs(idPrescription):
+        pAgg.status = 0
+
     if 'data' in resultAgg:
         pAgg.features = getFeatures(resultAgg)
         pAgg.aggDrugs = pAgg.features['drugIDs']

--- a/services/prescription_drug_service.py
+++ b/services/prescription_drug_service.py
@@ -18,6 +18,14 @@ def getPrescriptionDrug(idPrescriptionDrug):
         .filter(PrescriptionDrug.id == idPrescriptionDrug)\
         .first()
 
+def has_unchecked_drugs(idPrescription):
+    count = db.session.query(PrescriptionDrug)\
+        .filter(PrescriptionDrug.idPrescription == idPrescription)\
+        .filter(or_(PrescriptionDrug.checked == False, PrescriptionDrug.checked == None))\
+        .count()
+
+    return count > 0
+
 def prescriptionDrugToDTO(pd):
     pdWhiteList = bool(pd[6].whiteList) if pd[6] is not None else False
 


### PR DESCRIPTION
### Problema:

Prescrições agregadas voltam a ficar pendentes após checadas.
Isso acontece muito no CPOE, pois o mesmo medicamento chega mais de uma vez no mesmo dia, apenas com a vigência alterada.

### Proposta de solução:

Atualmente sempre que chega uma prescrição nova para uma prescrição agregada, o status retorna para "não checada".
A proposta de solução é fazer essa alteração de status da prescrição agregada somente se a nova prescrição contém medicamentos que ainda não foram checados.
O que tu acha? Não consigo isolar essa lógica só pra CPOE, pois não tenho essa info na prescrição.
Acho legal conversarmos antes de bater o martelo sobre essa proposta.