### PR TITLE
test: add coverage for numberutils and exams service

### DIFF
--- a/tests/integration/test_exams.py
+++ b/tests/integration/test_exams.py
@@ -1,0 +1,138 @@
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import session
+
+from models.segment import Exams
+
+# Admission / patient present in the seed data (see tests/integration/test_patient.py)
+ADMISSION = 5
+PATIENT_ID = 5
+
+
+@pytest.fixture(autouse=True)
+def cleanup_manual_exams():
+    """Remove exams inserted manually during a test so the suite stays re-runnable.
+
+    Seed exams have created_by = NULL; manually created ones (the only kind these
+    tests insert) always set created_by, so deleting those leaves seed data intact.
+    """
+    yield
+    session.query(Exams).filter(
+        Exams.admissionNumber == ADMISSION,
+        Exams.created_by.isnot(None),
+    ).delete(synchronize_session=False)
+    session.commit()
+
+
+def _get_manual_exams():
+    """Return the manually inserted exams for the test admission, newest first."""
+    return (
+        session.query(Exams)
+        .filter(
+            Exams.admissionNumber == ADMISSION,
+            Exams.created_by.isnot(None),
+        )
+        .all()
+    )
+
+
+def test_create_exam_permission(client, viewer_headers):
+    """POST /exams/create - returns 401 for a user without WRITE_PRESCRIPTION"""
+    payload = {
+        "admissionNumber": ADMISSION,
+        "examDate": "2024-01-10T08:00:00",
+        "examType": "tgo",
+        "result": 42.0,
+    }
+    response = client.post("/exams/create", json=payload, headers=viewer_headers)
+
+    assert response.status_code == 401
+    # nothing should have been persisted
+    assert _get_manual_exams() == []
+
+
+def test_create_exam_persists_record(client, analyst_headers):
+    """POST /exams/create - persists the exam with an uppercased type and the author id"""
+    payload = {
+        "admissionNumber": ADMISSION,
+        "examDate": "2024-01-10T08:00:00",
+        "examType": "tgo",
+        "result": 42.5,
+    }
+
+    # the cache refresh talks to Redis; it is out of scope for this test
+    with patch("services.exams_service.refresh_exams_cache") as refresh_mock:
+        response = client.post("/exams/create", json=payload, headers=analyst_headers)
+
+    assert response.status_code == 200
+    refresh_mock.assert_called_once()
+
+    session.expire_all()
+    exams = _get_manual_exams()
+    assert len(exams) == 1
+
+    exam = exams[0]
+    assert exam.idPatient == PATIENT_ID
+    assert exam.admissionNumber == ADMISSION
+    assert exam.typeExam == "TGO"  # stored uppercased
+    assert exam.value == 42.5
+    assert exam.created_by == 1  # demo user
+
+
+def test_create_exam_unknown_admission_returns_400(client, analyst_headers):
+    """POST /exams/create - returns 400 when the admission does not exist"""
+    payload = {
+        "admissionNumber": 999999999,
+        "examDate": "2024-01-10T08:00:00",
+        "examType": "tgo",
+        "result": 10.0,
+    }
+
+    with patch("services.exams_service.refresh_exams_cache") as refresh_mock:
+        response = client.post("/exams/create", json=payload, headers=analyst_headers)
+
+    assert response.status_code == 400
+    refresh_mock.assert_not_called()
+    assert _get_manual_exams() == []
+
+
+def test_create_exam_multiple_persists_all_entries(client, analyst_headers):
+    """POST /exams/create-multiple - persists every entry in the batch"""
+    payload = {
+        "admissionNumber": ADMISSION,
+        "exams": [
+            {"examDate": "2024-01-10T08:00:00", "examType": "tgo", "result": 30.0},
+            {"examDate": "2024-01-10T08:00:00", "examType": "tgp", "result": 55.0},
+        ],
+    }
+
+    with patch("services.exams_service.refresh_exams_cache"):
+        response = client.post(
+            "/exams/create-multiple", json=payload, headers=analyst_headers
+        )
+
+    assert response.status_code == 200
+
+    session.expire_all()
+    exams = _get_manual_exams()
+    assert len(exams) == 2
+    stored = {(e.typeExam, e.value) for e in exams}
+    assert stored == {("TGO", 30.0), ("TGP", 55.0)}
+
+
+def test_delete_unknown_exam_returns_400(client, analyst_headers):
+    """POST /exams/delete - returns 400 when the exam does not exist"""
+    payload = {"admissionNumber": ADMISSION, "idExam": 999999999999}
+    response = client.post("/exams/delete", json=payload, headers=analyst_headers)
+
+    assert response.status_code == 400
+
+
+def test_list_exam_types_returns_list(client, analyst_headers):
+    """GET /exams/types/list - returns a 200 with a list payload"""
+    response = client.get("/exams/types/list", headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert isinstance(response.get_json()["data"], list)

--- a/tests/unit/test_numberutils.py
+++ b/tests/unit/test_numberutils.py
@@ -1,0 +1,84 @@
+import pytest
+
+from utils import numberutils
+
+
+class TestIsFloat:
+    """Teste numberutils - is_float (safe check whether a value is convertible to float)"""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            1,
+            0,
+            -3,
+            1.5,
+            -2.75,
+            "0",
+            "10",
+            "3.14",
+            "-4.2",
+            "  7.5  ",
+            "1e3",
+            True,
+        ],
+    )
+    def test_convertible_values_return_true(self, value):
+        """Numbers and numeric strings are recognized as float-convertible"""
+        assert numberutils.is_float(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "",
+            "abc",
+            "1.2.3",
+            "10,5",
+            [],
+            {},
+            "  ",
+        ],
+    )
+    def test_non_convertible_values_return_false(self, value):
+        """None, empty strings, non-numeric text and containers are rejected"""
+        assert numberutils.is_float(value) is False
+
+
+class TestNone2Zero:
+    """Teste numberutils - none2zero (coerce a value to float, defaulting to 0)"""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("2.5", 2.5),
+            ("10", 10.0),
+            (3, 3.0),
+            (-4.2, -4.2),
+            (0, 0.0),
+            ("  1.5 ", 1.5),
+        ],
+    )
+    def test_numeric_values_are_converted_to_float(self, value, expected):
+        """Numeric values and numeric strings are converted to their float value"""
+        assert numberutils.none2zero(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "",
+            "abc",
+            "1.2.3",
+            [],
+        ],
+    )
+    def test_non_numeric_values_default_to_zero(self, value):
+        """Non-convertible values (used in economy calculations) default to 0"""
+        assert numberutils.none2zero(value) == 0
+
+    def test_result_is_always_float_for_valid_input(self):
+        """A convertible value is returned as a float, not the original type"""
+        result = numberutils.none2zero(5)
+        assert isinstance(result, float)
+        assert result == 5.0


### PR DESCRIPTION
## Summary

Increases test coverage by adding tests for two previously untested features.

### 1. `utils/numberutils` — unit tests (`tests/unit/test_numberutils.py`)
Pure-logic helpers (`is_float`, `none2zero`) used in economy/dose calculations had no coverage. Added parametrized tests covering:
- numeric values, numeric strings and whitespace-padded strings → converted
- `None`, empty strings, non-numeric text and containers → safely rejected / defaulted to `0`
- return type is always `float` for valid input

### 2. Exams service — integration tests (`tests/integration/test_exams.py`)
The exam write/list endpoints (`/exams/create`, `/exams/create-multiple`, `/exams/delete`, `/exams/types/list`) were untested. Added integration tests covering:
- **create**: persists the record with an uppercased exam type, correct value, patient id and author id
- **create-multiple**: persists every entry in the batch
- **permission enforcement**: a `VIEWER` (no `WRITE_PRESCRIPTION`) gets `401` and nothing is persisted
- **invalid admission**: returns `400` and does not persist
- **delete of a non-existent exam**: returns `400`
- **list exam types**: returns `200` with a list payload

The Redis-backed cache refresh is patched out (out of scope), and an autouse fixture removes manually-inserted exams so the suite stays re-runnable.

## Testing
- New tests: 38 passing
- Full suite: 645 passing (607 baseline + 38 new), verified re-runnable across two consecutive runs
- `black --check` clean on both new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmQt6unipshD1ZfUt39v5j

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmQt6unipshD1ZfUt39v5j)_