### PR TITLE
Add protocol evaluation tracing with user-friendly explanations

### DIFF
--- a/models/requests/protocol_request.py
+++ b/models/requests/protocol_request.py
@@ -13,6 +13,13 @@ class ProtocolListRequest(BaseModel):
     statusType: Optional[int] = None
 
 
+class ProtocolTraceRequest(BaseModel):
+    """Protocol trace request parameters"""
+
+    idPrescription: int
+    idProtocol: Optional[int] = None
+
+
 class ProtocolConfig(BaseModel):
     """Protocol: structure of a protocol configuration"""
 

--- a/repository/protocol_repository.py
+++ b/repository/protocol_repository.py
@@ -36,6 +36,19 @@ def list_protocols(request_data: ProtocolListRequest, schema: str) -> list[Proto
     )
 
 
+def get_protocol_by_id(protocol_id: int, schema: str) -> Protocol:
+    """Get one protocol visible to the schema (global or schema-owned)"""
+
+    return (
+        db.session.query(Protocol)
+        .filter(
+            Protocol.id == protocol_id,
+            or_(Protocol.schema == None, Protocol.schema == schema),
+        )
+        .first()
+    )
+
+
 def get_active_protocols(schema: str, protocol_type_list: list[ProtocolTypeEnum]):
     """get protocols to apply"""
 

--- a/routes/protocol.py
+++ b/routes/protocol.py
@@ -2,8 +2,8 @@
 
 from flask import Blueprint, request
 
-from services import protocol_service
-from models.requests.protocol_request import ProtocolListRequest
+from services import protocol_service, protocol_trace_service
+from models.requests.protocol_request import ProtocolListRequest, ProtocolTraceRequest
 from decorators.api_endpoint_decorator import api_endpoint
 
 app_protocol = Blueprint("app_protocol", __name__)
@@ -15,4 +15,13 @@ def list_protocols():
     """List all and filter protocols"""
     return protocol_service.list_protocols(
         request_data=ProtocolListRequest(**request.args)
+    )
+
+
+@app_protocol.route("/protocol/prescription-trace", methods=["GET"])
+@api_endpoint()
+def trace_protocol():
+    """Explain why protocols did or did not activate for a prescription"""
+    return protocol_trace_service.trace_protocol(
+        request_data=ProtocolTraceRequest(**request.args.to_dict(flat=True))
     )

--- a/services/alert_protocol_service.py
+++ b/services/alert_protocol_service.py
@@ -42,7 +42,7 @@ def find_protocols(
     results = {"items": []}
     summary = set()
 
-    drugs_by_expire_date = _split_drugs_by_date(
+    drugs_by_expire_date = split_drugs_by_date(
         drug_list=drug_list, prescription=prescription
     )
 
@@ -74,7 +74,8 @@ def find_protocols(
     return results
 
 
-def _split_drugs_by_date(drug_list: dict, prescription: Prescription):
+def split_drugs_by_date(drug_list: dict, prescription: Prescription):
+    """Groups prescription drugs by expire date (protocols run per date group)"""
     expire_dates = {}
     is_cpoe = segment_service.is_cpoe(id_segment=prescription.idSegment)
 

--- a/services/prescription_view_service.py
+++ b/services/prescription_view_service.py
@@ -676,6 +676,57 @@ def _get_alerts(
     return {"relations": relations, "alerts": alerts, "protocols": protocols}
 
 
+def get_protocol_evaluation_context(id_prescription: int, user_context: User) -> dict:
+    """Builds the same inputs _get_alerts uses for protocol evaluation.
+    Reused by the protocol trace endpoint to replay evaluation with tracing."""
+
+    prescription, patient, _, segment, _, _ = _get_prescription_data(
+        id_prescription=id_prescription
+    )
+
+    config_data = _get_configs(
+        prescription=prescription, patient=patient, is_complete=False
+    )
+
+    cn_data = _get_clinical_notes_stats(
+        prescription=prescription,
+        patient=patient,
+        config_data=config_data,
+        user_context=user_context,
+        is_complete=False,
+    )
+
+    exam_data = _get_exams(
+        patient=patient,
+        prescription=prescription,
+        config_data=config_data,
+        is_complete=False,
+        user_context=user_context,
+    )
+
+    drug_list = _get_drug_list(
+        prescription=prescription,
+        patient=patient,
+        config_data=config_data,
+        user_context=user_context,
+    )
+
+    protocol_extra_info = ProtocolExtraInfo()
+    protocol_extra_info.is_cpoe = config_data["is_cpoe"]
+    if segment:
+        protocol_extra_info.segment_type = segment.type
+
+    return {
+        "prescription": prescription,
+        "patient": patient,
+        "segment": segment,
+        "drug_list": drug_list,
+        "exams": exam_data["exams"],
+        "cn_stats": cn_data["cn_stats"],
+        "protocol_extra_info": protocol_extra_info,
+    }
+
+
 @timed()
 def _get_drug_data(
     drugs,

--- a/services/protocol_trace_service.py
+++ b/services/protocol_trace_service.py
@@ -1,0 +1,243 @@
+"""Service: protocol evaluation tracing (explains why protocols did/did not activate)"""
+
+from datetime import datetime
+
+from config import Config
+from decorators.has_permission_decorator import Permission, has_permission
+from exception.validation_error import ValidationError
+from models.appendix import Protocol
+from models.enums import NoHarmENV, ProtocolStatusTypeEnum, ProtocolTypeEnum
+from models.main import Drug, Substance, User, db
+from models.prescription import Prescription
+from models.requests.protocol_request import ProtocolTraceRequest
+from repository import protocol_repository
+from services import alert_protocol_service, prescription_view_service
+from utils import status
+from utils.alert_protocol import AlertProtocol
+from utils.alert_protocol_trace import build_summary, variable_trace_to_dict
+
+
+@has_permission(Permission.READ_PRESCRIPTION)
+def trace_protocol(request_data: ProtocolTraceRequest, user_context: User = None):
+    """Re-runs protocol evaluation for a prescription with tracing enabled and
+    returns a structured, user-friendly explanation per protocol"""
+
+    context = prescription_view_service.get_protocol_evaluation_context(
+        id_prescription=request_data.idPrescription, user_context=user_context
+    )
+    prescription: Prescription = context["prescription"]
+
+    applicable_types = _get_applicable_types(prescription=prescription)
+
+    if request_data.idProtocol is not None:
+        protocol = protocol_repository.get_protocol_by_id(
+            protocol_id=request_data.idProtocol, schema=user_context.schema
+        )
+
+        if protocol is None:
+            raise ValidationError(
+                "Protocolo inexistente",
+                "errors.invalidRecord",
+                status.HTTP_400_BAD_REQUEST,
+            )
+
+        protocols = [protocol]
+    else:
+        protocols = protocol_repository.get_active_protocols(
+            schema=user_context.schema, protocol_type_list=applicable_types
+        )
+
+    drugs_by_expire_date = alert_protocol_service.split_drugs_by_date(
+        drug_list=context["drug_list"], prescription=prescription
+    )
+
+    name_lookup = _build_name_lookup(
+        drug_list=context["drug_list"], protocols=protocols
+    )
+
+    return {
+        "idPrescription": str(prescription.id),
+        "evaluatedAt": datetime.now().isoformat(),
+        "protocols": [
+            _trace_single_protocol(
+                protocol=protocol,
+                context=context,
+                drugs_by_expire_date=drugs_by_expire_date,
+                applicable_types=applicable_types,
+                name_lookup=name_lookup,
+            )
+            for protocol in protocols
+        ],
+    }
+
+
+def _get_applicable_types(prescription: Prescription) -> list[ProtocolTypeEnum]:
+    """Protocol types that run for this prescription (mirrors find_protocols)"""
+
+    protocol_types = [
+        ProtocolTypeEnum.PRESCRIPTION_ALL,
+        ProtocolTypeEnum.PRESCRIPTION_ITEM,
+    ]
+    if prescription.agg:
+        protocol_types.append(ProtocolTypeEnum.PRESCRIPTION_AGG)
+    else:
+        protocol_types.append(ProtocolTypeEnum.PRESCRIPTION_INDIVIDUAL)
+
+    return protocol_types
+
+
+def _get_applicability(
+    protocol: Protocol, applicable_types: list[ProtocolTypeEnum]
+) -> tuple[bool, list[str]]:
+    """Checks if the protocol would run automatically for this prescription,
+    returning user-friendly notes when it would not"""
+
+    notes = []
+
+    if protocol.status_type == ProtocolStatusTypeEnum.INACTIVE.value:
+        notes.append("Este protocolo está inativo e não é executado automaticamente.")
+    elif (
+        protocol.status_type == ProtocolStatusTypeEnum.STAGING.value
+        and Config.ENV == NoHarmENV.PRODUCTION.value
+    ):
+        notes.append(
+            "Este protocolo está em homologação e não é executado em produção."
+        )
+
+    if protocol.protocol_type not in [t.value for t in applicable_types]:
+        notes.append(
+            "O tipo deste protocolo não se aplica a esta prescrição "
+            "(ex.: protocolo de prescrição agregada em prescrição individual)."
+        )
+
+    return len(notes) == 0, notes
+
+
+def _trace_single_protocol(
+    protocol: Protocol,
+    context: dict,
+    drugs_by_expire_date: dict,
+    applicable_types: list[ProtocolTypeEnum],
+    name_lookup: dict,
+) -> dict:
+    """Evaluates one protocol with tracing inside each expire-date group"""
+
+    applicable, applicability_notes = _get_applicability(
+        protocol=protocol, applicable_types=applicable_types
+    )
+
+    date_groups = []
+    for expire_date, drugs in drugs_by_expire_date.items():
+        alert_protocol = AlertProtocol(
+            drugs=drugs,
+            exams=context["exams"],
+            prescription=context["prescription"],
+            patient=context["patient"],
+            cn_stats=context["cn_stats"],
+            protocol_extra_info=context["protocol_extra_info"],
+        )
+
+        try:
+            trace = alert_protocol.evaluate_with_trace(protocol=protocol.config)
+        except (ValueError, NotImplementedError) as error:
+            date_groups.append(
+                {
+                    "date": expire_date,
+                    "error": f"Configuração do protocolo inválida: {str(error)}",
+                }
+            )
+            continue
+
+        date_groups.append(
+            {
+                "date": expire_date,
+                "activated": trace["activated"],
+                "summary": build_summary(
+                    activated=trace["activated"],
+                    protocol_name=protocol.name,
+                    substituted_trigger=trace["substituted_trigger"],
+                ),
+                "trigger": {
+                    "expression": trace["trigger"],
+                    "substituted": trace["substituted_trigger"],
+                    "result": trace["activated"],
+                },
+                "result": trace["result"],
+                "variableMessages": trace["variable_messages"],
+                "relatedItems": trace["related_items"],
+                "variables": [
+                    variable_trace_to_dict(trace=v, name_lookup=name_lookup)
+                    for v in trace["variables"]
+                ],
+            }
+        )
+
+    return {
+        "idProtocol": protocol.id,
+        "name": protocol.name,
+        "protocolType": protocol.protocol_type,
+        "statusType": protocol.status_type,
+        "applicable": applicable,
+        "applicabilityNotes": applicability_notes,
+        "dateGroups": date_groups,
+    }
+
+
+def _build_name_lookup(drug_list, protocols: list[Protocol]) -> dict:
+    """Maps substance/drug ids to names so trace messages show names instead of ids.
+    Covers ids present in the prescription plus ids expected by the protocols."""
+
+    substance_map = {}
+    drug_map = {}
+
+    for d in drug_list:
+        prescription_drug = d[0]
+        drug = d[1]
+        substance = d[11]
+
+        if substance is not None:
+            substance_map[str(substance.id)] = substance.name
+
+        if drug is not None and prescription_drug.idDrug is not None:
+            drug_map[str(prescription_drug.idDrug)] = drug.name
+
+    # ids referenced by protocol configs but absent from the prescription
+    substance_ids = set()
+    drug_ids = set()
+    for protocol in protocols:
+        config = protocol.config if protocol.config else {}
+        for variable in config.get("variables", []):
+            field = variable.get("field")
+
+            if field == "substance":
+                substance_ids.update(str(v) for v in variable.get("value") or [])
+            elif field == "idDrug":
+                drug_ids.update(str(v) for v in variable.get("value") or [])
+            elif field == "combination":
+                substance_ids.update(str(v) for v in variable.get("substance") or [])
+                drug_ids.update(str(v) for v in variable.get("drug") or [])
+
+    substance_ids = {
+        i for i in substance_ids if i not in substance_map and i.isdigit()
+    }
+    drug_ids = {i for i in drug_ids if i not in drug_map and i.isdigit()}
+
+    if substance_ids:
+        substances = (
+            db.session.query(Substance)
+            .filter(Substance.id.in_([int(i) for i in substance_ids]))
+            .all()
+        )
+        for substance in substances:
+            substance_map[str(substance.id)] = substance.name
+
+    if drug_ids:
+        drugs = (
+            db.session.query(Drug)
+            .filter(Drug.id.in_([int(i) for i in drug_ids]))
+            .all()
+        )
+        for drug in drugs:
+            drug_map[str(drug.id)] = drug.name
+
+    return {"substance": substance_map, "drug": drug_map}

--- a/tests/unit/test_alert_protocol_trace.py
+++ b/tests/unit/test_alert_protocol_trace.py
@@ -1,0 +1,374 @@
+"""Test: protocol evaluation tracing (evaluate_with_trace + PT messages)"""
+
+from datetime import date, timedelta
+
+from models.prescription import Patient, Prescription
+from tests.utils import utils_test_prescription
+from utils.alert_protocol import AlertProtocol
+from utils.alert_protocol_trace import (
+    CombinationCriterionTrace,
+    CombinationDrugTrace,
+    TraceReasonEnum,
+    VariableTrace,
+    build_summary,
+    build_variable_message,
+    variable_trace_to_dict,
+)
+
+
+def _get_alert_protocol(drug_list=None, exams=None, cn_stats=None):
+    """Builds an AlertProtocol instance with minimal mock data"""
+
+    prescription = Prescription()
+    prescription.idDepartment = 100
+
+    patient = Patient()
+
+    return AlertProtocol(
+        drugs=drug_list if drug_list is not None else [],
+        exams=exams if exams is not None else {},
+        prescription=prescription,
+        patient=patient,
+        cn_stats=cn_stats if cn_stats is not None else {},
+    )
+
+
+def _folfox_drug_list():
+    return [
+        utils_test_prescription.get_prescription_drug_mock_row(
+            id_prescription_drug=1,
+            dose=10,
+            drug_name="FLUOROURACIL",
+            drug_class="Q1",
+            sctid="FLUOROURACIL",
+        ),
+        utils_test_prescription.get_prescription_drug_mock_row(
+            id_prescription_drug=2,
+            dose=20,
+            drug_name="OXALIPLATINA",
+            drug_class="Q1",
+            sctid="OXALIPLATINA",
+        ),
+    ]
+
+
+def test_trace_activated():
+    """Protocol trace: activated protocol exposes per-variable results and trigger"""
+
+    protocol = {
+        "variables": [
+            {
+                "name": "v1",
+                "field": "substance",
+                "operator": "IN",
+                "value": ["FLUOROURACIL"],
+            },
+            {
+                "name": "v2",
+                "field": "substance",
+                "operator": "IN",
+                "value": ["OXALIPLATINA"],
+            },
+            {
+                "name": "v3",
+                "field": "substance",
+                "operator": "IN",
+                "value": ["DEXAMETASONA"],
+            },
+        ],
+        "trigger": "{{v1}} and ({{v2}} or {{v3}})",
+        "result": {"type": "SHOW_MESSAGE", "level": "high", "message": "FOLFOX"},
+    }
+
+    alert_protocol = _get_alert_protocol(drug_list=_folfox_drug_list())
+    trace = alert_protocol.evaluate_with_trace(protocol=protocol)
+
+    assert trace["activated"] is True
+    assert trace["result"] is not None
+    assert trace["trigger"] == "{{v1}} and ({{v2}} or {{v3}})"
+    assert trace["substituted_trigger"] == "True and (True or False)"
+
+    variables = trace["variables"]
+    assert len(variables) == 3
+
+    v1 = variables[0]
+    assert v1.name == "v1"
+    assert v1.result is True
+    assert v1.reason == TraceReasonEnum.COMPARED.value
+    assert "FLUOROURACIL" in v1.actual_value
+    assert v1.details["matched"] == ["FLUOROURACIL"]
+
+    v3 = variables[2]
+    assert v3.result is False
+    assert v3.reason == TraceReasonEnum.COMPARED.value
+    assert v3.details["matched"] == []
+
+
+def test_trace_not_activated():
+    """Protocol trace: non-activated protocol identifies the false variable"""
+
+    protocol = {
+        "variables": [
+            {
+                "name": "v1",
+                "field": "substance",
+                "operator": "IN",
+                "value": ["FLUOROURACIL"],
+            },
+            {
+                "name": "v3",
+                "field": "substance",
+                "operator": "IN",
+                "value": ["DEXAMETASONA"],
+            },
+        ],
+        "trigger": "{{v1}} and {{v3}}",
+        "result": {"type": "SHOW_MESSAGE", "level": "high", "message": "test"},
+    }
+
+    alert_protocol = _get_alert_protocol(drug_list=_folfox_drug_list())
+    trace = alert_protocol.evaluate_with_trace(protocol=protocol)
+
+    assert trace["activated"] is False
+    assert trace["result"] is None
+    assert trace["substituted_trigger"] == "True and False"
+
+    false_variables = [v for v in trace["variables"] if not v.result]
+    assert len(false_variables) == 1
+    assert false_variables[0].name == "v3"
+
+
+def test_trace_exam_missing_and_expired():
+    """Protocol trace: missing exam and expired exam produce distinct reasons"""
+
+    exams = {
+        "tgp": {
+            "value": 50,
+            "date": (date.today() - timedelta(days=10)).isoformat(),
+        },
+    }
+
+    protocol = {
+        "variables": [
+            {
+                "name": "tgo_alto",
+                "field": "exam",
+                "examType": "tgo",
+                "operator": ">",
+                "value": 40,
+            },
+            {
+                "name": "tgp_alto",
+                "field": "exam",
+                "examType": "tgp",
+                "examPeriod": 3,
+                "operator": ">",
+                "value": 40,
+            },
+        ],
+        "trigger": "{{tgo_alto}} and {{tgp_alto}}",
+        "result": {"type": "SHOW_MESSAGE", "level": "high", "message": "test"},
+    }
+
+    alert_protocol = _get_alert_protocol(exams=exams)
+    trace = alert_protocol.evaluate_with_trace(protocol=protocol)
+
+    assert trace["activated"] is False
+
+    tgo = trace["variables"][0]
+    assert tgo.result is False
+    assert tgo.reason == TraceReasonEnum.EXAM_NOT_FOUND.value
+    assert tgo.details["examType"] == "tgo"
+
+    tgp = trace["variables"][1]
+    assert tgp.result is False
+    assert tgp.reason == TraceReasonEnum.EXAM_EXPIRED.value
+    assert tgp.details["daysDiff"] == 10
+    assert tgp.details["examPeriod"] == 3
+
+
+def test_trace_combination_per_drug():
+    """Protocol trace: combination variables expose per-drug criteria detail"""
+
+    drug_list = [
+        utils_test_prescription.get_prescription_drug_mock_row(
+            id_prescription_drug=1,
+            dose=10,
+            drug_name="Drug A",
+            drug_class="J1",
+            route="ORAL",
+        ),
+        utils_test_prescription.get_prescription_drug_mock_row(
+            id_prescription_drug=2,
+            dose=200,
+            drug_name="Drug B",
+            drug_class="J1",
+            route="IV",
+        ),
+    ]
+
+    protocol = {
+        "variables": [
+            {
+                "name": "v1",
+                "field": "combination",
+                "class": ["J1"],
+                "dose": 100,
+                "doseOperator": ">",
+                "route": ["IV"],
+            },
+        ],
+        "trigger": "{{v1}}",
+        "result": {"type": "SHOW_MESSAGE", "level": "high", "message": "test"},
+    }
+
+    alert_protocol = _get_alert_protocol(drug_list=drug_list)
+    trace = alert_protocol.evaluate_with_trace(protocol=protocol)
+
+    assert trace["activated"] is True
+    assert trace["related_items"] == [2]
+
+    variable = trace["variables"][0]
+    assert variable.reason == TraceReasonEnum.COMBINATION_MATCHED.value
+    assert len(variable.drugs) == 2
+
+    drug_a = variable.drugs[0]
+    assert drug_a.drug_name == "Drug A"
+    assert drug_a.matched is False
+    assert drug_a.failed_criterion == "dose"
+    # criteria order: class, dose, route — route short-circuited
+    assert drug_a.criteria[0].result is True
+    assert drug_a.criteria[1].result is False
+    assert drug_a.criteria[2].criterion == "route"
+    assert drug_a.criteria[2].result is None
+    assert drug_a.criteria[2].actual is None
+
+    drug_b = variable.drugs[1]
+    assert drug_b.matched is True
+    assert drug_b.failed_criterion is None
+
+
+def test_get_protocol_alerts_unchanged():
+    """Protocol trace: plain get_protocol_alerts is unaffected by tracing"""
+
+    protocol = {
+        "variables": [
+            {
+                "name": "v1",
+                "field": "substance",
+                "operator": "IN",
+                "value": ["FLUOROURACIL"],
+            },
+        ],
+        "trigger": "{{v1}}",
+        "result": {"type": "SHOW_MESSAGE", "level": "high", "message": "test"},
+    }
+
+    alert_protocol = _get_alert_protocol(drug_list=_folfox_drug_list())
+
+    plain_before = alert_protocol.get_protocol_alerts(protocol=protocol)
+    assert alert_protocol.trace_log == []
+
+    trace = alert_protocol.evaluate_with_trace(protocol=protocol)
+    assert trace["activated"] is True
+    assert len(trace["variables"]) == 1
+
+    plain_after = alert_protocol.get_protocol_alerts(protocol=protocol)
+    assert plain_before == plain_after
+    # plain call must not have appended new trace entries
+    assert len(alert_protocol.trace_log) == 1
+
+
+def test_pt_messages():
+    """Protocol trace: Portuguese message builder output"""
+
+    substance_in = VariableTrace(
+        name="possui_fluorouracil",
+        field="substance",
+        operator="IN",
+        expected_value=["7947"],
+        result=True,
+        reason=TraceReasonEnum.COMPARED.value,
+        actual_value=["7947", "8812"],
+        details={"matched": ["7947"]},
+    )
+    name_lookup = {"substance": {"7947": "FLUOROURACIL"}, "drug": {}}
+    assert build_variable_message(substance_in, name_lookup) == (
+        "Variável 'possui_fluorouracil' (substância): "
+        "a prescrição contém: FLUOROURACIL → verdadeiro"
+    )
+
+    exam_missing = VariableTrace(
+        name="tgo_alto",
+        field="exam",
+        operator=">",
+        expected_value="40",
+        result=False,
+        reason=TraceReasonEnum.EXAM_NOT_FOUND.value,
+        details={"examType": "tgo"},
+    )
+    assert build_variable_message(exam_missing, name_lookup) == (
+        "Variável 'tgo_alto' (exame): o paciente não possui o exame 'tgo' "
+        "registrado → falso (dado indisponível)"
+    )
+
+    scalar = VariableTrace(
+        name="peso_baixo",
+        field="weight",
+        operator="<",
+        expected_value=60,
+        result=False,
+        reason=TraceReasonEnum.COMPARED.value,
+        actual_value=80.0,
+    )
+    assert build_variable_message(scalar, name_lookup) == (
+        "Variável 'peso_baixo' (peso (kg)): o valor encontrado foi 80; "
+        "esperado: menor que 60 → falso"
+    )
+
+    combination = VariableTrace(
+        name="combo_dose",
+        field="combination",
+        result=False,
+        reason=TraceReasonEnum.COMBINATION_NO_MATCH.value,
+        drugs=[
+            CombinationDrugTrace(
+                id_prescription_drug=982,
+                id_drug=77,
+                drug_name="OXALIPLATINA 50MG",
+                matched=False,
+                failed_criterion="dose",
+                criteria=[
+                    CombinationCriterionTrace(
+                        criterion="dose",
+                        operator=">=",
+                        expected=100.0,
+                        actual=50.0,
+                        result=False,
+                    ),
+                ],
+            ),
+        ],
+    )
+    combination_message = build_variable_message(combination, name_lookup)
+    assert "nenhum item da prescrição atende aos critérios" in combination_message
+    assert "'OXALIPLATINA 50MG' falhou no critério dose" in combination_message
+    assert "encontrado: 50; esperado: maior ou igual a 100" in combination_message
+
+    assert build_summary(
+        activated=True,
+        protocol_name="FOLFOX",
+        substituted_trigger="True and True",
+    ) == ("Protocolo 'FOLFOX' ATIVADO: o gatilho 'True and True' avaliou como verdadeiro.")
+
+    assert build_summary(
+        activated=False,
+        protocol_name="FOLFOX",
+        substituted_trigger="True and False",
+    ) == ("Protocolo 'FOLFOX' NÃO ativado: o gatilho 'True and False' avaliou como falso.")
+
+    # serialization includes labels and the ready-made message
+    serialized = variable_trace_to_dict(substance_in, name_lookup)
+    assert serialized["fieldLabel"] == "substância"
+    assert serialized["operatorLabel"] == "contém pelo menos um de"
+    assert serialized["message"].endswith("→ verdadeiro")

--- a/utils/alert_protocol.py
+++ b/utils/alert_protocol.py
@@ -10,6 +10,12 @@ from models.enums import DrugTypeEnum
 from models.main import DrugAttributes, Substance
 from models.prescription import Patient, Prescription, PrescriptionDrug
 from utils import prescriptionutils
+from utils.alert_protocol_trace import (
+    CombinationCriterionTrace,
+    CombinationDrugTrace,
+    TraceReasonEnum,
+    VariableTrace,
+)
 
 # Simpler regex that avoids ReDoS by using alternation without nested quantifiers
 # Matches any combination of: keywords (True, False, and, or, not) OR structural chars (whitespace, parens)
@@ -40,6 +46,7 @@ class AlertProtocol:
     protocol_msgs = None
     related_items = None  # list of prescriptions items who were related to the protocol being active
     protocol_extra_info: Union[ProtocolExtraInfo, None] = None
+    trace_log = None  # list of VariableTrace filled when tracing is enabled
 
     def __init__(
         self,
@@ -84,6 +91,11 @@ class AlertProtocol:
         self.related_items = []
         self.protocol_extra_info = protocol_extra_info if protocol_extra_info else None
 
+        self._trace_enabled = False
+        self.trace_log = []
+        self._current_trace = None
+        self._last_substituted_trigger = None
+
         # fill lists
         for d in self.filtered_drugs:
             prescription_drug: PrescriptionDrug = d[0]
@@ -109,7 +121,21 @@ class AlertProtocol:
         self.related_items = []
 
         for v in protocol.get("variables", []):
+            if self._trace_enabled:
+                self._current_trace = VariableTrace(
+                    name=v.get("name"),
+                    field=v.get("field"),
+                    operator=v.get("operator"),
+                    expected_value=v.get("value"),
+                )
+
             self.protocol_variables[v.get("name")] = self._fill_variable(variable=v)
+
+            if self._trace_enabled and self._current_trace is not None:
+                self._current_trace.result = self.protocol_variables[v.get("name")]
+                self.trace_log.append(self._current_trace)
+                self._current_trace = None
+
             fail_msg = v.get("message", {})
             if fail_msg.get("if", None) == self.protocol_variables[v.get("name")]:
                 self.protocol_msgs.append(fail_msg.get("then"))
@@ -117,6 +143,8 @@ class AlertProtocol:
         trigger = protocol.get("trigger")
         for var, value in self.protocol_variables.items():
             trigger = trigger.replace("{{" + var + "}}", str(value))
+
+        self._last_substituted_trigger = trigger
 
         if not self._is_safe_logical_expression(trigger):
             raise ValueError("unsafe expression")
@@ -132,6 +160,93 @@ class AlertProtocol:
 
         return None
 
+    def evaluate_with_trace(self, protocol: dict) -> dict:
+        """Runs get_protocol_alerts with tracing enabled and returns the result
+        plus a structured evaluation trace (one VariableTrace per variable)"""
+
+        self._trace_enabled = True
+        self.trace_log = []
+        try:
+            result = self.get_protocol_alerts(protocol=protocol)
+        finally:
+            self._trace_enabled = False
+            self._current_trace = None
+
+        return {
+            "activated": result is not None,
+            "result": result,
+            "trigger": protocol.get("trigger"),
+            "substituted_trigger": self._last_substituted_trigger,
+            "variables": self.trace_log,
+            "related_items": list(self.related_items),
+            "variable_messages": list(self.protocol_msgs),
+        }
+
+    def _trace_miss(self, reason: TraceReasonEnum, **details) -> bool:
+        """Records an early-exit reason when tracing; always returns False"""
+
+        if self._trace_enabled and self._current_trace is not None:
+            self._current_trace.reason = reason.value
+            self._current_trace.details.update(details)
+
+        return False
+
+    def _trace_compare(self, op: str, value1, value2, **details) -> bool:
+        """Wraps _compare, recording actual/expected values when tracing"""
+
+        result = self._compare(op=op, value1=value1, value2=value2)
+
+        if self._trace_enabled and self._current_trace is not None:
+            self._current_trace.reason = TraceReasonEnum.COMPARED.value
+            self._current_trace.actual_value = value1
+            self._current_trace.details.update(details)
+
+            if op in ("IN", "NOTIN", "NOT IN"):
+                try:
+                    self._current_trace.details["matched"] = sorted(
+                        set(value1) & set(value2)
+                    )
+                except TypeError:
+                    pass
+
+        return result
+
+    def _combo_criterion(
+        self, current: bool, criterion: str, op: str, value1, value2, drug_trace
+    ) -> bool:
+        """Evaluates one combination criterion preserving short-circuit semantics;
+        records per-drug trace when tracing is enabled"""
+
+        if not current:
+            if drug_trace is not None:
+                drug_trace.criteria.append(
+                    CombinationCriterionTrace(
+                        criterion=criterion,
+                        operator=op,
+                        expected=value2,
+                        actual=None,
+                        result=None,
+                    )
+                )
+            return False
+
+        result = self._compare(op=op, value1=value1, value2=value2)
+
+        if drug_trace is not None:
+            drug_trace.criteria.append(
+                CombinationCriterionTrace(
+                    criterion=criterion,
+                    operator=op,
+                    expected=value2,
+                    actual=value1,
+                    result=result,
+                )
+            )
+            if not result and drug_trace.failed_criterion is None:
+                drug_trace.failed_criterion = criterion
+
+        return result
+
     def _fill_variable(self, variable: dict):
         field = variable.get("field", None)
         operator = variable.get("operator")
@@ -139,43 +254,63 @@ class AlertProtocol:
 
         if field == "substance":
             value = [str(v) for v in value]
-            return self._compare(op=operator, value1=self.substance_list, value2=value)
+            return self._trace_compare(
+                op=operator, value1=self.substance_list, value2=value
+            )
 
         if field == "class":
-            return self._compare(op=operator, value1=self.class_list, value2=value)
+            return self._trace_compare(
+                op=operator, value1=self.class_list, value2=value
+            )
 
         if field == "idDrug":
             value = [str(v) for v in value]
-            return self._compare(op=operator, value1=self.id_drug_list, value2=value)
+            return self._trace_compare(
+                op=operator, value1=self.id_drug_list, value2=value
+            )
 
         if field == "route":
-            return self._compare(op=operator, value1=self.route_list, value2=value)
+            return self._trace_compare(
+                op=operator, value1=self.route_list, value2=value
+            )
 
         if field == "cn_stats":
             stats_type = variable.get("statsType")
             if stats_type not in self.cn_stats:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.STAT_NOT_FOUND, statsType=stats_type
+                )
 
             if self.cn_stats.get(stats_type, None) is None:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.STAT_NOT_FOUND, statsType=stats_type
+                )
 
             try:
                 stats_value = int(self.cn_stats.get(stats_type))
                 value = int(value)
             except ValueError:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.VALUE_NOT_NUMERIC, statsType=stats_type
+                )
 
-            return self._compare(op=operator, value1=stats_value, value2=value)
+            return self._trace_compare(
+                op=operator, value1=stats_value, value2=value, statsType=stats_type
+            )
 
         if field == "exam":
             exam_type = variable.get("examType")
             exam_period = variable.get("examPeriod", None)
 
             if exam_type not in self.exams:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.EXAM_NOT_FOUND, examType=exam_type
+                )
 
             if self.exams[exam_type]["value"] is None:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.EXAM_VALUE_MISSING, examType=exam_type
+                )
 
             if exam_period is not None:
                 try:
@@ -185,30 +320,52 @@ class AlertProtocol:
                     days_diff = (date.today() - exam_date).days
 
                     if int(days_diff) > int(exam_period):
-                        return False
+                        return self._trace_miss(
+                            TraceReasonEnum.EXAM_EXPIRED,
+                            examType=exam_type,
+                            examDate=exam_date.isoformat(),
+                            daysDiff=days_diff,
+                            examPeriod=exam_period,
+                        )
                 except (ValueError, KeyError):
-                    return False
+                    return self._trace_miss(
+                        TraceReasonEnum.EXAM_DATE_INVALID, examType=exam_type
+                    )
 
             try:
                 exam_value = float(self.exams[exam_type]["value"])
                 value = float(value)
             except ValueError:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.VALUE_NOT_NUMERIC, examType=exam_type
+                )
 
-            return self._compare(op=operator, value1=exam_value, value2=value)
+            return self._trace_compare(
+                op=operator,
+                value1=exam_value,
+                value2=value,
+                examType=exam_type,
+                examDate=self.exams[exam_type].get("date"),
+            )
 
         if field == "exam_ref":
             exam_type = variable.get("examRefType")
             exam_period = variable.get("examRefPeriod", None)
 
             if not self.exams_by_ref:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.EXAM_NOT_FOUND, examType=exam_type
+                )
 
             if exam_type not in self.exams_by_ref:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.EXAM_NOT_FOUND, examType=exam_type
+                )
 
             if self.exams_by_ref[exam_type]["value"] is None:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.EXAM_VALUE_MISSING, examType=exam_type
+                )
 
             if exam_period is not None:
                 try:
@@ -218,24 +375,40 @@ class AlertProtocol:
                     days_diff = (date.today() - exam_date).days
 
                     if int(days_diff) > int(exam_period):
-                        return False
+                        return self._trace_miss(
+                            TraceReasonEnum.EXAM_EXPIRED,
+                            examType=exam_type,
+                            examDate=exam_date.isoformat(),
+                            daysDiff=days_diff,
+                            examPeriod=exam_period,
+                        )
                 except (ValueError, KeyError):
-                    return False
+                    return self._trace_miss(
+                        TraceReasonEnum.EXAM_DATE_INVALID, examType=exam_type
+                    )
 
             try:
                 exam_value = float(self.exams_by_ref[exam_type]["value"])
                 value = float(value)
             except ValueError:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.VALUE_NOT_NUMERIC, examType=exam_type
+                )
 
-            return self._compare(op=operator, value1=exam_value, value2=value)
+            return self._trace_compare(
+                op=operator,
+                value1=exam_value,
+                value2=value,
+                examType=exam_type,
+                examDate=self.exams_by_ref[exam_type].get("date"),
+            )
 
         if field == "admissionTime":
             if not self.patient:
-                return False
+                return self._trace_miss(TraceReasonEnum.NO_PATIENT)
 
             if not self.patient.admissionDate:
-                return False
+                return self._trace_miss(TraceReasonEnum.NO_ADMISSION_DATE)
 
             hours_diff = (
                 datetime.now() - self.patient.admissionDate
@@ -244,13 +417,18 @@ class AlertProtocol:
             try:
                 value = float(value)
             except ValueError:
-                return False
+                return self._trace_miss(TraceReasonEnum.VALUE_NOT_NUMERIC)
 
-            return self._compare(op=operator, value1=hours_diff, value2=value)
+            return self._trace_compare(
+                op=operator,
+                value1=hours_diff,
+                value2=value,
+                admissionDate=self.patient.admissionDate.isoformat(),
+            )
 
         if field == "stConcilia":
             if not self.patient:
-                return False
+                return self._trace_miss(TraceReasonEnum.NO_PATIENT)
 
             st_concilia = (
                 self.patient.st_conciliation
@@ -261,41 +439,41 @@ class AlertProtocol:
             try:
                 value = int(value)
             except ValueError:
-                return False
+                return self._trace_miss(TraceReasonEnum.VALUE_NOT_NUMERIC)
 
-            return self._compare(op=operator, value1=st_concilia, value2=value)
+            return self._trace_compare(op=operator, value1=st_concilia, value2=value)
 
         if field == "age":
             age = self.exams.get("age", None)
             if not age:
-                return False
+                return self._trace_miss(TraceReasonEnum.AGE_MISSING)
 
             try:
                 age = float(age)
                 value = float(value)
             except ValueError:
-                return False
+                return self._trace_miss(TraceReasonEnum.VALUE_NOT_NUMERIC)
 
-            return self._compare(op=operator, value1=age, value2=value)
+            return self._trace_compare(op=operator, value1=age, value2=value)
 
         if field == "weight":
             weight = self.exams.get("weight", None)
             if not weight:
-                return False
+                return self._trace_miss(TraceReasonEnum.WEIGHT_MISSING)
             try:
                 weight = float(weight)
                 value = float(value)
             except ValueError:
-                return False
+                return self._trace_miss(TraceReasonEnum.VALUE_NOT_NUMERIC)
 
-            return self._compare(op=operator, value1=weight, value2=value)
+            return self._trace_compare(op=operator, value1=weight, value2=value)
 
         if field == "segmentType":
             if (
                 self.protocol_extra_info is None
                 or self.protocol_extra_info.segment_type is None
             ):
-                return False
+                return self._trace_miss(TraceReasonEnum.NO_SEGMENT_TYPE)
 
             if operator in ["IN", "NOT IN"]:
                 segment_type = [self.protocol_extra_info.segment_type]
@@ -303,7 +481,7 @@ class AlertProtocol:
             else:
                 segment_type = self.protocol_extra_info.segment_type
 
-            return self._compare(op=operator, value1=segment_type, value2=value)
+            return self._trace_compare(op=operator, value1=segment_type, value2=value)
 
         if field == "idDepartment":
             if operator in ["IN", "NOT IN"]:
@@ -312,27 +490,29 @@ class AlertProtocol:
             else:
                 department = self.prescription.idDepartment
 
-            return self._compare(op=operator, value1=department, value2=value)
+            return self._trace_compare(op=operator, value1=department, value2=value)
 
         if field == "idIcd":
             if operator in ["IN", "NOT IN"]:
                 id_icd = [str(self.patient.id_icd).lower()]
                 value = [str(v).lower() for v in value]
             else:
-                return False
+                return self._trace_miss(
+                    TraceReasonEnum.OPERATOR_NOT_SUPPORTED, operator=operator
+                )
 
-            return self._compare(op=operator, value1=id_icd, value2=value)
+            return self._trace_compare(op=operator, value1=id_icd, value2=value)
 
         if field == "dischargeReason":
-            return self._compare(
+            return self._trace_compare(
                 op="CONTAINS", value1=self.patient.dischargeReason, value2=value
             )
 
         if field == "insurance":
             if self.prescription is None or self.prescription.insurance is None:
-                return False
+                return self._trace_miss(TraceReasonEnum.INSURANCE_MISSING)
 
-            return self._compare(
+            return self._trace_compare(
                 op="CONTAINS", value1=self.prescription.insurance, value2=value
             )
 
@@ -343,7 +523,7 @@ class AlertProtocol:
             else:
                 segment = self.prescription.idSegment
 
-            return self._compare(op=operator, value1=segment, value2=value)
+            return self._trace_compare(op=operator, value1=segment, value2=value)
 
         if field == "combination":
             v_substance = variable.get("substance", None)
@@ -379,57 +559,81 @@ class AlertProtocol:
                 period_cpoe = d.period_cpoe
                 drug_attr_keys = self._get_drug_attribute_keys(drug_attributes)
 
+                drug_trace = None
+                if self._trace_enabled and self._current_trace is not None:
+                    drug_trace = CombinationDrugTrace(
+                        id_prescription_drug=prescription_drug.id,
+                        id_drug=prescription_drug.idDrug,
+                        drug_name=d[1].name if d[1] is not None else None,
+                    )
+                    self._current_trace.drugs.append(drug_trace)
+
                 exp_result = True
 
                 if v_substance is not None:
-                    if substance:
-                        exp_result = exp_result and self._compare(
-                            op="IN", value1=[str(substance.id)], value2=v_substance
-                        )
-                    else:
-                        exp_result = False
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="substance",
+                        op="IN",
+                        value1=[str(substance.id)] if substance else [],
+                        value2=v_substance,
+                        drug_trace=drug_trace,
+                    )
 
                 if v_drug is not None:
-                    exp_result = exp_result and self._compare(
-                        op="IN", value1=[str(prescription_drug.idDrug)], value2=v_drug
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="drug",
+                        op="IN",
+                        value1=[str(prescription_drug.idDrug)],
+                        value2=v_drug,
+                        drug_trace=drug_trace,
                     )
 
                 if v_class is not None:
-                    if substance:
-                        exp_result = exp_result and self._compare(
-                            op="IN", value1=[str(substance.idclass)], value2=v_class
-                        )
-                    else:
-                        exp_result = False
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="class",
+                        op="IN",
+                        value1=[str(substance.idclass)] if substance else [],
+                        value2=v_class,
+                        drug_trace=drug_trace,
+                    )
 
                 if v_dose is not None:
                     try:
                         v_dose = float(v_dose)
                     except ValueError:
-                        return False
-
-                    exp_result = exp_result and (
-                        self._compare(
-                            op=v_dose_op,
-                            value1=prescription_drug.doseconv
-                            if prescription_drug.doseconv is not None
-                            else 0,
-                            value2=v_dose,
+                        return self._trace_miss(
+                            TraceReasonEnum.VALUE_NOT_NUMERIC, criterion="dose"
                         )
+
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="dose",
+                        op=v_dose_op,
+                        value1=prescription_drug.doseconv
+                        if prescription_drug.doseconv is not None
+                        else 0,
+                        value2=v_dose,
+                        drug_trace=drug_trace,
                     )
 
                 if v_frequencyday is not None:
                     try:
                         v_frequencyday = float(v_frequencyday)
                     except ValueError:
-                        return False
-
-                    exp_result = exp_result and (
-                        self._compare(
-                            op=v_frequency_op,
-                            value1=prescription_drug.frequency,
-                            value2=v_frequencyday,
+                        return self._trace_miss(
+                            TraceReasonEnum.VALUE_NOT_NUMERIC, criterion="frequencyday"
                         )
+
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="frequencyday",
+                        op=v_frequency_op,
+                        value1=prescription_drug.frequency,
+                        value2=v_frequencyday,
+                        drug_trace=drug_trace,
                     )
 
                 if v_intravenous is not None:
@@ -439,12 +643,13 @@ class AlertProtocol:
                         else False
                     )
 
-                    exp_result = exp_result and (
-                        self._compare(
-                            op="=",
-                            value1=intravenous_value,
-                            value2=bool(v_intravenous),
-                        )
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="intravenous",
+                        op="=",
+                        value1=intravenous_value,
+                        value2=bool(v_intravenous),
+                        drug_trace=drug_trace,
                     )
 
                 if v_feeding_tube is not None:
@@ -454,31 +659,38 @@ class AlertProtocol:
                         else False
                     )
 
-                    exp_result = exp_result and (
-                        self._compare(
-                            op="=",
-                            value1=feeding_tube_value,
-                            value2=bool(v_feeding_tube),
-                        )
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="feedingTube",
+                        op="=",
+                        value1=feeding_tube_value,
+                        value2=bool(v_feeding_tube),
+                        drug_trace=drug_trace,
                     )
 
                 if v_default_measure_unit is not None:
                     if measure_unit is None:
-                        return False
-
-                    exp_result = exp_result and (
-                        self._compare(
-                            op="=",
-                            value1=measure_unit.measureunit_nh,
-                            value2=v_default_measure_unit,
+                        return self._trace_miss(
+                            TraceReasonEnum.MEASURE_UNIT_MISSING,
+                            criterion="defaultMeasureUnit",
                         )
+
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="defaultMeasureUnit",
+                        op="=",
+                        value1=measure_unit.measureunit_nh,
+                        value2=v_default_measure_unit,
+                        drug_trace=drug_trace,
                     )
 
                 if v_period is not None:
                     try:
                         v_period = int(v_period)
                     except ValueError:
-                        return False
+                        return self._trace_miss(
+                            TraceReasonEnum.VALUE_NOT_NUMERIC, criterion="period"
+                        )
 
                     _, item_period = prescriptionutils.get_prescription_item_period(
                         is_cpoe=self.protocol_extra_info.is_cpoe
@@ -488,40 +700,58 @@ class AlertProtocol:
                         cpoe_period=period_cpoe,
                     )
 
-                    exp_result = exp_result and (
-                        self._compare(
-                            op=v_period_op,
-                            value1=item_period,
-                            value2=v_period,
-                        )
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="period",
+                        op=v_period_op,
+                        value1=item_period,
+                        value2=v_period,
+                        drug_trace=drug_trace,
                     )
 
                 if v_route is not None:
-                    exp_result = exp_result and (
-                        self._compare(
-                            op="IN",
-                            value1=[prescription_drug.route],
-                            value2=v_route,
-                        )
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="route",
+                        op="IN",
+                        value1=[prescription_drug.route],
+                        value2=v_route,
+                        drug_trace=drug_trace,
                     )
 
                 if v_observation is not None:
-                    exp_result = exp_result and (
-                        self._compare(
-                            op="CONTAINS",
-                            value1=prescription_drug.notes,
-                            value2=v_observation,
-                        )
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="observation",
+                        op="CONTAINS",
+                        value1=prescription_drug.notes,
+                        value2=v_observation,
+                        drug_trace=drug_trace,
                     )
 
                 if v_drug_attribute is not None and len(v_drug_attribute) > 0:
-                    exp_result = exp_result and self._compare(
-                        op="IN", value1=drug_attr_keys, value2=v_drug_attribute
+                    exp_result = self._combo_criterion(
+                        current=exp_result,
+                        criterion="drugAttribute",
+                        op="IN",
+                        value1=drug_attr_keys,
+                        value2=v_drug_attribute,
+                        drug_trace=drug_trace,
                     )
+
+                if drug_trace is not None:
+                    drug_trace.matched = exp_result
 
                 if exp_result:
                     found = True
                     self.related_items.append(prescription_drug.id)
+
+            if self._trace_enabled and self._current_trace is not None:
+                self._current_trace.reason = (
+                    TraceReasonEnum.COMBINATION_MATCHED.value
+                    if found
+                    else TraceReasonEnum.COMBINATION_NO_MATCH.value
+                )
 
             return found
 

--- a/utils/alert_protocol_trace.py
+++ b/utils/alert_protocol_trace.py
@@ -1,0 +1,369 @@
+"""Trace structures and user-friendly messages for protocol evaluation (AlertProtocol)"""
+
+import dataclasses
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class TraceReasonEnum(Enum):
+    """Enum: why a protocol variable evaluated to its result"""
+
+    # a real comparison ran
+    COMPARED = "COMPARED"
+    COMBINATION_MATCHED = "COMBINATION_MATCHED"
+    COMBINATION_NO_MATCH = "COMBINATION_NO_MATCH"
+
+    # data-missing / defaulted-to-false early exits
+    STAT_NOT_FOUND = "STAT_NOT_FOUND"
+    EXAM_NOT_FOUND = "EXAM_NOT_FOUND"
+    EXAM_VALUE_MISSING = "EXAM_VALUE_MISSING"
+    EXAM_EXPIRED = "EXAM_EXPIRED"
+    EXAM_DATE_INVALID = "EXAM_DATE_INVALID"
+    VALUE_NOT_NUMERIC = "VALUE_NOT_NUMERIC"
+    NO_PATIENT = "NO_PATIENT"
+    NO_ADMISSION_DATE = "NO_ADMISSION_DATE"
+    AGE_MISSING = "AGE_MISSING"
+    WEIGHT_MISSING = "WEIGHT_MISSING"
+    NO_SEGMENT_TYPE = "NO_SEGMENT_TYPE"
+    INSURANCE_MISSING = "INSURANCE_MISSING"
+    OPERATOR_NOT_SUPPORTED = "OPERATOR_NOT_SUPPORTED"
+    MEASURE_UNIT_MISSING = "MEASURE_UNIT_MISSING"
+
+
+@dataclass
+class CombinationCriterionTrace:
+    """Trace: one criterion of a combination variable tested against one drug"""
+
+    criterion: str
+    operator: str
+    expected: any
+    actual: any
+    result: Optional[bool]  # None = not evaluated (short-circuited)
+
+
+@dataclass
+class CombinationDrugTrace:
+    """Trace: one prescription item tested against a combination variable"""
+
+    id_prescription_drug: int
+    id_drug: int
+    drug_name: Optional[str] = None
+    matched: bool = False
+    failed_criterion: Optional[str] = None
+    criteria: list[CombinationCriterionTrace] = dataclasses.field(
+        default_factory=list
+    )
+
+
+@dataclass
+class VariableTrace:
+    """Trace: evaluation record of one protocol variable"""
+
+    name: str
+    field: str
+    operator: Optional[str] = None
+    expected_value: any = None
+    result: bool = False
+    reason: str = TraceReasonEnum.COMPARED.value
+    actual_value: any = None
+    details: dict = dataclasses.field(default_factory=dict)
+    drugs: list[CombinationDrugTrace] = dataclasses.field(
+        default_factory=list
+    )  # combination only
+
+
+FIELD_LABELS = {
+    "substance": "substância",
+    "class": "classe de medicamento",
+    "idDrug": "medicamento",
+    "route": "via de administração",
+    "cn_stats": "indicador NoHarm Care",
+    "exam": "exame",
+    "exam_ref": "exame (por referência)",
+    "admissionTime": "tempo de internação (horas)",
+    "stConcilia": "situação da conciliação",
+    "age": "idade",
+    "weight": "peso (kg)",
+    "segmentType": "tipo de segmento",
+    "idDepartment": "setor",
+    "idIcd": "CID",
+    "dischargeReason": "motivo de alta",
+    "insurance": "convênio",
+    "idSegment": "segmento",
+    "combination": "combinação de critérios do item",
+}
+
+OPERATOR_LABELS = {
+    "IN": "contém pelo menos um de",
+    "NOTIN": "não contém nenhum de",
+    "NOT IN": "não contém nenhum de",
+    "CONTAINS": "contém o texto",
+    ">": "maior que",
+    "<": "menor que",
+    ">=": "maior ou igual a",
+    "<=": "menor ou igual a",
+    "=": "igual a",
+    "!=": "diferente de",
+}
+
+COMBINATION_CRITERION_LABELS = {
+    "substance": "substância",
+    "drug": "medicamento",
+    "class": "classe",
+    "dose": "dose",
+    "frequencyday": "frequência/dia",
+    "period": "período (dias)",
+    "route": "via de administração",
+    "observation": "observação",
+    "intravenous": "intravenoso",
+    "feedingTube": "sonda",
+    "defaultMeasureUnit": "unidade de medida padrão",
+    "drugAttribute": "atributo do medicamento",
+}
+
+# templates for early-exit reasons ("why the variable defaulted to false")
+REASON_TEMPLATES = {
+    TraceReasonEnum.STAT_NOT_FOUND.value: "o indicador '{statsType}' não está disponível para este paciente",
+    TraceReasonEnum.EXAM_NOT_FOUND.value: "o paciente não possui o exame '{examType}' registrado",
+    TraceReasonEnum.EXAM_VALUE_MISSING.value: "o exame '{examType}' não possui valor registrado",
+    TraceReasonEnum.EXAM_EXPIRED.value: (
+        "o exame '{examType}' mais recente é de {examDate} ({daysDiff} dias atrás), "
+        "fora do período de {examPeriod} dias exigido pelo protocolo"
+    ),
+    TraceReasonEnum.EXAM_DATE_INVALID.value: "não foi possível interpretar a data do exame '{examType}'",
+    TraceReasonEnum.VALUE_NOT_NUMERIC.value: "o valor configurado no protocolo não é numérico",
+    TraceReasonEnum.NO_PATIENT.value: "não há dados do paciente disponíveis",
+    TraceReasonEnum.NO_ADMISSION_DATE.value: "o paciente não possui data de internação registrada",
+    TraceReasonEnum.AGE_MISSING.value: "o paciente não possui idade registrada",
+    TraceReasonEnum.WEIGHT_MISSING.value: "o paciente não possui peso registrado",
+    TraceReasonEnum.NO_SEGMENT_TYPE.value: "o segmento da prescrição não possui tipo definido",
+    TraceReasonEnum.INSURANCE_MISSING.value: "a prescrição não possui convênio registrado",
+    TraceReasonEnum.OPERATOR_NOT_SUPPORTED.value: "o operador '{operator}' não é suportado para este campo",
+    TraceReasonEnum.MEASURE_UNIT_MISSING.value: "um dos itens da prescrição não possui unidade de medida padrão cadastrada",
+}
+
+# reasons caused by protocol configuration rather than missing patient data
+_CONFIG_REASONS = {
+    TraceReasonEnum.VALUE_NOT_NUMERIC.value,
+    TraceReasonEnum.OPERATOR_NOT_SUPPORTED.value,
+}
+
+_LIST_OPERATORS = {"IN", "NOTIN", "NOT IN"}
+
+
+def _fmt_value(value) -> str:
+    """Formats a value for display, trimming float noise"""
+    if isinstance(value, bool):
+        return "sim" if value else "não"
+    if isinstance(value, float):
+        rounded = round(value, 2)
+        if rounded == int(rounded):
+            return str(int(rounded))
+        return str(rounded)
+    return str(value)
+
+
+def _translate_values(values, mapping: dict) -> list[str]:
+    """Translates a list of ids to names using mapping; falls back to the raw value"""
+    if values is None:
+        return []
+    if not isinstance(values, (list, tuple, set)):
+        values = [values]
+    mapping = mapping or {}
+    return [mapping.get(str(v), _fmt_value(v)) for v in values]
+
+
+def _lookup_for_field(field_name: str, name_lookup: dict) -> dict:
+    """Picks the id->name map applicable to a variable field"""
+    name_lookup = name_lookup or {}
+    if field_name in ("substance",):
+        return name_lookup.get("substance", {})
+    if field_name in ("idDrug", "drug"):
+        return name_lookup.get("drug", {})
+    return {}
+
+
+def _result_suffix(result: bool) -> str:
+    return " → verdadeiro" if result else " → falso"
+
+
+def build_variable_message(trace: VariableTrace, name_lookup: dict = None) -> str:
+    """Builds a user-friendly Portuguese sentence explaining one variable's evaluation"""
+
+    field_label = FIELD_LABELS.get(trace.field, trace.field)
+    prefix = f"Variável '{trace.name}' ({field_label}): "
+
+    if trace.field == "combination":
+        return prefix + _build_combination_body(trace, name_lookup) + _result_suffix(
+            trace.result
+        )
+
+    if trace.reason in REASON_TEMPLATES:
+        template = REASON_TEMPLATES[trace.reason]
+        context = dict(trace.details)
+        context.setdefault("operator", trace.operator)
+        try:
+            body = template.format(**context)
+        except (KeyError, IndexError):
+            body = template.replace("{", "").replace("}", "")
+
+        note = (
+            " (configuração do protocolo inválida)"
+            if trace.reason in _CONFIG_REASONS
+            else " (dado indisponível)"
+        )
+        return prefix + body + _result_suffix(trace.result) + note
+
+    # reason == COMPARED
+    return prefix + _build_compared_body(trace, name_lookup) + _result_suffix(
+        trace.result
+    )
+
+
+def _build_compared_body(trace: VariableTrace, name_lookup: dict) -> str:
+    """Body for variables where a real comparison ran"""
+
+    mapping = _lookup_for_field(trace.field, name_lookup)
+    op = trace.operator
+
+    if op in _LIST_OPERATORS:
+        expected_names = ", ".join(_translate_values(trace.expected_value, mapping))
+        matched_names = ", ".join(
+            _translate_values(trace.details.get("matched", []), mapping)
+        )
+
+        if op == "IN":
+            if trace.result:
+                return f"a prescrição contém: {matched_names}"
+            return f"a prescrição não contém nenhum de: {expected_names}"
+
+        # NOTIN / NOT IN
+        if trace.result:
+            return f"a prescrição não contém nenhum de: {expected_names}"
+        return f"a prescrição contém: {matched_names}"
+
+    if op == "CONTAINS" or trace.operator is None:
+        actual = trace.actual_value if trace.actual_value is not None else "(vazio)"
+        return (
+            f"o valor encontrado foi '{actual}'; "
+            f"esperado conter o texto '{_fmt_value(trace.expected_value)}'"
+        )
+
+    op_label = OPERATOR_LABELS.get(op, op)
+    actual = (
+        _fmt_value(trace.actual_value) if trace.actual_value is not None else "(vazio)"
+    )
+    return (
+        f"o valor encontrado foi {actual}; "
+        f"esperado: {op_label} {_fmt_value(trace.expected_value)}"
+    )
+
+
+def _build_combination_body(trace: VariableTrace, name_lookup: dict) -> str:
+    """Body for combination variables, with per-drug detail"""
+
+    if trace.reason in REASON_TEMPLATES:
+        template = REASON_TEMPLATES[trace.reason]
+        try:
+            body = template.format(**trace.details)
+        except (KeyError, IndexError):
+            body = template.replace("{", "").replace("}", "")
+        return body
+
+    matched = [d for d in trace.drugs if d.matched]
+
+    if matched:
+        names = ", ".join(
+            f"'{d.drug_name}'" if d.drug_name else f"item {d.id_prescription_drug}"
+            for d in matched
+        )
+        count = len(matched)
+        plural = "itens atendem" if count > 1 else "item atende"
+        return f"{count} {plural} aos critérios: {names}"
+
+    if not trace.drugs:
+        return "não há itens de prescrição para avaliar"
+
+    body = "nenhum item da prescrição atende aos critérios"
+    example = next((d for d in trace.drugs if d.failed_criterion), None)
+    if example:
+        failed = next(
+            (c for c in example.criteria if c.criterion == example.failed_criterion),
+            None,
+        )
+        name = example.drug_name or f"item {example.id_prescription_drug}"
+        if failed:
+            criterion_label = COMBINATION_CRITERION_LABELS.get(
+                failed.criterion, failed.criterion
+            )
+            op_label = OPERATOR_LABELS.get(failed.operator, failed.operator)
+            mapping = _lookup_for_field(failed.criterion, name_lookup)
+            expected = ", ".join(_translate_values(failed.expected, mapping))
+            actual = ", ".join(_translate_values(failed.actual, mapping)) or "(vazio)"
+            body += (
+                f"; ex.: '{name}' falhou no critério {criterion_label} "
+                f"(encontrado: {actual}; esperado: {op_label} {expected})"
+            )
+
+    return body
+
+
+def build_summary(activated: bool, protocol_name: str, substituted_trigger: str) -> str:
+    """Builds the final Portuguese verdict for a protocol evaluation"""
+
+    if activated:
+        return (
+            f"Protocolo '{protocol_name}' ATIVADO: o gatilho "
+            f"'{substituted_trigger}' avaliou como verdadeiro."
+        )
+
+    return (
+        f"Protocolo '{protocol_name}' NÃO ativado: o gatilho "
+        f"'{substituted_trigger}' avaliou como falso."
+    )
+
+
+def criterion_trace_to_dict(criterion: CombinationCriterionTrace) -> dict:
+    """Serializes a combination criterion trace to a camelCase dict"""
+    return {
+        "criterion": criterion.criterion,
+        "criterionLabel": COMBINATION_CRITERION_LABELS.get(
+            criterion.criterion, criterion.criterion
+        ),
+        "operator": criterion.operator,
+        "operatorLabel": OPERATOR_LABELS.get(criterion.operator, criterion.operator),
+        "expected": criterion.expected,
+        "actual": criterion.actual,
+        "result": criterion.result,
+    }
+
+
+def drug_trace_to_dict(drug: CombinationDrugTrace) -> dict:
+    """Serializes a combination drug trace to a camelCase dict"""
+    return {
+        "idPrescriptionDrug": drug.id_prescription_drug,
+        "idDrug": drug.id_drug,
+        "name": drug.drug_name,
+        "matched": drug.matched,
+        "failedCriterion": drug.failed_criterion,
+        "criteria": [criterion_trace_to_dict(c) for c in drug.criteria],
+    }
+
+
+def variable_trace_to_dict(trace: VariableTrace, name_lookup: dict = None) -> dict:
+    """Serializes a variable trace to a camelCase dict, including the PT message"""
+    return {
+        "name": trace.name,
+        "field": trace.field,
+        "fieldLabel": FIELD_LABELS.get(trace.field, trace.field),
+        "operator": trace.operator,
+        "operatorLabel": OPERATOR_LABELS.get(trace.operator, trace.operator),
+        "expectedValue": trace.expected_value,
+        "actualValue": trace.actual_value,
+        "result": trace.result,
+        "reason": trace.reason,
+        "details": trace.details,
+        "drugs": [drug_trace_to_dict(d) for d in trace.drugs],
+        "message": build_variable_message(trace=trace, name_lookup=name_lookup),
+    }


### PR DESCRIPTION
## Summary

Adds comprehensive tracing capabilities to protocol evaluation in AlertProtocol, enabling detailed visibility into why protocols activate or fail. Includes a new service endpoint that replays protocol evaluation with tracing enabled and returns structured, user-friendly Portuguese explanations of each variable's evaluation.

## Key Changes

- **Protocol Tracing Infrastructure** (`utils/alert_protocol_trace.py`):
  - New `TraceReasonEnum` with 16+ reasons explaining early-exit conditions (missing data, expired exams, invalid values, etc.)
  - `VariableTrace` dataclass capturing per-variable evaluation details (name, field, operator, expected/actual values, result, reason)
  - `CombinationDrugTrace` and `CombinationCriterionTrace` for detailed per-drug combination variable tracing
  - Message builders (`build_variable_message`, `build_summary`) generating Portuguese explanations of variable evaluations
  - Serialization helpers for API responses

- **AlertProtocol Tracing** (`utils/alert_protocol.py`):
  - New `evaluate_with_trace()` method that runs protocol evaluation with tracing enabled and returns structured trace data
  - `_trace_enabled`, `trace_log`, `_current_trace` instance variables to track tracing state
  - `_trace_miss()` helper to record early-exit reasons when data is unavailable
  - `_trace_compare()` wrapper around `_compare()` that records actual/expected values and matched items for list operators
  - `_combo_criterion()` helper for per-drug combination criterion evaluation with short-circuit semantics
  - Updated `_fill_variable()` to use `_trace_compare()` and `_trace_miss()` throughout, replacing direct `_compare()` calls
  - Stores last substituted trigger expression for trace output

- **Protocol Trace Service** (`services/protocol_trace_service.py`):
  - New `trace_protocol()` endpoint handler that re-runs protocol evaluation with tracing
  - Supports tracing single protocol by ID or all applicable protocols for a prescription
  - Respects protocol applicability rules (status, type, environment)
  - Groups results by drug expiration date (mirrors alert_protocol_service behavior)
  - Builds name lookup mapping substance/drug IDs to names for readable trace messages
  - Returns structured response with per-protocol evaluation details

- **API Integration**:
  - New `ProtocolTraceRequest` model in `models/requests/protocol_request.py`
  - New `/protocol/trace` POST endpoint in `routes/protocol.py`
  - New `get_protocol_evaluation_context()` helper in `prescription_view_service.py` to extract reusable protocol evaluation inputs
  - Refactored `_split_drugs_by_date()` to public `split_drugs_by_date()` in `alert_protocol_service.py` for reuse

## Implementation Details

- Tracing is opt-in via `evaluate_with_trace()` method; plain `get_protocol_alerts()` calls are unaffected
- Trace data includes per-variable reason codes, actual/expected values, and details dict for context-specific information
- Combination variables expose per-drug criteria evaluation with short-circuit semantics (unevaluated criteria show `result=None`)
- Portuguese message templates handle 16+ early-exit reasons with context-specific details (exam dates, stat types, etc.)
- Name lookup maps substance/drug IDs to names so trace messages show readable names instead of numeric IDs
- Supports multi-date drug grouping for prescriptions with drugs expiring on different dates

https://claude.ai/code/session_01STVdKqJLWFP7XDhMPvadcC