### PR TITLE
test: add coverage for substance_service and feature_service

### DIFF
--- a/tests/integration/test_substance.py
+++ b/tests/integration/test_substance.py
@@ -1,0 +1,243 @@
+"""Integration tests for the /substance/* endpoints (substance_service).
+
+The seed database ships with empty ``public.substancia`` and ``public.classe``
+tables, so a fixture seeds a small, distinctive set of rows (removed after the
+test) to exercise the service behaviour.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import get_access, make_headers, session, session_commit
+
+from security.role import Role
+
+# Distinctive test ids. Substance ids >= 90000 are wiped by the session-scoped
+# clean_test_artifacts fixture (see tests/conftest.py); the class rows are
+# removed by the seed fixture below.
+SUBSTANCE_ALPHA = 99001
+SUBSTANCE_BETA = 99002
+SUBSTANCE_INACTIVE = 99003
+
+CLASS_PARENT = "ZZTPARENT"
+CLASS_CHILD = "ZZTCHILD"
+
+NAME_ALPHA = "zztest alpha substance"
+NAME_BETA = "zztest beta substance"
+NAME_INACTIVE = "zztest gamma inactive"
+
+
+@pytest.fixture
+def seed_substances():
+    """Insert distinctive substance/class rows and remove them afterwards."""
+    session.execute(
+        text(
+            "INSERT INTO public.classe (idclasse, idclassemae, nome) "
+            "VALUES (:id, NULL, :nome)"
+        ),
+        {"id": CLASS_PARENT, "nome": "zztest parent class"},
+    )
+    session.execute(
+        text(
+            "INSERT INTO public.classe (idclasse, idclassemae, nome) "
+            "VALUES (:id, :parent, :nome)"
+        ),
+        {"id": CLASS_CHILD, "parent": CLASS_PARENT, "nome": "zztest child class"},
+    )
+
+    rows = [
+        (SUBSTANCE_ALPHA, NAME_ALPHA, CLASS_CHILD, True),
+        (SUBSTANCE_BETA, NAME_BETA, CLASS_CHILD, True),
+        (SUBSTANCE_INACTIVE, NAME_INACTIVE, CLASS_CHILD, False),
+    ]
+    for sctid, nome, idclasse, ativo in rows:
+        session.execute(
+            text(
+                "INSERT INTO public.substancia (sctid, nome, idclasse, ativo, manejo) "
+                "VALUES (:sctid, :nome, :idclasse, :ativo, CAST(:manejo AS jsonb))"
+            ),
+            {
+                "sctid": sctid,
+                "nome": nome,
+                "idclasse": idclasse,
+                "ativo": ativo,
+                # only the alpha substance carries handling text
+                "manejo": (
+                    '{"allergy": "cuidado especial de alergia"}'
+                    if sctid == SUBSTANCE_ALPHA
+                    else None
+                ),
+            },
+        )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM public.substancia WHERE sctid IN (:a, :b, :c)"),
+        {"a": SUBSTANCE_ALPHA, "b": SUBSTANCE_BETA, "c": SUBSTANCE_INACTIVE},
+    )
+    session.execute(
+        text("DELETE FROM public.classe WHERE idclasse IN (:a, :b)"),
+        {"a": CLASS_PARENT, "b": CLASS_CHILD},
+    )
+    session_commit()
+
+
+def _data(response):
+    """Return the ``data`` payload of a successful response envelope."""
+    return response.get_json()["data"]
+
+
+def test_get_substances_requires_permission(client, seed_substances):
+    """A user without READ_BASIC_FEATURES cannot list substances [401]."""
+    headers = make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+    response = client.get("/substance", headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_get_substances_returns_seeded_rows(client, analyst_headers, seed_substances):
+    """Listing returns the seeded substances with upper-cased names and string ids."""
+    response = client.get("/substance", headers=analyst_headers)
+
+    assert response.status_code == 200
+    items = _data(response)
+    match = next((i for i in items if i["sctid"] == str(SUBSTANCE_ALPHA)), None)
+    assert match is not None, "seeded substance not present in listing"
+    assert match["name"] == NAME_ALPHA.upper()
+    assert match["idclass"] == CLASS_CHILD
+    assert match["active"] is True
+
+
+def test_get_substances_orders_active_before_inactive(
+    client, analyst_headers, seed_substances
+):
+    """Active substances are ordered ahead of inactive ones."""
+    response = client.get("/substance", headers=analyst_headers)
+
+    items = _data(response)
+    positions = {i["sctid"]: idx for idx, i in enumerate(items)}
+    # the inactive substance must appear after both active ones
+    assert positions[str(SUBSTANCE_INACTIVE)] > positions[str(SUBSTANCE_ALPHA)]
+    assert positions[str(SUBSTANCE_INACTIVE)] > positions[str(SUBSTANCE_BETA)]
+
+
+def test_find_substance_by_term(client, analyst_headers, seed_substances):
+    """Searching by term returns matching substances sorted by name ascending."""
+    response = client.get("/substance/find?term=zztest", headers=analyst_headers)
+
+    assert response.status_code == 200
+    items = _data(response)
+    names = [i["name"] for i in items]
+    # results are upper-cased and alpha sorts before beta
+    assert NAME_ALPHA.upper() in names
+    assert NAME_BETA.upper() in names
+    assert names.index(NAME_ALPHA.upper()) < names.index(NAME_BETA.upper())
+
+
+def test_find_substance_empty_term_is_rejected(client, analyst_headers):
+    """An empty search term is a bad request [400]."""
+    response = client.get("/substance/find?term=", headers=analyst_headers)
+
+    assert response.status_code == 400
+
+
+def test_resolve_substances_by_ids(client, analyst_headers, seed_substances):
+    """Resolving by ids returns the matching substances only."""
+    response = client.get(
+        f"/substance/resolve?ids={SUBSTANCE_ALPHA},{SUBSTANCE_BETA}",
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 200
+    sctids = {i["sctid"] for i in _data(response)}
+    assert sctids == {str(SUBSTANCE_ALPHA), str(SUBSTANCE_BETA)}
+
+
+def test_resolve_substances_ignores_non_numeric_ids(
+    client, analyst_headers, seed_substances
+):
+    """Non-numeric ids are discarded before querying (sctid is numeric)."""
+    response = client.get(
+        f"/substance/resolve?ids={SUBSTANCE_ALPHA},abc", headers=analyst_headers
+    )
+
+    assert response.status_code == 200
+    sctids = {i["sctid"] for i in _data(response)}
+    assert sctids == {str(SUBSTANCE_ALPHA)}
+
+
+def test_resolve_substances_empty_returns_empty_list(client, analyst_headers):
+    """An empty id list resolves to an empty result."""
+    response = client.get("/substance/resolve?ids=", headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert _data(response) == []
+
+
+def test_get_substance_classes(client, analyst_headers, seed_substances):
+    """Listing classes returns the seeded classes with upper-cased names."""
+    response = client.get("/substance/class", headers=analyst_headers)
+
+    assert response.status_code == 200
+    by_id = {i["id"]: i for i in _data(response)}
+    assert CLASS_CHILD in by_id
+    assert by_id[CLASS_CHILD]["name"] == "zztest child class".upper()
+
+
+def test_find_substance_class_resolves_parent_name(
+    client, analyst_headers, seed_substances
+):
+    """Searching classes exposes the parent class name for a child class."""
+    response = client.get(
+        "/substance/class/find?term=zztest child", headers=analyst_headers
+    )
+
+    assert response.status_code == 200
+    match = next((i for i in _data(response) if i["id"] == CLASS_CHILD), None)
+    assert match is not None
+    assert match["parent"] == "zztest parent class"
+
+
+def test_find_substance_class_empty_term_is_rejected(client, analyst_headers):
+    """An empty class search term is a bad request [400]."""
+    response = client.get("/substance/class/find?term=", headers=analyst_headers)
+
+    assert response.status_code == 400
+
+
+def test_resolve_substance_classes_by_ids(client, analyst_headers, seed_substances):
+    """Resolving classes by ids returns them together with their parent name."""
+    response = client.get(
+        f"/substance/class/resolve?ids={CLASS_CHILD}", headers=analyst_headers
+    )
+
+    assert response.status_code == 200
+    match = next((i for i in _data(response) if i["id"] == CLASS_CHILD), None)
+    assert match is not None
+    assert match["parent"] == "zztest parent class"
+
+
+def test_substance_handling_returns_text(client, analyst_headers, seed_substances):
+    """A substance with handling text for the alert type returns that text."""
+    response = client.get(
+        f"/substance/handling?sctid={SUBSTANCE_ALPHA}&alertType=allergy",
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 200
+    assert "cuidado" in str(_data(response))
+
+
+def test_substance_handling_missing_returns_none(
+    client, analyst_headers, seed_substances
+):
+    """A substance without handling text for the alert type returns null data."""
+    response = client.get(
+        f"/substance/handling?sctid={SUBSTANCE_BETA}&alertType=allergy",
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 200
+    assert _data(response) is None

--- a/tests/unit/test_feature_service.py
+++ b/tests/unit/test_feature_service.py
@@ -1,0 +1,119 @@
+"""Unit tests for services.feature_service.
+
+feature_service resolves three kinds of flags — tenant features, per-user
+features and system feature flags. Each caches its lookup on Flask's request
+global ``g`` and only touches the database on a cache miss. These tests drive
+both paths using a request context for ``g`` and a mocked ``db`` session for the
+database-backed path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from flask import g
+
+from mobile import app
+from models.enums import AppFeatureFlagEnum, FeatureEnum
+from services import feature_service
+
+
+def _query_returning(value):
+    """Build a mock db whose Memory/GlobalMemory query resolves to ``value``.
+
+    ``value`` is what ``.first()`` returns (an object exposing ``.value`` or
+    ``None`` for a missing row).
+    """
+    mock_db = MagicMock()
+    mock_db.session.query.return_value.filter.return_value.first.return_value = value
+    return mock_db
+
+
+class TestHasFeature:
+    """Tests for feature_service.has_feature (tenant features)."""
+
+    def test_returns_true_when_present_in_cache(self):
+        """A feature already cached on ``g`` is detected without a db lookup."""
+        with app.test_request_context():
+            g.features = [FeatureEnum.CONCILIATION.value]
+            assert feature_service.has_feature(FeatureEnum.CONCILIATION) is True
+
+    def test_returns_false_when_absent_from_cache(self):
+        """A feature missing from the cached list is reported as disabled."""
+        with app.test_request_context():
+            g.features = [FeatureEnum.CONCILIATION.value]
+            assert feature_service.has_feature(FeatureEnum.OAUTH) is False
+
+    def test_loads_and_caches_from_memory_on_miss(self):
+        """On a cache miss the feature list is loaded from Memory and cached on g."""
+        memory_row = MagicMock(value=[FeatureEnum.OAUTH.value])
+        with app.test_request_context():
+            with patch.object(feature_service, "db", _query_returning(memory_row)):
+                assert feature_service.has_feature(FeatureEnum.OAUTH) is True
+            # the loaded list is now cached on g for subsequent calls
+            assert g.features == [FeatureEnum.OAUTH.value]
+
+    def test_returns_false_when_memory_row_missing(self):
+        """With no Memory row configured, every feature is disabled."""
+        with app.test_request_context():
+            with patch.object(feature_service, "db", _query_returning(None)):
+                assert feature_service.has_feature(FeatureEnum.OAUTH) is False
+
+
+class TestHasUserFeature:
+    """Tests for feature_service.has_user_feature (per-user features)."""
+
+    def test_short_circuits_in_test_env(self):
+        """In the test environment user features are always disabled."""
+        # Config.ENV is 'test' while running the suite -> early empty return.
+        assert not feature_service.has_user_feature(FeatureEnum.OAUTH)
+
+    def test_checks_user_features_outside_test_env(self):
+        """Outside the test env the flag is looked up in the cached user list."""
+        with app.test_request_context():
+            g.user_features = [FeatureEnum.OAUTH.value]
+            with patch.object(feature_service, "Config") as mock_config:
+                mock_config.ENV = "development"
+                assert feature_service.has_user_feature(FeatureEnum.OAUTH) is True
+                assert (
+                    feature_service.has_user_feature(FeatureEnum.CONCILIATION) is False
+                )
+
+
+class TestHasFeatureFlag:
+    """Tests for feature_service.has_feature_flag (system feature flags)."""
+
+    def test_returns_true_when_flag_cached(self):
+        """A flag enabled in the cached mapping is reported as enabled."""
+        with app.test_request_context():
+            g.feature_flags = {AppFeatureFlagEnum.REDIS_CACHE.value: True}
+            assert (
+                feature_service.has_feature_flag(AppFeatureFlagEnum.REDIS_CACHE) is True
+            )
+
+    def test_returns_false_when_flag_absent_from_cache(self):
+        """A flag missing from the cached mapping defaults to disabled."""
+        with app.test_request_context():
+            g.feature_flags = {AppFeatureFlagEnum.REDIS_CACHE.value: True}
+            assert (
+                feature_service.has_feature_flag(AppFeatureFlagEnum.REDIS_CACHE_EXAMS)
+                is False
+            )
+
+    def test_loads_and_caches_from_global_memory_on_miss(self):
+        """On a cache miss flags are loaded from GlobalMemory and cached on g."""
+        memory_row = MagicMock(value={AppFeatureFlagEnum.REDIS_CACHE.value: True})
+        with app.test_request_context():
+            with patch.object(feature_service, "db", _query_returning(memory_row)):
+                assert (
+                    feature_service.has_feature_flag(AppFeatureFlagEnum.REDIS_CACHE)
+                    is True
+                )
+            assert g.feature_flags == {AppFeatureFlagEnum.REDIS_CACHE.value: True}
+
+    def test_returns_false_when_global_memory_missing(self):
+        """With no GlobalMemory row configured, every flag defaults to disabled."""
+        with app.test_request_context():
+            with patch.object(feature_service, "db", _query_returning(None)):
+                assert (
+                    feature_service.has_feature_flag(AppFeatureFlagEnum.REDIS_CACHE)
+                    is False
+                )


### PR DESCRIPTION
## Summary

Increases automated test coverage by adding tests for two previously untested features.

### `substance_service` — integration tests (`tests/integration/test_substance.py`)
Exercises the `/substance/*` endpoints end-to-end (following the existing `test_tag.py` pattern). A fixture seeds a small, distinctive set of substance/class rows (removed afterwards), since the seed database ships with empty `public.substancia`/`public.classe` tables. Covered behaviour:
- Listing substances — upper-cased names, string ids, active-before-inactive ordering
- `find` by term and `resolve` by ids — including non-numeric id filtering and empty-input handling
- Class listing, `class/find` (parent-name resolution) and `class/resolve`
- Substance handling text lookup (present → text, absent → null)
- Permission enforcement (`READ_BASIC_FEATURES`) and empty-term validation (`400`)

### `feature_service` — unit tests (`tests/unit/test_feature_service.py`)
Covers the three flag resolvers (`has_feature`, `has_user_feature`, `has_feature_flag`) using a Flask request context for the `g` cache and a mocked `db` session for the database-backed path:
- Cache-hit path (flag present / absent in the cached list or mapping)
- Cache-miss path that loads from `Memory` / `GlobalMemory` and then caches on `g`
- Missing-memory fallback (everything disabled)
- Test-environment short-circuit for per-user features

## Testing
- `24` new tests pass locally (14 integration + 10 unit)
- Full suite green: `679 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKPsPVQf9zXrGLWb4PrLor)_