### PR TITLE
test: add coverage for lists ICD endpoint and cryptutils encryption

### DIFF
--- a/tests/integration/test_lists.py
+++ b/tests/integration/test_lists.py
@@ -1,0 +1,91 @@
+"""Integration tests for the /lists/icds endpoint (lists_service.list_icds)."""
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import get_access, make_headers, session, session_commit
+
+from security.role import Role
+
+# ICD test rows live in the shared public.tb_cid10 table. Use a high co_cid10
+# range and distinctive names so the rows never collide with real seed data
+# and are trivial to clean up afterwards. nu_cid10 is capped at 4 chars.
+_ICD_ACTIVE_A = (999001, "ZZ1", "ZZTest Cholera", 1)
+_ICD_ACTIVE_B = (999002, "ZZ2", "ZZTest Anthrax", 1)
+_ICD_INACTIVE = (999003, "ZZ3", "ZZTest Retired", 0)
+
+_ALL_IDS = (_ICD_ACTIVE_A[0], _ICD_ACTIVE_B[0], _ICD_INACTIVE[0])
+
+
+@pytest.fixture
+def seed_icds():
+    """Insert distinctive tb_cid10 rows and remove them after the test."""
+    for co, nu, no, active in (_ICD_ACTIVE_A, _ICD_ACTIVE_B, _ICD_INACTIVE):
+        session.execute(
+            text(
+                "INSERT INTO public.tb_cid10 "
+                "(co_cid10, nu_cid10, tp_agravo, no_cid10, no_cid10_filtro, st_ativo) "
+                "VALUES (:co, :nu, 0, :no, :no, :active)"
+            ),
+            {"co": co, "nu": nu, "no": no, "active": active},
+        )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM public.tb_cid10 WHERE co_cid10 IN (:a, :b, :c)"),
+        {"a": _ALL_IDS[0], "b": _ALL_IDS[1], "c": _ALL_IDS[2]},
+    )
+    session_commit()
+
+
+def _data(response):
+    """Extract the data list from a successful response envelope."""
+    return response.get_json()["data"]
+
+
+def test_list_icds_permission_denied(client):
+    """A user without READ_BASIC_FEATURES cannot list ICDs [401 UNAUTHORIZED]."""
+    headers = make_headers(get_access(client, roles=[Role.SUPPORT_REQUESTER.value]))
+    response = client.get("/lists/icds", headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_list_icds_returns_formatted_active_rows(client, analyst_headers, seed_icds):
+    """Active ICDs are returned as '{id_str} - {name}' with the code as id."""
+    response = client.get("/lists/icds", headers=analyst_headers)
+
+    assert response.status_code == 200
+    items = _data(response)
+    by_id = {item["id"]: item["name"] for item in items}
+
+    assert _ICD_ACTIVE_A[1] in by_id
+    assert by_id[_ICD_ACTIVE_A[1]] == f"{_ICD_ACTIVE_A[1]} - {_ICD_ACTIVE_A[2]}"
+    assert by_id[_ICD_ACTIVE_B[1]] == f"{_ICD_ACTIVE_B[1]} - {_ICD_ACTIVE_B[2]}"
+
+
+def test_list_icds_excludes_inactive_rows(client, analyst_headers, seed_icds):
+    """ICDs with st_ativo != 1 are omitted from the listing."""
+    response = client.get("/lists/icds", headers=analyst_headers)
+
+    assert response.status_code == 200
+    ids = {item["id"] for item in _data(response)}
+    assert _ICD_INACTIVE[1] not in ids
+
+
+def test_list_icds_ordered_by_name(client, analyst_headers, seed_icds):
+    """Results are ordered alphabetically by ICD name (no_cid10)."""
+    response = client.get("/lists/icds", headers=analyst_headers)
+
+    assert response.status_code == 200
+    items = _data(response)
+    positions = {
+        item["id"]: index
+        for index, item in enumerate(items)
+        if item["id"] in (_ICD_ACTIVE_A[1], _ICD_ACTIVE_B[1])
+    }
+
+    # "ZZTest Anthrax" (B) must precede "ZZTest Cholera" (A).
+    assert positions[_ICD_ACTIVE_B[1]] < positions[_ICD_ACTIVE_A[1]]

--- a/tests/unit/test_cryptutils.py
+++ b/tests/unit/test_cryptutils.py
@@ -1,0 +1,65 @@
+"""Unit tests for utils.cryptutils.encrypt_data (Fernet symmetric encryption)."""
+
+import base64
+
+import pytest
+from cryptography.fernet import Fernet
+
+from config import Config
+from utils import cryptutils
+
+
+@pytest.fixture
+def fernet_key(monkeypatch):
+    """Configure a valid Fernet key on Config and return the Fernet helper."""
+    key = Fernet.generate_key()
+    monkeypatch.setattr(Config, "ENCRYPTION_KEY", key.decode("utf-8"))
+    return Fernet(key)
+
+
+@pytest.mark.parametrize("empty", [None, ""])
+def test_encrypt_data_returns_none_for_empty_input(empty):
+    """Empty or missing plaintext short-circuits to None without touching the key."""
+    assert cryptutils.encrypt_data(empty) is None
+
+
+def test_encrypt_data_raises_when_key_missing(monkeypatch):
+    """A missing ENCRYPTION_KEY raises ValueError before any encryption happens."""
+    monkeypatch.setattr(Config, "ENCRYPTION_KEY", None)
+
+    with pytest.raises(ValueError, match="ENCRYPTION_KEY not set"):
+        cryptutils.encrypt_data("sensitive")
+
+
+def test_encrypt_data_roundtrips_to_original(fernet_key):
+    """The ciphertext is base64-wrapped Fernet output that decrypts to the input."""
+    plaintext = "paciente 12345 - dado sensível"
+
+    ciphertext = cryptutils.encrypt_data(plaintext)
+
+    assert isinstance(ciphertext, str)
+    assert ciphertext != plaintext
+    inner = base64.b64decode(ciphertext.encode("utf-8"))
+    assert fernet_key.decrypt(inner).decode("utf-8") == plaintext
+
+
+def test_encrypt_data_produces_distinct_ciphertexts(fernet_key):
+    """Fernet embeds a random IV, so repeated encryption yields different output."""
+    plaintext = "repeatable-value"
+
+    first = cryptutils.encrypt_data(plaintext)
+    second = cryptutils.encrypt_data(plaintext)
+
+    assert first != second
+    # Both must still decrypt back to the same plaintext.
+    for ciphertext in (first, second):
+        inner = base64.b64decode(ciphertext.encode("utf-8"))
+        assert fernet_key.decrypt(inner).decode("utf-8") == plaintext
+
+
+def test_encrypt_data_raises_on_invalid_key(monkeypatch):
+    """A malformed ENCRYPTION_KEY surfaces as a friendly ValueError, not a crash."""
+    monkeypatch.setattr(Config, "ENCRYPTION_KEY", "not-a-valid-fernet-key")
+
+    with pytest.raises(ValueError, match="Erro ao criptografar dados sensíveis"):
+        cryptutils.encrypt_data("sensitive")

--- a/tests/unit/test_cryptutils.py
+++ b/tests/unit/test_cryptutils.py
@@ -33,7 +33,7 @@ def test_encrypt_data_raises_when_key_missing(monkeypatch):
 
 def test_encrypt_data_roundtrips_to_original(fernet_key):
     """The ciphertext is base64-wrapped Fernet output that decrypts to the input."""
-    plaintext = "paciente 12345 - dado sensível"
+    plaintext = "generic-placeholder-value-ção"
 
     ciphertext = cryptutils.encrypt_data(plaintext)
 


### PR DESCRIPTION
## Summary

Increases test coverage by adding tests for two previously untested features.

### 1. `GET /lists/icds` — integration tests (`tests/integration/test_lists.py`)

Covers `lists_service.list_icds`, which had no tests. The suite seeds a few
`public.tb_cid10` rows (and cleans them up) to assert:

- **Permission enforcement** — a role without `READ_BASIC_FEATURES`
  (`SUPPORT_REQUESTER`) gets `401`.
- **Formatting** — active ICDs are returned as `"{id_str} - {name}"` with the
  ICD code as `id`.
- **Active filter** — rows with `st_ativo != 1` are excluded.
- **Ordering** — results come back ordered alphabetically by ICD name.

### 2. `utils.cryptutils.encrypt_data` — unit tests (`tests/unit/test_cryptutils.py`)

Covers the Fernet symmetric-encryption helper, which had no tests:

- **Empty input** short-circuits to `None` (both `None` and `""`).
- **Missing `ENCRYPTION_KEY`** raises `ValueError`.
- **Round-trip** — ciphertext is base64-wrapped Fernet output that decrypts
  back to the original plaintext.
- **IV randomness** — encrypting the same value twice yields distinct
  ciphertexts that both still decrypt correctly.
- **Invalid key** surfaces as a friendly `ValueError` rather than a raw crash.

## Testing

All tests pass locally against a PostgreSQL 16 instance loaded with the
standard `noharm-ai/database` seed data (`655 passed`, including the 10 new
tests). Both new files are self-contained: they create and clean up their own
data and do not depend on optional seed rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TURk9Ppe9FR65otxMCfCb

---
_Generated by [Claude Code](https://claude.ai/code/session_013TURk9Ppe9FR65otxMCfCb)_