### PR TITLE
test: cover queue_service and segment_service

### DIFF
--- a/tests/integration/test_segment.py
+++ b/tests/integration/test_segment.py
@@ -1,0 +1,83 @@
+"""Integration tests for the /segments endpoints (segment_service).
+
+The seed database ships two segments (a non-CPOE and a CPOE one) and three
+segment/department associations. These tests drive the two read endpoints
+through the HTTP layer, asserting ordering, the department join shape and the
+READ_BASIC_FEATURES permission gate.
+"""
+
+from tests.conftest import get_access, make_headers
+
+from security.role import Role
+
+# Seed identifiers (see database/noharm-insert.sql loaded into the demo schema).
+SEGMENT_ADULT = 1
+SEGMENT_ADULT_CPOE = 2
+
+
+def _data(response):
+    """Return the ``data`` payload of a successful response envelope."""
+    return response.get_json()["data"]
+
+
+def test_get_segments_requires_permission(client):
+    """A role without READ_BASIC_FEATURES cannot list segments [401]."""
+    headers = make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+    response = client.get("/segments", headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_get_segments_returns_seeded_rows(client, analyst_headers):
+    """Listing returns the seeded segments with their id, description and cpoe flag."""
+    response = client.get("/segments", headers=analyst_headers)
+
+    assert response.status_code == 200
+    by_id = {s["id"]: s for s in _data(response)}
+
+    assert SEGMENT_ADULT in by_id
+    assert SEGMENT_ADULT_CPOE in by_id
+    assert by_id[SEGMENT_ADULT]["cpoe"] is False
+    assert by_id[SEGMENT_ADULT_CPOE]["cpoe"] is True
+
+
+def test_get_segments_ordered_by_description(client, analyst_headers):
+    """Segments are returned ordered by description ascending."""
+    response = client.get("/segments", headers=analyst_headers)
+
+    descriptions = [s["description"] for s in _data(response)]
+    assert descriptions == sorted(descriptions)
+
+
+def test_get_segment_departments_requires_permission(client):
+    """A role without READ_BASIC_FEATURES cannot list segment departments [401]."""
+    headers = make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+    response = client.get("/segments/departments", headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_get_segment_departments_shape_and_join(client, analyst_headers):
+    """Each department entry exposes idSegment, idDepartment and a label from the join."""
+    response = client.get("/segments/departments", headers=analyst_headers)
+
+    assert response.status_code == 200
+    items = _data(response)
+    assert len(items) >= 1
+
+    for item in items:
+        assert set(item.keys()) == {"idSegment", "idDepartment", "label"}
+        assert item["label"]  # department name resolved through the join
+
+    # the seed associates departments with both segments
+    segments = {item["idSegment"] for item in items}
+    assert SEGMENT_ADULT in segments
+    assert SEGMENT_ADULT_CPOE in segments
+
+
+def test_get_segment_departments_ordered_by_label(client, analyst_headers):
+    """Segment departments are ordered by department name ascending."""
+    response = client.get("/segments/departments", headers=analyst_headers)
+
+    labels = [item["label"] for item in _data(response)]
+    assert labels == sorted(labels)

--- a/tests/unit/test_queue_service.py
+++ b/tests/unit/test_queue_service.py
@@ -1,0 +1,244 @@
+"""Unit tests for services.queue_service.check_sqs_message.
+
+``check_sqs_message`` polls the ``backend`` SQS queue looking for a message
+whose ``requestContext.requestId`` matches the requested id, deleting and
+returning it when found. The SQS boundary (``utils.aws``) is mocked, so these
+tests exercise the polling loop, payload parsing, deletion and the error/
+validation branches without any AWS access.
+
+The service is guarded by ``@has_permission(READ_BASIC_FEATURES)``. The
+decorator resolves the caller from the JWT identity, so the JWT lookup and
+``User`` model are patched to inject a fabricated user with the required (or
+missing) role inside a Flask request context.
+"""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from exception.authorization_error import AuthorizationError
+from exception.validation_error import ValidationError
+from mobile import app
+from security.role import Role
+from services import queue_service
+from utils import status
+
+
+@contextmanager
+def acting_as(roles):
+    """Run the block inside a request context authenticated as ``roles``.
+
+    Patches the permission decorator's JWT identity lookup and ``User`` model
+    so the decorated service resolves a fabricated user carrying ``roles``.
+    """
+    fake_user = MagicMock()
+    fake_user.config = {"roles": roles}
+    with app.test_request_context():
+        with patch(
+            "decorators.has_permission_decorator.get_jwt_identity", return_value=1
+        ), patch("decorators.has_permission_decorator.User") as mock_user_cls:
+            mock_user_cls.find.return_value = fake_user
+            yield
+
+
+def _message(request_id, response_payload=None, message_id="m1", receipt="r1"):
+    """Build a raw SQS message dict with the given request id and payload."""
+    body = {"requestContext": {"requestId": request_id}}
+    if response_payload is not None:
+        body["responsePayload"] = response_payload
+    return {
+        "MessageId": message_id,
+        "ReceiptHandle": receipt,
+        "Body": json.dumps(body),
+        "Attributes": {"SentTimestamp": "1700000000"},
+    }
+
+
+def _mock_sqs(mock_aws, receive_side_effect=None, receive_return=None):
+    """Wire ``mock_aws.get_client`` to a MagicMock SQS client and return it."""
+    sqs = MagicMock()
+    sqs.get_queue_url.return_value = {"QueueUrl": "http://queue.local/backend"}
+    if receive_side_effect is not None:
+        sqs.receive_message.side_effect = receive_side_effect
+    else:
+        sqs.receive_message.return_value = receive_return or {"Messages": []}
+    mock_aws.get_client.return_value = sqs
+    return sqs
+
+
+class TestValidation:
+    """Input validation and permission gating."""
+
+    def test_missing_request_id_raises_400(self):
+        """An empty request id is rejected before any SQS access."""
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            with pytest.raises(ValidationError) as exc:
+                queue_service.check_sqs_message(request_id="")
+
+        assert exc.value.httpStatus == status.HTTP_400_BAD_REQUEST
+
+    def test_permission_denied_without_basic_features(self):
+        """A role lacking READ_BASIC_FEATURES cannot check the queue."""
+        with acting_as([Role.DISPENSING_MANAGER.value]):
+            with pytest.raises(AuthorizationError):
+                queue_service.check_sqs_message(request_id="abc")
+
+
+class TestMessageMatching:
+    """Happy-path polling, matching, payload parsing and deletion."""
+
+    @patch("services.queue_service.aws")
+    def test_found_deletes_and_returns_parsed_payload(self, mock_aws):
+        """A matching message is deleted and its string payload is JSON-decoded."""
+        sqs = _mock_sqs(
+            mock_aws,
+            receive_return={
+                "Messages": [_message("abc", response_payload='{"ok": true, "n": 5}')]
+            },
+        )
+
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            result = queue_service.check_sqs_message(request_id="abc")
+
+        assert result["found"] is True
+        assert result["deleted"] is True
+        assert result["response"] == {"ok": True, "n": 5}
+        assert result["message_id"] == "m1"
+        assert result["iterations"] == 1
+        assert result["total_checked"] == 1
+        sqs.delete_message.assert_called_once_with(
+            QueueUrl="http://queue.local/backend", ReceiptHandle="r1"
+        )
+
+    @patch("services.queue_service.aws")
+    def test_payload_already_dict_is_passed_through(self, mock_aws):
+        """A responsePayload that is already a dict is returned unchanged."""
+        _mock_sqs(
+            mock_aws,
+            receive_return={
+                "Messages": [_message("abc", response_payload={"already": "dict"})]
+            },
+        )
+
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            result = queue_service.check_sqs_message(request_id="abc")
+
+        assert result["response"] == {"already": "dict"}
+
+    @patch("services.queue_service.aws")
+    def test_invalid_json_payload_kept_as_string(self, mock_aws):
+        """A non-JSON string payload is left intact rather than raising."""
+        _mock_sqs(
+            mock_aws,
+            receive_return={
+                "Messages": [_message("abc", response_payload="not-json{")]
+            },
+        )
+
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            result = queue_service.check_sqs_message(request_id="abc")
+
+        assert result["found"] is True
+        assert result["response"] == "not-json{"
+
+    @patch("services.queue_service.aws")
+    def test_match_found_in_later_batch(self, mock_aws):
+        """Polling continues across batches until the matching id appears."""
+        first_batch = {"Messages": [_message("other", message_id="m0", receipt="r0")]}
+        second_batch = {"Messages": [_message("abc")]}
+        _mock_sqs(mock_aws, receive_side_effect=[first_batch, second_batch])
+
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            result = queue_service.check_sqs_message(request_id="abc")
+
+        assert result["found"] is True
+        assert result["iterations"] == 2
+        # both batches were inspected before the match
+        assert result["total_checked"] == 2
+
+    @patch("services.queue_service.aws")
+    def test_uses_configured_sqs_region(self, mock_aws):
+        """The SQS client is created for the configured NiFi queue region."""
+        _mock_sqs(mock_aws, receive_return={"Messages": [_message("abc")]})
+
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            queue_service.check_sqs_message(request_id="abc")
+
+        args, kwargs = mock_aws.get_client.call_args
+        assert args[0] == "sqs"
+        assert "region_name" in kwargs
+
+
+class TestMessageNotFound:
+    """Exhausting the queue without a match."""
+
+    @patch("services.queue_service.aws")
+    def test_empty_queue_returns_found_false(self, mock_aws):
+        """An immediately empty queue short-circuits with nothing checked."""
+        _mock_sqs(mock_aws, receive_return={"Messages": []})
+
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            result = queue_service.check_sqs_message(request_id="abc")
+
+        assert result["found"] is False
+        assert result["checked_messages"] == 0
+
+    @patch("services.queue_service.aws")
+    def test_no_match_across_max_iterations(self, mock_aws):
+        """Non-matching, always-full batches stop after max_iterations."""
+        non_matching = {"Messages": [_message("other")]}
+        sqs = _mock_sqs(mock_aws, receive_return=non_matching)
+
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            result = queue_service.check_sqs_message(
+                request_id="abc", max_iterations=3
+            )
+
+        assert result["found"] is False
+        assert result["iterations"] == 3
+        assert result["checked_messages"] == 3
+        assert sqs.receive_message.call_count == 3
+        sqs.delete_message.assert_not_called()
+
+
+class TestErrorHandling:
+    """SQS failures are surfaced as 500 ValidationErrors."""
+
+    @patch("services.queue_service.aws")
+    def test_get_queue_url_failure_raises_500(self, mock_aws):
+        """A failure resolving the queue URL is a 500."""
+        sqs = MagicMock()
+        sqs.get_queue_url.side_effect = RuntimeError("boom")
+        mock_aws.get_client.return_value = sqs
+
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            with pytest.raises(ValidationError) as exc:
+                queue_service.check_sqs_message(request_id="abc")
+
+        assert exc.value.httpStatus == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    @patch("services.queue_service.aws")
+    def test_receive_message_failure_raises_500(self, mock_aws):
+        """A failure reading messages is a 500."""
+        sqs = _mock_sqs(mock_aws)
+        sqs.receive_message.side_effect = RuntimeError("boom")
+
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            with pytest.raises(ValidationError) as exc:
+                queue_service.check_sqs_message(request_id="abc")
+
+        assert exc.value.httpStatus == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    @patch("services.queue_service.aws")
+    def test_delete_message_failure_raises_500(self, mock_aws):
+        """A failure deleting the matched message is a 500."""
+        sqs = _mock_sqs(mock_aws, receive_return={"Messages": [_message("abc")]})
+        sqs.delete_message.side_effect = RuntimeError("boom")
+
+        with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+            with pytest.raises(ValidationError) as exc:
+                queue_service.check_sqs_message(request_id="abc")
+
+        assert exc.value.httpStatus == status.HTTP_500_INTERNAL_SERVER_ERROR


### PR DESCRIPTION
## Summary

Increases test coverage by adding tests for two previously untested features.

### 1. `queue_service.check_sqs_message` — unit tests (`tests/unit/test_queue_service.py`)
The SQS boundary (`utils.aws`) is mocked, so the tests exercise the service's own logic without any AWS access:
- Matching message is found, deleted, and its string `responsePayload` is JSON-decoded
- `responsePayload` already a dict is passed through; a non-JSON string is kept intact
- Match found in a later polling batch (multi-batch loop)
- Empty queue short-circuits; no match across `max_iterations`
- SQS client created for the configured region
- Validation (`400` on empty request id) and permission (`READ_BASIC_FEATURES`) gates
- `get_queue_url` / `receive_message` / `delete_message` failures surface as `500`

A small `acting_as` context manager patches the `@has_permission` decorator's JWT identity lookup so the decorated service can be driven directly with the desired role.

### 2. `segment_service` — integration tests (`tests/integration/test_segment.py`)
Drives the `/segments` and `/segments/departments` endpoints through the HTTP layer against the seeded `demo` schema:
- Segment listing returns the seeded rows with correct `cpoe` flags, ordered by description
- Department listing exposes `idSegment` / `idDepartment` / `label` from the join, ordered by department name
- Both endpoints reject a role lacking `READ_BASIC_FEATURES` with `401`

## Testing
- `ENV=test python -m pytest` — full suite green (**751 passed**), including the 18 new tests, run against a local PostgreSQL loaded with the same `noharm-ai/database` SQL the CI uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUiGCtdp8u8ZT29aMxnDcT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUiGCtdp8u8ZT29aMxnDcT)_