### PR TITLE
test: cover drug_list conciliation helpers and prescription feature aggregation

### DIFF
--- a/tests/unit/test_drug_list_helpers.py
+++ b/tests/unit/test_drug_list_helpers.py
@@ -1,0 +1,179 @@
+"""Unit tests for the pure/static helpers of utils.drug_list.DrugList.
+
+These cover medication-reconciliation (conciliation) helpers and small
+list-normalization utilities that do not require a database or app context,
+so they can be exercised directly as static methods.
+"""
+
+from datetime import datetime
+
+from utils.drug_list import DrugList, _get_legacy_alert
+
+
+class TestGetLegacyAlert:
+    """Tests for _get_legacy_alert (maps alert kinds to legacy keys)."""
+
+    def test_known_kinds_map_to_legacy_keys(self):
+        """Each known alert kind maps to its legacy identifier."""
+        assert _get_legacy_alert("it") == "int"
+        assert _get_legacy_alert("dt") == "dup"
+        assert _get_legacy_alert("dm") == "dup"
+        assert _get_legacy_alert("iy") == "inc"
+        assert _get_legacy_alert("sl") == "isl"
+        assert _get_legacy_alert("rx") == "rea"
+
+
+class TestSortDrugs:
+    """Tests for DrugList.sortDrugs (accent-insensitive sort key)."""
+
+    def test_returns_lowercased_ascii_key(self):
+        """The sort key strips accents and lowercases the drug name."""
+        # remove_accents returns bytes, so the key is a lowercased byte string.
+        assert DrugList.sortDrugs({"drug": "Ácido Fólico"}) == b"acido folico"
+
+    def test_orders_accented_names_naturally(self):
+        """Accented names sort alongside their unaccented equivalents."""
+        drugs = [{"drug": "Zinco"}, {"drug": "Água"}, {"drug": "Bromo"}]
+        ordered = sorted(drugs, key=DrugList.sortDrugs)
+        assert [d["drug"] for d in ordered] == ["Água", "Bromo", "Zinco"]
+
+
+class TestChangeDrugName:
+    """Tests for DrugList.changeDrugName (patient free-text drug relabeling)."""
+
+    def test_zero_id_drug_uses_time_as_name(self):
+        """A drug with idDrug '0' has its name replaced by its time field."""
+        result = DrugList.changeDrugName([{"idDrug": "0", "drug": "x", "time": "08:00"}])
+        assert result[0]["drug"] == "08:00"
+
+    def test_regular_drug_name_unchanged(self):
+        """A drug with a real idDrug keeps its original name."""
+        result = DrugList.changeDrugName(
+            [{"idDrug": "9", "drug": "Dipirona", "time": "y"}]
+        )
+        assert result[0]["drug"] == "Dipirona"
+
+    def test_returns_all_items(self):
+        """Every input item is present in the output."""
+        result = DrugList.changeDrugName(
+            [
+                {"idDrug": "0", "drug": "a", "time": "06:00"},
+                {"idDrug": "1", "drug": "b", "time": "c"},
+            ]
+        )
+        assert len(result) == 2
+        assert result[0]["drug"] == "06:00"
+        assert result[1]["drug"] == "b"
+
+
+class TestCpoeDrugs:
+    """Tests for DrugList.cpoeDrugs (rewrites prescription id for CPOE view)."""
+
+    def test_moves_original_id_into_cpoe_and_sets_new_id(self):
+        """The original idPrescription is preserved under 'cpoe' and replaced."""
+        result = DrugList.cpoeDrugs(
+            [{"idPrescription": "10"}, {"idPrescription": "11"}], "99"
+        )
+        assert result == [
+            {"idPrescription": "99", "cpoe": "10"},
+            {"idPrescription": "99", "cpoe": "11"},
+        ]
+
+    def test_empty_list(self):
+        """An empty drug list yields an empty result."""
+        assert DrugList.cpoeDrugs([], "99") == []
+
+
+class TestScheduleToArray:
+    """Tests for DrugList.schedule_to_array (schedule tuples to iso pairs)."""
+
+    def test_none_returns_empty_list(self):
+        """A missing schedule returns an empty list."""
+        assert DrugList.schedule_to_array(None) == []
+
+    def test_empty_returns_empty_list(self):
+        """An empty schedule returns an empty list."""
+        assert DrugList.schedule_to_array([]) == []
+
+    def test_formats_and_sorts_descending(self):
+        """Entries are converted to iso pairs and sorted newest-first."""
+        schedule = [
+            (datetime(2024, 1, 1, 8), datetime(2024, 1, 1, 9)),
+            (datetime(2024, 1, 2, 8), datetime(2024, 1, 2, 9)),
+        ]
+        result = DrugList.schedule_to_array(schedule)
+        assert result == [
+            ["2024-01-02T08:00:00", "2024-01-02T09:00:00"],
+            ["2024-01-01T08:00:00", "2024-01-01T09:00:00"],
+        ]
+
+    def test_limits_to_ten_entries(self):
+        """No more than ten entries are returned."""
+        schedule = [(datetime(2024, 1, 1, h), datetime(2024, 1, 1, h)) for h in range(15)]
+        result = DrugList.schedule_to_array(schedule)
+        assert len(result) == 10
+
+
+class TestInferSubstanceFuzzy:
+    """Tests for DrugList.infer_substance_fuzzy (fuzzy medication matching)."""
+
+    def test_non_zero_id_copies_substance_id(self):
+        """A drug that already has an id copies its idSubstance to sctid_infer."""
+        concilia = [{"idDrug": "5", "drug": "Something", "idSubstance": 77}]
+        result = DrugList.infer_substance_fuzzy(concilia, [], 0.7)
+        assert result[0]["sctid_infer"] == "77"
+
+    def test_non_zero_id_without_substance_sets_none(self):
+        """A drug with an id but no substance gets a None sctid_infer."""
+        concilia = [{"idDrug": "5", "drug": "Something"}]
+        result = DrugList.infer_substance_fuzzy(concilia, [], 0.7)
+        assert result[0]["sctid_infer"] is None
+
+    def test_matches_by_drug_name(self):
+        """A free-text drug is matched to a prescription drug by name."""
+        concilia = [{"idDrug": "0", "drug": "Dipirona 500mg"}]
+        prescription = [
+            {"drug": "DIPIRONA", "substance": "metamizol", "sctid": "111"},
+            {"drug": "PARACETAMOL", "substance": "acetaminofeno", "sctid": "222"},
+        ]
+        result = DrugList.infer_substance_fuzzy(concilia, prescription, 0.7)
+        assert result[0]["sctid_infer"] == "111"
+        assert result[0]["matched_drug"] == "DIPIRONA"
+        assert result[0]["match_score"] == 1.0
+
+    def test_matches_by_substance_name(self):
+        """A free-text drug can be matched against the substance name."""
+        concilia = [{"idDrug": "0", "drug": "Metamizol"}]
+        prescription = [
+            {"drug": "DIPIRONA", "substance": "METAMIZOL", "sctid": "111"},
+        ]
+        result = DrugList.infer_substance_fuzzy(concilia, prescription, 0.7)
+        assert result[0]["sctid_infer"] == "111"
+
+    def test_no_match_below_threshold_leaves_drug_untouched(self):
+        """When nothing clears the threshold, no inference keys are added."""
+        concilia = [{"idDrug": "0", "drug": "CompletelyUnknownXYZ"}]
+        prescription = [{"drug": "DIPIRONA", "substance": "metamizol", "sctid": "111"}]
+        result = DrugList.infer_substance_fuzzy(concilia, prescription, 0.7)
+        assert "sctid_infer" not in result[0]
+        assert "matched_drug" not in result[0]
+
+    def test_drug_without_name_is_skipped(self):
+        """An entry without a drug name is left unchanged."""
+        concilia = [{"idDrug": "0", "drug": ""}]
+        prescription = [{"drug": "DIPIRONA", "substance": "metamizol", "sctid": "111"}]
+        result = DrugList.infer_substance_fuzzy(concilia, prescription, 0.7)
+        assert "sctid_infer" not in result[0]
+
+    def test_threshold_is_respected(self):
+        """A very high threshold rejects an otherwise-plausible partial match."""
+        concilia = [{"idDrug": "0", "drug": "Dipirona Sodica"}]
+        prescription = [{"drug": "DIPIRONA", "substance": None, "sctid": "111"}]
+        strict = DrugList.infer_substance_fuzzy(
+            [dict(c) for c in concilia], prescription, 0.99
+        )
+        lenient = DrugList.infer_substance_fuzzy(
+            [dict(c) for c in concilia], prescription, 0.3
+        )
+        assert "sctid_infer" not in strict[0]
+        assert lenient[0]["sctid_infer"] == "111"

--- a/tests/unit/test_prescriptionutils.py
+++ b/tests/unit/test_prescriptionutils.py
@@ -197,3 +197,204 @@ class TestGetPrescriptionItemPeriod:
             is_cpoe=False, item_period=5, cpoe_period=None
         )
         assert total == 5.0
+
+
+class TestSortRelations:
+    """Tests for prescriptionutils.sortRelations (drug interaction sort key)."""
+
+    def test_returns_accent_stripped_key(self):
+        """The sort key is the accent-stripped 'nameB' field."""
+        # remove_accents returns bytes, so the key is an ascii byte string.
+        assert prescriptionutils.sortRelations({"nameB": "Ácido"}) == b"Acido"
+
+    def test_orders_relations_by_name_b(self):
+        """Relations are ordered by their accent-insensitive 'nameB'."""
+        relations = [{"nameB": "Zinco"}, {"nameB": "Ácido"}, {"nameB": "Bromo"}]
+        ordered = sorted(relations, key=prescriptionutils.sortRelations)
+        assert [r["nameB"] for r in ordered] == ["Ácido", "Bromo", "Zinco"]
+
+
+class TestGetInternalPrescriptionIds:
+    """Tests for prescriptionutils.get_internal_prescription_ids."""
+
+    def test_collects_ids_across_sources(self):
+        """Ids are gathered from prescription, solution and procedures."""
+        result = {
+            "prescription": [{"idPrescription": 10}],
+            "solution": [{"idPrescription": 20}],
+            "procedures": [{"idPrescription": 30}],
+        }
+        assert sorted(prescriptionutils.get_internal_prescription_ids(result)) == [
+            10,
+            20,
+            30,
+        ]
+
+    def test_cpoe_id_takes_precedence(self):
+        """When a 'cpoe' attribute is present it is used instead of idPrescription."""
+        result = {
+            "prescription": [{"cpoe": 20, "idPrescription": 99}],
+            "solution": [],
+            "procedures": [],
+        }
+        assert prescriptionutils.get_internal_prescription_ids(result) == [20]
+
+    def test_ids_are_deduplicated(self):
+        """Repeated ids across sources are returned only once."""
+        result = {
+            "prescription": [{"idPrescription": 10}, {"idPrescription": 10}],
+            "solution": [{"idPrescription": 10}],
+            "procedures": [],
+        }
+        assert prescriptionutils.get_internal_prescription_ids(result) == [10]
+
+
+def _make_drug(**overrides):
+    """Build a prescription-drug dict with the fields getFeatures reads."""
+    drug = {
+        "idDrug": 1,
+        "idSubstance": None,
+        "idSubstanceClass": None,
+        "whiteList": False,
+        "suspended": False,
+        "allergy": 0,
+        "alertsComplete": [],
+        "score": "0",
+        "am": 0,
+        "av": 0,
+        "np": 0,
+        "c": 0,
+        "checked": True,
+        "tubeAlert": 0,
+        "frequency": {"value": ""},
+        "idDepartment": 10,
+        "interval": None,
+    }
+    drug.update(overrides)
+    return drug
+
+
+def _make_result(**overrides):
+    """Build the aggregated prescription result dict getFeatures expects."""
+    result = {
+        "prescription": [],
+        "solution": [],
+        "procedures": [],
+        "interventions": [],
+        "alertExams": 0,
+        "complication": 0,
+    }
+    result.update(overrides)
+    return result
+
+
+class TestGetFeatures:
+    """Tests for prescriptionutils.getFeatures (prescription feature aggregation)."""
+
+    def test_empty_prescription_is_all_zero(self):
+        """An empty prescription produces zeroed counters and a low alert level."""
+        features = prescriptionutils.getFeatures(_make_result())
+        assert features["totalItens"] == 0
+        assert features["prescriptionScore"] == 0
+        assert features["globalScore"] == 0
+        assert features["alertLevel"] == "low"
+        assert features["drugIDs"] == []
+
+    def test_counts_scores_and_flags(self):
+        """Per-drug scores, flags and unchecked counts are aggregated."""
+        drug_high = _make_drug(
+            score="2",
+            am=1,
+            av=1,
+            allergy=1,
+            checked=False,
+            tubeAlert=1,
+            alertsComplete=[{"level": "high"}],
+        )
+        drug_three = _make_drug(idDrug=2, score="3", np=1, c=1)
+        features = prescriptionutils.getFeatures(
+            _make_result(
+                prescription=[drug_high, drug_three],
+                alertExams=2,
+                interventions=[{"status": "s"}, {"status": "x"}],
+            )
+        )
+        assert features["scoreTwo"] == 1
+        assert features["scoreThree"] == 1
+        assert features["prescriptionScore"] == 5
+        assert features["am"] == 1
+        assert features["av"] == 1
+        assert features["np"] == 1
+        assert features["controlled"] == 1
+        assert features["allergy"] == 1
+        assert features["alergy"] == 1  # legacy misspelled alias
+        assert features["diff"] == 1  # one unchecked item
+        assert features["tube"] == 1
+        assert features["alertLevel"] == "high"
+        assert features["interventions"] == 1  # only status 's' counts
+        # globalScore = pScore + av + am + exams + alerts + diff
+        assert features["globalScore"] == 5 + 1 + 1 + 2 + 1 + 1
+
+    def test_deduplicates_ids_and_collects_metadata(self):
+        """Drug/substance ids are de-duplicated and intervals/frequencies gathered."""
+        drug_a = _make_drug(
+            idDrug=1,
+            idSubstance=100,
+            idSubstanceClass=5,
+            interval="08:00 20:00",
+            frequency={"value": "12"},
+            idDepartment=3,
+        )
+        drug_b = _make_drug(
+            idDrug=1,
+            idSubstance=100,
+            frequency={"value": "8"},
+            idDepartment=4,
+        )
+        features = prescriptionutils.getFeatures(
+            _make_result(prescription=[drug_a, drug_b])
+        )
+        assert sorted(features["drugIDs"]) == [1]
+        assert features["substanceIDs"] == [100]
+        assert features["substanceClassIDs"] == [5]
+        assert features["intervals"] == ["08", "20"]
+        assert sorted(features["frequencies"]) == ["12", "8"]
+        assert sorted(features["departmentList"]) == [3, 4]
+
+    def test_whitelisted_drug_skips_scoring_but_counts_attributes(self):
+        """A whitelisted drug is excluded from scores yet still feeds ids/attributes."""
+        whitelisted = _make_drug(
+            idDrug=9,
+            whiteList=True,
+            score="5",
+            am=1,
+            idDepartment=99,
+            drugAttributes={"antimicro": 2},
+        )
+        features = prescriptionutils.getFeatures(
+            _make_result(prescription=[whitelisted])
+        )
+        # excluded from score/flag aggregation...
+        assert features["prescriptionScore"] == 0
+        assert features["am"] == 0
+        assert 99 not in features["departmentList"]
+        # ...but still contributes to id lists and attribute totals.
+        assert features["drugIDs"] == [9]
+        assert features["drugAttributes"]["antimicro"] == 2
+        assert features["totalItens"] == 1
+
+    def test_agg_path_uses_alert_stats(self):
+        """When alertStats is present it drives the alert total and level."""
+        drug = _make_drug(alertsComplete=[{"level": "high"}])
+        features = prescriptionutils.getFeatures(
+            _make_result(
+                prescription=[drug],
+                alertStats={"total": 7, "level": "medium"},
+                protocolAlerts={"summary": [1, 2]},
+            )
+        )
+        # alerts = alertStats total (7) + protocol summary length (2)
+        assert features["alerts"] == 9
+        assert features["alertLevel"] == "medium"
+        assert features["protocolAlerts"] == [1, 2]
+        assert features["alertStats"] == {"total": 7, "level": "medium"}

--- a/tests/unit/test_stringutils.py
+++ b/tests/unit/test_stringutils.py
@@ -180,3 +180,37 @@ class TestIsValidFilename:
     def test_invalid_extension_rejected(self):
         """A path whose extension is not allowed is rejected"""
         assert stringutils.is_valid_filename("report.txt", {".pdf", ".csv"}) is False
+
+
+class TestRemoveAccents:
+    """Teste stringutils - remove_accents (diacritic stripping)"""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("ção", b"cao"),
+            ("Olá Mundo", b"Ola Mundo"),
+            ("ÁÉÍÓÚ", b"AEIOU"),
+            ("ascii", b"ascii"),
+        ],
+    )
+    def test_strips_accents_returning_bytes(self, value, expected):
+        """Accents are removed; the result is an ASCII byte string."""
+        assert stringutils.remove_accents(value) == expected
+
+
+class TestSlugify:
+    """Teste stringutils - slugify (used as a grouping key)"""
+
+    def test_lowercases_and_replaces_non_word_runs(self):
+        """Non-word runs collapse to dashes and the text is lowercased.
+
+        Note: remove_accents returns bytes, so slugify currently includes the
+        byte-string repr in its output. These assertions document the current
+        behavior rather than an idealized slug.
+        """
+        assert stringutils.slugify("Hello World") == "b-hello-world-"
+
+    def test_strips_accents_before_slugifying(self):
+        """Accented characters are stripped before the slug is built."""
+        assert stringutils.slugify("Ação Média") == "b-acao-media-"


### PR DESCRIPTION
## Summary

Increases unit-test coverage for two previously untested areas of pure business logic. All new tests are DB-free and run as part of the existing `tests/unit/` suite.

### Feature 1 — `utils.drug_list.DrugList` conciliation & helper methods (`tests/unit/test_drug_list_helpers.py`, new)
- **`infer_substance_fuzzy`** — the fuzzy medication-reconciliation matcher (matching by drug name *and* substance name, threshold handling, copying `idSubstance` for already-identified drugs, leaving no-match/empty-name entries untouched).
- **`changeDrugName`**, **`cpoeDrugs`**, **`schedule_to_array`** (formatting, descending sort, 10-item cap), **`sortDrugs`**, and the **`_get_legacy_alert`** mapping.

### Feature 2 — `utils.prescriptionutils` feature aggregation (`tests/unit/test_prescriptionutils.py`)
- **`getFeatures`** — empty prescription, score/flag aggregation and `globalScore`, id/interval/frequency de-duplication, the whitelisted-drug skip path, and the aggregated (`alertStats`) path.
- **`sortRelations`** and **`get_internal_prescription_ids`** (including CPOE-id precedence and de-duplication).

### Also
- Added tests for `utils.stringutils.remove_accents` and `slugify`.

## Note for reviewers
`slugify` currently returns strings such as `"b-hello-world-"` because `remove_accents` returns `bytes` and the byte-string `repr` leaks into the slug via `str(text)`. `slugify` is only used as a grouping key in `exams_service`, so this is cosmetic rather than breaking. The new `TestSlugify` tests document the **current** behavior; a follow-up could fix `remove_accents` to return `str` (a one-line `.decode()`), at which point those assertions would be updated intentionally.

## Testing
- `ENV=test python -m pytest tests/unit/` → **577 passed** (35 new), run against a local PostgreSQL loaded from the same `noharm-ai/database` SQL used by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9VEKaxGukmAtg8xU1kr5D)_