### PR TITLE
test: add coverage for stringutils helpers and /tag/list endpoint

### DIFF
--- a/tests/integration/test_tag.py
+++ b/tests/integration/test_tag.py
@@ -63,7 +63,8 @@ def test_list_tags_returns_expected_shape(client, analyst_headers, seed_tags):
 
     assert response.status_code == 200
     items = response.get_json()["data"]
-    match = next(item for item in items if item["name"] == TAG_ACTIVE)
+    match = next((item for item in items if item["name"] == TAG_ACTIVE), None)
+    assert match is not None, f"Tag {TAG_ACTIVE} not found in response"
     assert match["tagType"] == PATIENT
     assert match["active"] is True
 

--- a/tests/integration/test_tag.py
+++ b/tests/integration/test_tag.py
@@ -1,0 +1,105 @@
+"""Integration tests for the /tag/list endpoint (tag_service.list_tags)."""
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import get_access, make_headers, session, session_commit
+
+from models.enums import TagTypeEnum
+from security.role import Role
+
+PATIENT = TagTypeEnum.PATIENT.value  # 1
+PATIENT_NAV = TagTypeEnum.PATIENT_NAVIGATION.value  # 2
+
+TAG_ACTIVE = "zztest_tag_active"
+TAG_INACTIVE = "zztest_tag_inactive"
+TAG_NAV = "zztest_tag_nav"
+
+
+@pytest.fixture
+def seed_tags():
+    """Insert distinctive marcador rows and remove them after the test."""
+    rows = [
+        (TAG_ACTIVE, PATIENT, True),
+        (TAG_INACTIVE, PATIENT, False),
+        (TAG_NAV, PATIENT_NAV, True),
+    ]
+    for name, tp, active in rows:
+        session.execute(
+            text(
+                "INSERT INTO demo.marcador "
+                "(nome, tp_marcador, ativo, created_at, created_by) "
+                "VALUES (:nome, :tp, :ativo, now(), 1)"
+            ),
+            {"nome": name, "tp": tp, "ativo": active},
+        )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM demo.marcador WHERE nome IN (:a, :b, :c)"),
+        {"a": TAG_ACTIVE, "b": TAG_INACTIVE, "c": TAG_NAV},
+    )
+    session_commit()
+
+
+def _names(response):
+    """Extract the set of tag names from a successful response envelope."""
+    return {item["name"] for item in response.get_json()["data"]}
+
+
+def test_list_tags_permission_denied(client):
+    """A user without READ_BASIC_FEATURES cannot list tags [401 UNAUTHORIZED]."""
+    headers = make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+    response = client.get("/tag/list", headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_list_tags_returns_expected_shape(client, analyst_headers, seed_tags):
+    """A successful listing returns objects with name, tagType and active fields."""
+    response = client.get(f"/tag/list?tagType={PATIENT}", headers=analyst_headers)
+
+    assert response.status_code == 200
+    items = response.get_json()["data"]
+    match = next(item for item in items if item["name"] == TAG_ACTIVE)
+    assert match["tagType"] == PATIENT
+    assert match["active"] is True
+
+
+def test_list_patient_tags_excludes_navigation_for_analyst(
+    client, analyst_headers, seed_tags
+):
+    """Without READ_NAV, listing patient tags excludes navigation-only tags."""
+    response = client.get(f"/tag/list?tagType={PATIENT}", headers=analyst_headers)
+
+    assert response.status_code == 200
+    names = _names(response)
+    assert TAG_ACTIVE in names
+    assert TAG_INACTIVE in names
+    assert TAG_NAV not in names
+
+
+def test_list_patient_tags_active_filter(client, analyst_headers, seed_tags):
+    """The active filter narrows results to active tags only."""
+    response = client.get(
+        f"/tag/list?tagType={PATIENT}&active=true", headers=analyst_headers
+    )
+
+    assert response.status_code == 200
+    names = _names(response)
+    assert TAG_ACTIVE in names
+    assert TAG_INACTIVE not in names
+
+
+def test_list_patient_tags_includes_navigation_for_curator(
+    client, curator_headers, seed_tags
+):
+    """With READ_NAV, listing patient tags also includes navigation tags."""
+    response = client.get(f"/tag/list?tagType={PATIENT}", headers=curator_headers)
+
+    assert response.status_code == 200
+    names = _names(response)
+    assert TAG_ACTIVE in names
+    assert TAG_NAV in names

--- a/tests/unit/test_stringutils.py
+++ b/tests/unit/test_stringutils.py
@@ -20,3 +20,163 @@ def test_prepare_drug_name(name, prepared_name):
     """Teste stringutils - prepare_drug_name"""
 
     assert stringutils.prepare_drug_name(name) == prepared_name
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, ""),
+        ("", ""),
+        (0, "0"),
+        (5, "5"),
+        ("abc", "abc"),
+    ],
+)
+def test_str_none(value, expected):
+    """Teste stringutils - strNone converts None to empty string, keeps others"""
+
+    assert stringutils.strNone(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (1234567.5, "1.234.567,50"),
+        (0, "0,00"),
+        (1000, "1.000,00"),
+        (12.3, "12,30"),
+    ],
+)
+def test_str_format_br(value, expected):
+    """Teste stringutils - strFormatBR uses Brazilian number formatting"""
+
+    assert stringutils.strFormatBR(value) == expected
+
+
+def test_strip_control_chars():
+    """Teste stringutils - strip_control_chars removes non-printable characters"""
+
+    assert stringutils.strip_control_chars("a\x00b\tc\n") == "abc"
+    assert stringutils.strip_control_chars("clean text") == "clean text"
+    assert stringutils.strip_control_chars("") == ""
+
+
+class TestTextToHtml:
+    """Teste stringutils - text_to_html (used to render user text safely as HTML)"""
+
+    def test_empty_returns_empty(self):
+        """Empty / falsy input returns an empty string"""
+        assert stringutils.text_to_html("") == ""
+        assert stringutils.text_to_html(None) == ""
+
+    def test_escapes_html_special_chars(self):
+        """HTML special characters are escaped to prevent XSS injection"""
+        assert (
+            stringutils.text_to_html("Hello & <b>x</b>")
+            == "Hello &amp; &lt;b&gt;x&lt;/b&gt;"
+        )
+
+    def test_escapes_script_tag(self):
+        """A script tag is fully neutralized when escaped"""
+        result = stringutils.text_to_html("<script>alert('xss')</script>")
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
+    def test_newline_becomes_br(self):
+        """Newlines become <br> tags when whitespace is preserved"""
+        assert stringutils.text_to_html("a\nb") == "a<br>b"
+
+    def test_multiple_spaces_preserved(self):
+        """Runs of spaces are preserved with non-breaking spaces"""
+        assert stringutils.text_to_html("a   b") == "a &nbsp;&nbsp;b"
+
+    def test_tab_becomes_nbsp(self):
+        """Tabs are converted to non-breaking spaces"""
+        assert stringutils.text_to_html("a\tb") == "a&nbsp;&nbsp;&nbsp;&nbsp;b"
+
+    def test_no_whitespace_preservation(self):
+        """When preserve_whitespace is False newlines are still escaped but not converted"""
+        result = stringutils.text_to_html("a\nb", preserve_whitespace=False)
+        assert "<br>" not in result
+
+
+class TestTruncate:
+    """Teste stringutils - truncate (safe string truncation)"""
+
+    def test_none_returns_empty(self):
+        """None / empty input returns an empty string"""
+        assert stringutils.truncate(None, 8) == ""
+        assert stringutils.truncate("", 8) == ""
+
+    def test_non_positive_max_length_returns_empty(self):
+        """A non-positive max_length returns an empty string"""
+        assert stringutils.truncate("abc", 0) == ""
+        assert stringutils.truncate("abc", -5) == ""
+
+    def test_short_text_unchanged(self):
+        """Text shorter than max_length is returned untouched"""
+        assert stringutils.truncate("Hello World", 20) == "Hello World"
+
+    def test_truncates_with_ellipsis(self):
+        """Longer text is truncated and ellipsis appended"""
+        assert stringutils.truncate("Hello World", 8) == "Hello..."
+
+    def test_custom_ellipsis(self):
+        """A custom ellipsis is honored"""
+        assert stringutils.truncate("Hello World", 8, ellipsis="…") == "Hello…"
+
+    def test_result_never_exceeds_max_length(self):
+        """The truncated result never exceeds max_length"""
+        result = stringutils.truncate("Hello World", 8)
+        assert len(result) <= 8
+
+    def test_word_boundary_disabled(self):
+        """Result is still within bounds when word boundary handling is off"""
+        result = stringutils.truncate("Hello World", 8, word_boundary=False)
+        assert len(result) <= 8
+
+
+class TestIsValidFilename:
+    """Teste stringutils - is_valid_filename (path-traversal protection)"""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "file.txt",
+            "folder/file.txt",
+            "a/b/c/file_1.pdf",
+            "report-2024.csv",
+        ],
+    )
+    def test_valid_paths(self, path):
+        """Well-formed relative paths are accepted"""
+        assert stringutils.is_valid_filename(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "",
+            "../etc/passwd",
+            "folder/../secret",
+            "a\\b",
+            "%2e%2e/x",
+            "%2f",
+            "file with space.txt",
+            "file$name.txt",
+        ],
+    )
+    def test_invalid_paths(self, path):
+        """Traversal, encoded traversal and illegal characters are rejected"""
+        assert stringutils.is_valid_filename(path) is False
+
+    def test_null_byte_rejected(self):
+        """Null byte injection is rejected"""
+        assert stringutils.is_valid_filename("a\x00b.txt") is False
+
+    def test_valid_extension_accepted(self):
+        """A path with an allowed extension passes the extension check"""
+        assert stringutils.is_valid_filename("report.pdf", {".pdf", ".csv"}) is True
+
+    def test_invalid_extension_rejected(self):
+        """A path whose extension is not allowed is rejected"""
+        assert stringutils.is_valid_filename("report.txt", {".pdf", ".csv"}) is False


### PR DESCRIPTION
## Summary

Increases test coverage by adding tests for two previously untested features.

### 1. `utils/stringutils` helpers (unit tests)
Extends `tests/unit/test_stringutils.py` — previously only `prepare_drug_name` was covered. Added tests for:
- `strNone` and `strFormatBR` (Brazilian number formatting)
- `strip_control_chars` (removal of non-printable characters)
- `text_to_html` — HTML/XSS escaping, newline/space/tab handling
- `truncate` — length bounds, ellipsis, word-boundary and edge cases
- `is_valid_filename` — path-traversal, encoded-traversal, null-byte and extension validation

### 2. `/tag/list` endpoint (integration tests)
New `tests/integration/test_tag.py` covering `tag_service.list_tags`:
- Permission gating (401 for a role without `READ_BASIC_FEATURES`)
- Response envelope shape (`name`, `tagType`, `active`)
- The `active` query filter
- The `READ_NAV`-dependent branch: patient-navigation tags are excluded for an analyst but included for a curator

The integration test seeds distinctive `marcador` rows via a fixture and removes them on teardown, so it is re-runnable and leaves no residue.

## Testing
Full suite run locally against a PostgreSQL instance loaded from `noharm-ai/database` (same SQL as CI): **577 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019u6LbS8mkJn7Ajk57wtQAe)_