### PR TITLE
fix cpoe solution grouping

### DIFF
--- a/models/prescription.py
+++ b/models/prescription.py
@@ -598,7 +598,10 @@ class PrescriptionDrug(db.Model):
                      .filter(or_(PrescriptionDrug.suspendedDate == None,\
                         func.date(PrescriptionDrug.suspendedDate) >= func.date(aggDate)))
         
-        return q.order_by(asc(Prescription.expire), desc(func.concat(PrescriptionDrug.idPrescription,PrescriptionDrug.solutionGroup)), asc(Drug.name)).all()
+        if is_cpoe:
+            return q.order_by(asc(Prescription.expire), desc(PrescriptionDrug.cpoe_group), asc(Drug.name)).all()
+        else:
+            return q.order_by(asc(Prescription.expire), desc(func.concat(PrescriptionDrug.idPrescription,PrescriptionDrug.solutionGroup)), asc(Drug.name)).all()
 
     def findByPrescriptionDrug(idPrescriptionDrug, future, is_cpoe = False):
         pd = PrescriptionDrug.query.get(idPrescriptionDrug)

--- a/routes/drugList.py
+++ b/routes/drugList.py
@@ -249,7 +249,7 @@ class DrugList():
     def getInfusionList(self):
         result = {}
         for pd in self.drugList:
-            if pd[0].solutionGroup and pd[0].source == 'Soluções':
+            if (pd[0].solutionGroup or pd[0].cpoe_group) and pd[0].source == 'Soluções':
                 key = self.getInfusionKey(pd)
 
                 if not key in result:


### PR DESCRIPTION
@heukirne
No cpoe, as soluções devem ser agrupadas pelo cpoe_grupo. Essa mudança já tinha sido feita, mas as views novas do cpoe não preenchem o campo sl_agrupamento. Sem esse campo, o backend não montava a lista com os totais das solução.