### PR TITLE
test: cover help_text_service and data_authorization_service

### DIFF
--- a/tests/integration/test_help_text.py
+++ b/tests/integration/test_help_text.py
@@ -1,0 +1,123 @@
+"""Integration tests for the /help-text endpoints (help_text_service).
+
+The help texts live in the shared ``public.texto_ajuda`` table (not a tenant
+schema), so each test uses a distinctive key and the ``clean_help_text``
+fixture removes it afterwards.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import get_access, make_headers, session, session_commit
+
+from security.role import Role
+
+HELP_KEY = "zztest_help_key"
+
+
+@pytest.fixture
+def clean_help_text():
+    """Remove the test help-text row before and after the test."""
+
+    def _delete():
+        session.execute(
+            text("DELETE FROM public.texto_ajuda WHERE chave = :key"),
+            {"key": HELP_KEY},
+        )
+        session_commit()
+
+    _delete()
+    yield
+    _delete()
+
+
+def test_get_help_text_missing_key(client, analyst_headers, clean_help_text):
+    """Reading an unknown key returns the key with a null content [200 OK]."""
+    response = client.get(f"/help-text/{HELP_KEY}", headers=analyst_headers)
+
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert data["key"] == HELP_KEY
+    assert data["content"] is None
+
+
+def test_update_help_text_creates_record(client, curator_headers, clean_help_text):
+    """A PUT with WRITE_HELP_TEXT creates the record and it is then readable."""
+    response = client.put(
+        f"/help-text/{HELP_KEY}",
+        headers=curator_headers,
+        json={"content": "first version"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["content"] == "first version"
+
+    # the newly created content is returned by a subsequent GET
+    read = client.get(f"/help-text/{HELP_KEY}", headers=curator_headers)
+    assert read.status_code == 200
+    assert read.get_json()["data"]["content"] == "first version"
+
+
+def test_update_help_text_overwrites_existing(
+    client, curator_headers, clean_help_text
+):
+    """A second PUT on the same key replaces the previous content (upsert)."""
+    client.put(
+        f"/help-text/{HELP_KEY}",
+        headers=curator_headers,
+        json={"content": "first version"},
+    )
+
+    response = client.put(
+        f"/help-text/{HELP_KEY}",
+        headers=curator_headers,
+        json={"content": "second version"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["content"] == "second version"
+
+    read = client.get(f"/help-text/{HELP_KEY}", headers=curator_headers)
+    assert read.get_json()["data"]["content"] == "second version"
+
+
+def test_update_help_text_clears_content(client, curator_headers, clean_help_text):
+    """Omitting content clears it to null while keeping the record."""
+    client.put(
+        f"/help-text/{HELP_KEY}",
+        headers=curator_headers,
+        json={"content": "to be cleared"},
+    )
+
+    response = client.put(f"/help-text/{HELP_KEY}", headers=curator_headers, json={})
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["content"] is None
+
+
+def test_get_help_text_permission_denied(client, clean_help_text):
+    """Without READ_BASIC_FEATURES the read is rejected [401 UNAUTHORIZED]."""
+    headers = make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+    response = client.get(f"/help-text/{HELP_KEY}", headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_update_help_text_permission_denied(
+    client, analyst_headers, clean_help_text
+):
+    """Without WRITE_HELP_TEXT the update is rejected and nothing is stored."""
+    response = client.put(
+        f"/help-text/{HELP_KEY}",
+        headers=analyst_headers,
+        json={"content": "should not persist"},
+    )
+
+    assert response.status_code == 401
+
+    # confirm the rejected write left no record behind
+    row = session.execute(
+        text("SELECT conteudo FROM public.texto_ajuda WHERE chave = :key"),
+        {"key": HELP_KEY},
+    ).first()
+    assert row is None

--- a/tests/unit/test_data_authorization_service.py
+++ b/tests/unit/test_data_authorization_service.py
@@ -1,0 +1,97 @@
+"""Unit tests for services.data_authorization_service.
+
+``has_segment_authorization`` decides whether a user may access a given
+segment. It short-circuits for missing segments and for privileged roles
+(MAINTAINER / CHECK_STATIC); otherwise, when the AUTHORIZATION_SEGMENT tenant
+feature is enabled, it checks for a matching ``UserAuthorization`` row. These
+tests drive every branch with a mocked ``db`` session and a patched
+``memory_service`` so no database or request context is required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from models.main import User
+from services import data_authorization_service
+
+
+def _user(roles):
+    """Build a User carrying the given role names in its config."""
+    user = User()
+    user.id = 42
+    user.config = {"roles": roles}
+    return user
+
+
+def _db_returning(auth_row):
+    """Mock db whose UserAuthorization query resolves ``.first()`` to auth_row."""
+    mock_db = MagicMock()
+    (
+        mock_db.session.query.return_value.filter.return_value.filter.return_value.first.return_value
+    ) = auth_row
+    return mock_db
+
+
+def test_returns_true_when_segment_is_none():
+    """A missing segment is always authorized, regardless of user."""
+    assert (
+        data_authorization_service.has_segment_authorization(
+            id_segment=None, user=_user([])
+        )
+        is True
+    )
+
+
+def test_returns_true_for_maintainer_role():
+    """A user with the MAINTAINER permission bypasses the feature/db check."""
+    with patch.object(
+        data_authorization_service.memory_service, "has_feature"
+    ) as has_feature:
+        result = data_authorization_service.has_segment_authorization(
+            id_segment=10, user=_user(["ADMIN"])
+        )
+
+    assert result is True
+    # privileged roles short-circuit before the feature flag is consulted
+    has_feature.assert_not_called()
+
+
+def test_returns_true_when_feature_disabled():
+    """With AUTHORIZATION_SEGMENT off, access is granted without a db lookup."""
+    with patch.object(
+        data_authorization_service.memory_service, "has_feature", return_value=False
+    ):
+        with patch.object(data_authorization_service, "db") as mock_db:
+            result = data_authorization_service.has_segment_authorization(
+                id_segment=10, user=_user(["PRESCRIPTION_ANALYST"])
+            )
+
+    assert result is True
+    mock_db.session.query.assert_not_called()
+
+
+def test_returns_true_when_feature_enabled_and_authorization_exists():
+    """With the feature on and a matching authorization row, access is granted."""
+    with patch.object(
+        data_authorization_service.memory_service, "has_feature", return_value=True
+    ):
+        with patch.object(
+            data_authorization_service, "db", _db_returning(MagicMock())
+        ):
+            result = data_authorization_service.has_segment_authorization(
+                id_segment=10, user=_user(["PRESCRIPTION_ANALYST"])
+            )
+
+    assert result is True
+
+
+def test_returns_false_when_feature_enabled_and_no_authorization():
+    """With the feature on and no matching row, access is denied."""
+    with patch.object(
+        data_authorization_service.memory_service, "has_feature", return_value=True
+    ):
+        with patch.object(data_authorization_service, "db", _db_returning(None)):
+            result = data_authorization_service.has_segment_authorization(
+                id_segment=10, user=_user(["PRESCRIPTION_ANALYST"])
+            )
+
+    assert result is False


### PR DESCRIPTION
## Summary

Increases test coverage by adding tests for two previously untested features.

### 1. `help_text_service` — integration tests (`tests/integration/test_help_text.py`)

Exercises the `/help-text/<key>` GET/PUT endpoints end-to-end:
- Reading an unknown key returns a `null` content.
- PUT creates the record (and it becomes readable via GET).
- A second PUT upserts/overwrites the existing content.
- Omitting `content` clears it to `null` while keeping the record.
- Read without `READ_BASIC_FEATURES` → 401.
- Write without `WRITE_HELP_TEXT` → 401, and no row is persisted.

Because `public.texto_ajuda` is a shared (non-tenant) table not covered by the session cleanup fixture, the tests use a distinctive key and a fixture that removes it before and after each test.

### 2. `data_authorization_service.has_segment_authorization` — unit tests (`tests/unit/test_data_authorization_service.py`)

Covers every branch of the authorization decision with a mocked `db` session and patched `memory_service` (no DB or request context required):
- Missing segment → authorized.
- Privileged role (MAINTAINER via ADMIN) → authorized, feature flag not consulted.
- `AUTHORIZATION_SEGMENT` feature disabled → authorized without a DB lookup.
- Feature enabled with a matching `UserAuthorization` row → authorized.
- Feature enabled with no matching row → denied.

## Testing

- `ENV=test python -m pytest tests/integration/test_help_text.py tests/unit/test_data_authorization_service.py` — 11 passed.
- Full suite: `731 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kmhkzCvE7TY1W6nUGnVen

---
_Generated by [Claude Code](https://claude.ai/code/session_015kmhkzCvE7TY1W6nUGnVen)_