### PR TITLE
test: add unit tests for network_utils and db_utils deadlock retry

### DIFF
--- a/tests/unit/test_db_utils.py
+++ b/tests/unit/test_db_utils.py
@@ -1,0 +1,113 @@
+"""Unit tests for utils.db_utils.run_with_deadlock_retry"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from utils.db_utils import run_with_deadlock_retry
+
+
+def _deadlock_error():
+    """Build an OperationalError that looks like a PostgreSQL deadlock (40P01)."""
+    return OperationalError("UPDATE ...", {}, Exception("deadlock detected"))
+
+
+def _other_error():
+    """Build a non-deadlock OperationalError."""
+    return OperationalError("UPDATE ...", {}, Exception("connection reset"))
+
+
+@pytest.fixture
+def fake_db():
+    """Inject a fake models.main module exposing a mock db session.
+
+    run_with_deadlock_retry does a late ``from models.main import db`` so the
+    session can be swapped out without touching the real ORM/app wiring.
+    """
+    fake_models = types.ModuleType("models")
+    fake_main = types.ModuleType("models.main")
+    fake_main.db = MagicMock()
+    fake_models.main = fake_main
+    with patch.dict(sys.modules, {"models": fake_models, "models.main": fake_main}):
+        yield fake_main.db
+
+
+@pytest.fixture(autouse=True)
+def no_sleep():
+    """Avoid real back-off delays and expose sleep for assertions."""
+    with patch("utils.db_utils.time.sleep") as mock_sleep:
+        yield mock_sleep
+
+
+class TestRunWithDeadlockRetry:
+    """Teste db_utils - run_with_deadlock_retry"""
+
+    def test_returns_value_without_retry_on_success(self, fake_db, no_sleep):
+        """When fn succeeds, its value is returned and nothing is retried"""
+        fn = MagicMock(return_value="ok")
+
+        result = run_with_deadlock_retry(fn)
+
+        assert result == "ok"
+        fn.assert_called_once()
+        fake_db.session.rollback.assert_not_called()
+        no_sleep.assert_not_called()
+
+    def test_retries_deadlock_then_succeeds(self, fake_db, no_sleep):
+        """A deadlock is retried after a rollback and the later value returned"""
+        fn = MagicMock(side_effect=[_deadlock_error(), "recovered"])
+        on_retry = MagicMock()
+
+        result = run_with_deadlock_retry(fn, on_retry=on_retry)
+
+        assert result == "recovered"
+        assert fn.call_count == 2
+        fake_db.session.rollback.assert_called_once()
+        on_retry.assert_called_once()
+        no_sleep.assert_called_once()
+
+    def test_raises_after_exhausting_retries(self, fake_db, no_sleep):
+        """A persistent deadlock is re-raised once retries are exhausted"""
+        fn = MagicMock(side_effect=_deadlock_error())
+
+        with pytest.raises(OperationalError):
+            run_with_deadlock_retry(fn, max_retries=3)
+
+        assert fn.call_count == 3
+        # rollback happens on every retry, i.e. max_retries - 1 times
+        assert fake_db.session.rollback.call_count == 2
+        assert no_sleep.call_count == 2
+
+    def test_non_deadlock_error_is_not_retried(self, fake_db, no_sleep):
+        """A non-deadlock OperationalError is raised immediately"""
+        fn = MagicMock(side_effect=_other_error())
+
+        with pytest.raises(OperationalError):
+            run_with_deadlock_retry(fn)
+
+        fn.assert_called_once()
+        fake_db.session.rollback.assert_not_called()
+        no_sleep.assert_not_called()
+
+    def test_exponential_backoff_delays(self, fake_db, no_sleep):
+        """Back-off grows exponentially from base_delay across attempts"""
+        fn = MagicMock(side_effect=_deadlock_error())
+
+        with pytest.raises(OperationalError):
+            run_with_deadlock_retry(fn, max_retries=3, base_delay=0.1)
+
+        delays = [call.args[0] for call in no_sleep.call_args_list]
+        assert delays == [pytest.approx(0.1), pytest.approx(0.2)]
+
+    def test_works_without_on_retry_callback(self, fake_db, no_sleep):
+        """on_retry is optional and omitting it still retries correctly"""
+        fn = MagicMock(side_effect=[_deadlock_error(), "ok"])
+
+        result = run_with_deadlock_retry(fn)
+
+        assert result == "ok"
+        assert fn.call_count == 2
+        fake_db.session.rollback.assert_called_once()

--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -1,0 +1,123 @@
+"""Unit tests for utils.network_utils (client IP extraction / validation)"""
+
+import pytest
+from flask import Flask
+
+from utils import network_utils
+
+
+@pytest.fixture
+def app():
+    """A bare Flask app used only to build request contexts."""
+    return Flask(__name__)
+
+
+class TestIsValidIp:
+    """Teste network_utils - is_valid_ip"""
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "192.168.0.1",
+            "8.8.8.8",
+            "255.255.255.255",
+            "0.0.0.0",
+            "::1",
+            "2001:db8::1",
+        ],
+    )
+    def test_valid_addresses(self, ip):
+        """Well-formed IPv4 and IPv6 addresses are accepted"""
+        assert network_utils.is_valid_ip(ip) is True
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "",
+            "not-an-ip",
+            "999.999.999.999",
+            "192.168.0",
+            "192.168.0.1.5",
+            "12345",
+            " 8.8.8.8",
+        ],
+    )
+    def test_invalid_addresses(self, ip):
+        """Malformed values are rejected"""
+        assert network_utils.is_valid_ip(ip) is False
+
+
+class TestGetClientIpFromRequest:
+    """Teste network_utils - get_client_ip_from_request"""
+
+    def test_uses_first_ip_from_x_forwarded_for(self, app):
+        """The first (original client) IP in X-Forwarded-For wins"""
+        with app.test_request_context(
+            headers={"X-Forwarded-For": "203.0.113.7, 70.41.3.18, 150.172.238.178"}
+        ):
+            assert network_utils.get_client_ip_from_request() == "203.0.113.7"
+
+    def test_x_forwarded_for_is_trimmed(self, app):
+        """Surrounding whitespace on the first entry is stripped"""
+        with app.test_request_context(
+            headers={"X-Forwarded-For": "  203.0.113.7  , 70.41.3.18"}
+        ):
+            assert network_utils.get_client_ip_from_request() == "203.0.113.7"
+
+    def test_falls_back_to_alternative_header(self, app):
+        """When X-Forwarded-For is absent, alternative headers are consulted"""
+        with app.test_request_context(headers={"X-Real-IP": "198.51.100.23"}):
+            assert network_utils.get_client_ip_from_request() == "198.51.100.23"
+
+    def test_cloudflare_header_supported(self, app):
+        """CF-Connecting-IP is honored as an alternative header"""
+        with app.test_request_context(headers={"CF-Connecting-IP": "198.51.100.9"}):
+            assert network_utils.get_client_ip_from_request() == "198.51.100.9"
+
+    def test_invalid_forwarded_for_falls_through(self, app):
+        """An invalid X-Forwarded-For entry is ignored in favor of a valid header"""
+        with app.test_request_context(
+            headers={"X-Forwarded-For": "garbage", "X-Real-IP": "198.51.100.23"}
+        ):
+            assert network_utils.get_client_ip_from_request() == "198.51.100.23"
+
+    def test_falls_back_to_remote_addr(self, app):
+        """With no forwarding headers, remote_addr is returned"""
+        with app.test_request_context(environ_base={"REMOTE_ADDR": "192.0.2.55"}):
+            assert network_utils.get_client_ip_from_request() == "192.0.2.55"
+
+    def test_forwarded_for_preferred_over_remote_addr(self, app):
+        """A valid X-Forwarded-For takes precedence over remote_addr"""
+        with app.test_request_context(
+            headers={"X-Forwarded-For": "203.0.113.7"},
+            environ_base={"REMOTE_ADDR": "192.0.2.55"},
+        ):
+            assert network_utils.get_client_ip_from_request() == "203.0.113.7"
+
+
+class TestGetClientIpWithValidation:
+    """Teste network_utils - get_client_ip_with_validation"""
+
+    def test_returns_normalized_public_ip(self, app):
+        """A valid public IP is returned normalized"""
+        with app.test_request_context(headers={"X-Forwarded-For": "203.0.113.7"}):
+            assert network_utils.get_client_ip_with_validation() == "203.0.113.7"
+
+    def test_ipv6_is_normalized(self, app):
+        """An IPv6 address is returned in its canonical compressed form"""
+        with app.test_request_context(headers={"X-Forwarded-For": "2001:0db8::0001"}):
+            assert network_utils.get_client_ip_with_validation() == "2001:db8::1"
+
+    def test_private_ip_is_still_returned(self, app):
+        """Private IPs are currently allowed and returned unchanged"""
+        with app.test_request_context(
+            environ_base={"REMOTE_ADDR": "10.0.0.5"}
+        ):
+            assert network_utils.get_client_ip_with_validation() == "10.0.0.5"
+
+    def test_invalid_ip_returns_original_value(self, app):
+        """If the resolved value is not a valid IP, it is returned as-is"""
+        with app.test_request_context(
+            environ_base={"REMOTE_ADDR": "not-an-ip"}
+        ):
+            assert network_utils.get_client_ip_with_validation() == "not-an-ip"


### PR DESCRIPTION
## Summary

Increases test coverage by adding unit tests for two previously untested utility modules.

### `tests/unit/test_network_utils.py` — `utils.network_utils`
Client IP extraction/validation (used for audit trails in `admin_integration_service`):
- `is_valid_ip`: accepts well-formed IPv4/IPv6, rejects malformed input.
- `get_client_ip_from_request`: `X-Forwarded-For` first-entry precedence and trimming, fallback to alternative headers (`X-Real-IP`, `CF-Connecting-IP`), skipping invalid forwarded values, and `remote_addr` fallback.
- `get_client_ip_with_validation`: public IP passthrough, IPv6 canonicalization, private-IP handling, and graceful return of the original value on invalid input.

### `tests/unit/test_db_utils.py` — `utils.db_utils.run_with_deadlock_retry`
PostgreSQL deadlock (40P01) retry helper used by `prescription_check_service`:
- returns fn value with no retry on success;
- retries a deadlock after a session rollback + `on_retry` callback, then returns;
- re-raises once retries are exhausted (asserting rollback count);
- passes non-deadlock `OperationalError` straight through without retry;
- verifies exponential back-off delays;
- works when the optional `on_retry` callback is omitted.

Tests are pure unit tests: `network_utils` uses a bare Flask request context, and `db_utils` injects a fake `models.main` module and patches `time.sleep`, so neither touches the database.

## Test plan
- 30 tests pass locally: `pytest tests/unit/test_network_utils.py tests/unit/test_db_utils.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAC6VbqFgVZcgpBq1Z9W8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAC6VbqFgVZcgpBq1Z9W8s)_