### PR TITLE
perf: add 25s statement timeout and SQL-side observation truncation on /prescriptions

### DIFF
--- a/decorators/api_endpoint_decorator.py
+++ b/decorators/api_endpoint_decorator.py
@@ -167,7 +167,13 @@ def api_endpoint(download_headers=None, is_admin=False):
                 db.session.remove()
 
                 logger.backend_logger.exception(str(e))
-                logger.backend_logger.error("Request data: %s", request.get_data())
+                # request.get_data() is the body only; log the query string too
+                # so GET params (e.g. /prescriptions filters) show up on timeouts
+                logger.backend_logger.error(
+                    "Request data: %s | query string: %s",
+                    request.get_data(),
+                    request.query_string.decode("utf-8", "replace"),
+                )
 
                 logger.backend_logger.warning(
                     json.dumps(

--- a/repository/prioritization_repository.py
+++ b/repository/prioritization_repository.py
@@ -1,9 +1,8 @@
 import re
 from datetime import date, datetime, timedelta
 
-from sqlalchemy import BigInteger, Integer, and_, cast, desc, func, or_
+from sqlalchemy import BigInteger, Integer, and_, cast, desc, func, or_, text
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.orm import undefer
 
 from exception.validation_error import ValidationError
 from models.appendix import Department
@@ -385,6 +384,10 @@ def get_prioritization_list(request: PrioritizationRequest, run_count: bool = Tr
     """
     base_q = _build_base_query(request)
 
+    # SET LOCAL lasts until the request transaction ends; keeps this query below
+    # the 30s API Gateway limit and stops abandoned queries from loading the db
+    db.session.execute(text("SET LOCAL statement_timeout = '25s'"))
+
     results = (
         base_q.with_entities(
             Prescription,
@@ -393,9 +396,10 @@ def get_prioritization_list(request: PrioritizationRequest, run_count: bool = Tr
             (Prescription.features["globalScore"].astext.cast(Integer)).label(
                 "globalScore"
             ),
+            # the service truncates to 300 chars; fetch 301 to detect overflow
+            func.left(Patient.observation, 301).label("observation"),
         )
         .order_by(desc("globalScore"))
-        .options(undefer(Patient.observation))
         .limit(500)
         .all()
     )

--- a/services/prioritization_service.py
+++ b/services/prioritization_service.py
@@ -79,12 +79,12 @@ def get_prioritization_list(request: PrioritizationRequest):
             features["scoreVariation"] = 0
             features["class"] = "blue"
 
+        # p.observation is truncated to 301 chars in SQL (func.left); a length
+        # over 300 means the original text overflows and gets an ellipsis
         observation = None
-        if p[1] and p[1].observation != None and p[1].observation != "":
+        if p.observation:
             observation = (
-                p[1].observation[:300] + "..."
-                if len(p[1].observation) > 300
-                else p[1].observation
+                p.observation[:300] + "..." if len(p.observation) > 300 else p.observation
             )
 
         results.append(


### PR DESCRIPTION
- Set LOCAL statement_timeout of 25s on the prioritization query so it
  fails fast below the 30s API Gateway limit instead of leaving orphaned
  queries running on the database after the gateway gives up
- Truncate Patient.observation to 301 chars in SQL (left()) instead of
  undeferring the full text for up to 500 rows and truncating in Python
- Log the query string in the generic exception handler so GET filter
  params are captured when a timeout (or any error) occurs

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WgD5r4MaepA9fCPptxrRYA