### PR TITLE
test: add coverage for string utilities and segments API

### DIFF
--- a/tests/integration/test_segment.py
+++ b/tests/integration/test_segment.py
@@ -1,0 +1,84 @@
+from security.role import Role
+from tests.conftest import get_access, make_headers
+
+
+def _support_requester_headers(client):
+    """Headers for a role that lacks READ_BASIC_FEATURES (used to assert 401)."""
+    return make_headers(
+        get_access(client, roles=[Role.SUPPORT_REQUESTER.value])
+    )
+
+
+def test_get_segments_success(client, analyst_headers):
+    """Test get /segments - returns 200 with the seeded segments and expected fields"""
+    response = client.get("/segments", headers=analyst_headers)
+    data = response.get_json()["data"]
+
+    assert response.status_code == 200
+    assert isinstance(data, list)
+
+    segments_by_id = {s["id"]: s for s in data}
+
+    # Seed data contains two segments (see noharm-ai/database seed)
+    assert 1 in segments_by_id
+    assert 2 in segments_by_id
+
+    # Every serialized segment exposes the documented fields
+    for segment in data:
+        assert set(segment.keys()) == {"id", "description", "status", "type", "cpoe"}
+
+
+def test_get_segments_cpoe_flag(client, analyst_headers):
+    """Test get /segments - the cpoe flag reflects the underlying segment configuration"""
+    response = client.get("/segments", headers=analyst_headers)
+    segments_by_id = {s["id"]: s for s in response.get_json()["data"]}
+
+    assert response.status_code == 200
+    # Segment 1 is a regular segment, segment 2 is the CPOE segment
+    assert segments_by_id[1]["cpoe"] is False
+    assert segments_by_id[2]["cpoe"] is True
+
+
+def test_get_segments_ordered_by_description(client, analyst_headers):
+    """Test get /segments - results are ordered ascending by description"""
+    response = client.get("/segments", headers=analyst_headers)
+    descriptions = [s["description"] for s in response.get_json()["data"]]
+
+    assert response.status_code == 200
+    assert descriptions == sorted(descriptions)
+
+
+def test_get_segments_requires_basic_features_permission(client):
+    """Test get /segments - returns 401 when the user lacks READ_BASIC_FEATURES"""
+    response = client.get("/segments", headers=_support_requester_headers(client))
+
+    assert response.status_code == 401
+
+
+def test_get_segments_requires_authentication(client):
+    """Test get /segments - returns 401 when no authorization header is provided"""
+    response = client.get("/segments")
+
+    assert response.status_code == 401
+
+
+def test_get_segment_departments_success(client, analyst_headers):
+    """Test get /segments/departments - returns 200 with a list payload"""
+    response = client.get("/segments/departments", headers=analyst_headers)
+    data = response.get_json()["data"]
+
+    assert response.status_code == 200
+    assert isinstance(data, list)
+
+    # When departments exist, each entry exposes the documented mapping fields
+    for department in data:
+        assert set(department.keys()) == {"idSegment", "idDepartment", "label"}
+
+
+def test_get_segment_departments_requires_basic_features_permission(client):
+    """Test get /segments/departments - returns 401 when the user lacks READ_BASIC_FEATURES"""
+    response = client.get(
+        "/segments/departments", headers=_support_requester_headers(client)
+    )
+
+    assert response.status_code == 401

--- a/tests/unit/test_stringutils.py
+++ b/tests/unit/test_stringutils.py
@@ -20,3 +20,144 @@ def test_prepare_drug_name(name, prepared_name):
     """Teste stringutils - prepare_drug_name"""
 
     assert stringutils.prepare_drug_name(name) == prepared_name
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, ""),
+        (5, "5"),
+        ("text", "text"),
+        (0, "0"),
+        (False, "False"),
+    ],
+)
+def test_strNone(value, expected):
+    """Teste stringutils - strNone converts None to empty string, otherwise str()"""
+
+    assert stringutils.strNone(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (1234.5, "1.234,50"),
+        (1234567.89, "1.234.567,89"),
+        (5, "5,00"),
+        (0, "0,00"),
+        (999, "999,00"),
+    ],
+)
+def test_strFormatBR(value, expected):
+    """Teste stringutils - strFormatBR formats numbers in Brazilian notation"""
+
+    assert stringutils.strFormatBR(value) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("abc", "abc"),
+        ("a\x00b", "ab"),
+        ("a\tb\nc", "abc"),
+        ("hello world", "hello world"),
+        ("", ""),
+    ],
+)
+def test_strip_control_chars(text, expected):
+    """Teste stringutils - strip_control_chars removes non-printable characters"""
+
+    assert stringutils.strip_control_chars(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        # HTML special characters are escaped to prevent XSS
+        ("Hello & goodbye", "Hello &amp; goodbye"),
+        (
+            "<script>alert('xss')</script>",
+            "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;",
+        ),
+        # Newlines become <br> tags when whitespace is preserved
+        ("Line 1\nLine 2", "Line 1<br>Line 2"),
+        # Empty input is returned unchanged
+        ("", ""),
+    ],
+)
+def test_text_to_html(text, expected):
+    """Teste stringutils - text_to_html escapes HTML and preserves line breaks"""
+
+    assert stringutils.text_to_html(text) == expected
+
+
+def test_text_to_html_without_whitespace_preservation():
+    """Teste stringutils - text_to_html without whitespace preservation keeps escaping only"""
+
+    result = stringutils.text_to_html("Line 1\nLine 2", preserve_whitespace=False)
+
+    assert result == "Line 1\nLine 2"
+
+
+def test_text_to_html_collapses_multiple_spaces():
+    """Teste stringutils - text_to_html converts extra spaces to non-breaking spaces"""
+
+    assert stringutils.text_to_html("a   b") == "a &nbsp;&nbsp;b"
+
+
+@pytest.mark.parametrize(
+    "text, max_length, expected",
+    [
+        # Truncates on word boundary and appends ellipsis
+        ("Hello World", 8, "Hello..."),
+        # Returns text unchanged when it already fits
+        ("Hello World", 20, "Hello World"),
+        # Falsy input returns empty string
+        (None, 8, ""),
+        ("", 8, ""),
+        # Non-positive max_length returns empty string
+        ("abc", 0, ""),
+        ("abc", -5, ""),
+    ],
+)
+def test_truncate(text, max_length, expected):
+    """Teste stringutils - truncate shortens text respecting boundaries and edge cases"""
+
+    assert stringutils.truncate(text, max_length) == expected
+
+
+def test_truncate_custom_ellipsis():
+    """Teste stringutils - truncate honors a custom ellipsis string"""
+
+    assert stringutils.truncate("Hello World", 8, ellipsis="…") == "Hello…"
+
+
+@pytest.mark.parametrize(
+    "resource_path, valid_extensions, expected",
+    [
+        # Valid, simple filenames and paths
+        ("report.pdf", None, True),
+        ("folder/report.pdf", None, True),
+        ("UPPER_case-1.2.PDF", None, True),
+        # Empty path is rejected
+        ("", None, False),
+        # Path traversal attempts are rejected
+        ("../etc/passwd", None, False),
+        ("folder/../secret", None, False),
+        ("a\\b", None, False),
+        # URL-encoded traversal / separators are rejected
+        ("file%2e%2e", None, False),
+        ("file%2f", None, False),
+        # Null byte injection is rejected
+        ("file\x00.pdf", None, False),
+        # Disallowed characters are rejected
+        ("file!.pdf", None, False),
+        # Extension whitelist is enforced
+        ("report.pdf", {".pdf"}, True),
+        ("report.txt", {".pdf"}, False),
+    ],
+)
+def test_is_valid_filename(resource_path, valid_extensions, expected):
+    """Teste stringutils - is_valid_filename blocks path traversal and enforces extensions"""
+
+    assert stringutils.is_valid_filename(resource_path, valid_extensions) == expected


### PR DESCRIPTION
## Summary

Increases test coverage by adding tests for two previously untested features.

### 1. String utilities (`utils/stringutils.py`) — unit tests
Added to `tests/unit/test_stringutils.py`, covering functions that had no coverage:
- `strNone` — None → empty string conversion
- `strFormatBR` — Brazilian number formatting (`1234.5` → `1.234,50`)
- `strip_control_chars` — removal of non-printable characters
- `text_to_html` — HTML/XSS escaping and line-break preservation
- `truncate` — length limiting with word boundaries, custom ellipsis, and edge cases
- `is_valid_filename` — path-traversal, URL-encoded traversal, null-byte, and extension-whitelist validation (security-relevant)

### 2. Segments feature (`GET /segments`, `GET /segments/departments`) — integration tests
New file `tests/integration/test_segment.py`, covering:
- Payload shape and serialized fields
- The `cpoe` flag reflecting segment configuration
- Ascending ordering by description
- Permission enforcement (401 without `READ_BASIC_FEATURES`)
- Authentication enforcement (401 without a token)

## Testing
Full suite run locally against a seeded PostgreSQL database: **581 passed**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbDEQVB1GMK3ejNT11gzHG

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbDEQVB1GMK3ejNT11gzHG)_