### PR TITLE
test: cover protocol listing endpoint and drug_list intervention helpers

### DIFF
--- a/tests/integration/test_protocol.py
+++ b/tests/integration/test_protocol.py
@@ -1,7 +1,7 @@
 """Integration tests for the /protocol/list endpoint (protocol_service.list_protocols)."""
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 
 from tests.conftest import get_access, make_headers, session, session_commit
 
@@ -49,8 +49,9 @@ def seed_protocols():
 
     session.execute(
         text("DELETE FROM public.protocolo WHERE idprotocolo IN :ids").bindparams(
-            ids=_ALL_IDS
-        )
+            bindparam("ids", expanding=True)
+        ),
+        {"ids": list(_ALL_IDS)},
     )
     session_commit()
 

--- a/tests/integration/test_protocol.py
+++ b/tests/integration/test_protocol.py
@@ -1,0 +1,158 @@
+"""Integration tests for the /protocol/list endpoint (protocol_service.list_protocols)."""
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import get_access, make_headers, session, session_commit
+
+from security.role import Role
+
+# Protocol test rows live in the shared public.protocolo table. Use a high
+# idprotocolo range so they never collide with real seed data and are trivial
+# to clean up afterwards. tp_protocolo/tp_situacao follow ProtocolTypeEnum and
+# ProtocolStatusTypeEnum: type 1 = PRESCRIPTION_AGG, 2 = PRESCRIPTION_INDIVIDUAL;
+# status 0 = INACTIVE, 1 = ACTIVE.
+#
+# Fields: (id, schema_name, name, tp_protocolo, tp_situacao)
+_GLOBAL_ACTIVE = (990001, None, "ZZTest Global Agg", 1, 1)
+_DEMO_ACTIVE = (990002, "demo", "ZZTest Demo Individual", 2, 1)
+_DEMO_INACTIVE = (990003, "demo", "ZZTest Demo Inactive", 1, 0)
+_OTHER_SCHEMA = (990004, "other-schema", "ZZTest Other Schema", 1, 1)
+
+_ALL_ROWS = (_GLOBAL_ACTIVE, _DEMO_ACTIVE, _DEMO_INACTIVE, _OTHER_SCHEMA)
+_ALL_IDS = tuple(row[0] for row in _ALL_ROWS)
+
+
+@pytest.fixture
+def seed_protocols():
+    """Insert distinctive protocolo rows and remove them after the test."""
+    for id_protocol, schema, name, tp_protocolo, tp_situacao in _ALL_ROWS:
+        session.execute(
+            text(
+                "INSERT INTO public.protocolo "
+                "(idprotocolo, schema_name, nome, tp_protocolo, tp_situacao, "
+                "configuracao, created_at, created_by) "
+                "VALUES (:id, :schema, :name, :tp_protocolo, :tp_situacao, "
+                "CAST('{}' AS json), now(), 1)"
+            ),
+            {
+                "id": id_protocol,
+                "schema": schema,
+                "name": name,
+                "tp_protocolo": tp_protocolo,
+                "tp_situacao": tp_situacao,
+            },
+        )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM public.protocolo WHERE idprotocolo IN :ids").bindparams(
+            ids=_ALL_IDS
+        )
+    )
+    session_commit()
+
+
+def _data(response):
+    """Extract the data list from a successful response envelope."""
+    return response.get_json()["data"]
+
+
+def _by_id(response):
+    """Index the returned protocols by their id for easy assertions."""
+    return {item["id"]: item for item in _data(response)}
+
+
+def test_list_protocols_permission_denied(client):
+    """A user without READ_BASIC_FEATURES cannot list protocols [401 UNAUTHORIZED]."""
+    headers = make_headers(get_access(client, roles=[Role.SUPPORT_REQUESTER.value]))
+    response = client.get("/protocol/list", headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_list_protocols_returns_visible_rows(client, analyst_headers, seed_protocols):
+    """Global (schema-less) and same-schema protocols are returned together."""
+    response = client.get("/protocol/list", headers=analyst_headers)
+
+    assert response.status_code == 200
+    by_id = _by_id(response)
+
+    # Global and demo-owned protocols are visible...
+    assert _GLOBAL_ACTIVE[0] in by_id
+    assert _DEMO_ACTIVE[0] in by_id
+    assert _DEMO_INACTIVE[0] in by_id
+    # ...but a protocol owned by another schema is hidden.
+    assert _OTHER_SCHEMA[0] not in by_id
+
+
+def test_list_protocols_response_shape(client, analyst_headers, seed_protocols):
+    """Each protocol exposes id, name, protocolType and status fields."""
+    response = client.get("/protocol/list", headers=analyst_headers)
+
+    assert response.status_code == 200
+    item = _by_id(response)[_DEMO_ACTIVE[0]]
+
+    assert item["name"] == _DEMO_ACTIVE[2]
+    assert item["protocolType"] == _DEMO_ACTIVE[3]
+    assert item["status"] == _DEMO_ACTIVE[4]
+
+
+def test_list_protocols_filter_by_type(client, analyst_headers, seed_protocols):
+    """Filtering by protocolType returns only protocols of that type."""
+    response = client.get("/protocol/list?protocolType=2", headers=analyst_headers)
+
+    assert response.status_code == 200
+    by_id = _by_id(response)
+
+    # Only the type-2 (individual) protocol among the seeded rows is returned.
+    assert _DEMO_ACTIVE[0] in by_id
+    assert _GLOBAL_ACTIVE[0] not in by_id
+    assert _DEMO_INACTIVE[0] not in by_id
+
+
+def test_list_protocols_filter_by_status(client, analyst_headers, seed_protocols):
+    """Filtering by statusType returns only protocols in that status."""
+    response = client.get("/protocol/list?statusType=0", headers=analyst_headers)
+
+    assert response.status_code == 200
+    by_id = _by_id(response)
+
+    # Only the inactive (status 0) seeded protocol is returned.
+    assert _DEMO_INACTIVE[0] in by_id
+    assert _GLOBAL_ACTIVE[0] not in by_id
+    assert _DEMO_ACTIVE[0] not in by_id
+
+
+def test_list_protocols_active_flag_keeps_only_active(
+    client, analyst_headers, seed_protocols
+):
+    """The active flag restricts the listing to ACTIVE protocols."""
+    response = client.get("/protocol/list?active=true", headers=analyst_headers)
+
+    assert response.status_code == 200
+    by_id = _by_id(response)
+
+    # Active protocols remain, the inactive one is dropped.
+    assert _GLOBAL_ACTIVE[0] in by_id
+    assert _DEMO_ACTIVE[0] in by_id
+    assert _DEMO_INACTIVE[0] not in by_id
+
+
+def test_list_protocols_ordered_by_name(client, analyst_headers, seed_protocols):
+    """Results are ordered alphabetically by protocol name."""
+    response = client.get("/protocol/list", headers=analyst_headers)
+
+    assert response.status_code == 200
+    items = _data(response)
+    positions = {
+        item["id"]: index
+        for index, item in enumerate(items)
+        if item["id"] in (_GLOBAL_ACTIVE[0], _DEMO_ACTIVE[0], _DEMO_INACTIVE[0])
+    }
+
+    # "ZZTest Demo Inactive" < "ZZTest Demo Individual" < "ZZTest Global Agg".
+    assert positions[_DEMO_INACTIVE[0]] < positions[_DEMO_ACTIVE[0]]
+    assert positions[_DEMO_ACTIVE[0]] < positions[_GLOBAL_ACTIVE[0]]

--- a/tests/unit/test_drug_list_intervention.py
+++ b/tests/unit/test_drug_list_intervention.py
@@ -1,0 +1,216 @@
+"""Unit tests for utils.drug_list.DrugList intervention-matching and helper methods.
+
+These methods carry the pharmacist-facing logic that links a prescription drug to
+prior clinical interventions and normalizes drug/schedule data for the prescription
+view. They are pure with respect to the object's own attributes, so the tests build a
+bare ``DrugList`` via ``__new__`` and set only the attributes each method reads,
+avoiding the heavy database/feature-flag work in ``DrugList.__init__``.
+"""
+
+from datetime import datetime
+
+from utils.drug_list import DrugList
+
+
+def _make_drug_list(interventions=None, drug_results=None, admission_number=111):
+    """Build a DrugList without running the DB-heavy constructor.
+
+    Only the attributes exercised by the methods under test are populated.
+    """
+    instance = DrugList.__new__(DrugList)
+    instance.admission_number = admission_number
+    instance.interventions = interventions if interventions is not None else []
+    instance.drug_results = drug_results if drug_results is not None else []
+    return instance
+
+
+def _intervention(
+    id_intervention,
+    id_drug=10,
+    status="s",
+    id_prescription="50",
+    admission_number=111,
+):
+    """Build an intervention record shaped like the ones DrugList consumes."""
+    return {
+        "id": id_intervention,
+        "idDrug": id_drug,
+        "status": status,
+        "idPrescription": id_prescription,
+        "admissionNumber": admission_number,
+    }
+
+
+class TestGetPrevIntervention:
+    """Tests for DrugList.getPrevIntervention (most recent accepted prior intervention)."""
+
+    def test_no_interventions_returns_empty_dict(self):
+        """With no interventions the result is an empty dict."""
+        drug_list = _make_drug_list()
+        assert drug_list.getPrevIntervention(idDrug=10, idPrescription=100) == {}
+
+    def test_matches_accepted_prior_intervention(self):
+        """An accepted ('s') intervention on the same drug/admission is returned."""
+        drug_list = _make_drug_list(interventions=[_intervention(1)])
+        result = drug_list.getPrevIntervention(idDrug=10, idPrescription=100)
+        assert result["id"] == 1
+
+    def test_ignores_non_accepted_status(self):
+        """Interventions whose status is not 's' are ignored."""
+        drug_list = _make_drug_list(interventions=[_intervention(1, status="0")])
+        assert drug_list.getPrevIntervention(idDrug=10, idPrescription=100) == {}
+
+    def test_ignores_other_drug(self):
+        """Interventions for a different drug are ignored."""
+        drug_list = _make_drug_list(interventions=[_intervention(1, id_drug=99)])
+        assert drug_list.getPrevIntervention(idDrug=10, idPrescription=100) == {}
+
+    def test_ignores_other_admission(self):
+        """Interventions from a different admission are ignored."""
+        drug_list = _make_drug_list(
+            interventions=[_intervention(1, admission_number=222)]
+        )
+        assert drug_list.getPrevIntervention(idDrug=10, idPrescription=100) == {}
+
+    def test_ignores_same_or_later_prescription(self):
+        """Only interventions on an earlier prescription qualify."""
+        drug_list = _make_drug_list(
+            interventions=[_intervention(1, id_prescription="100")]
+        )
+        assert drug_list.getPrevIntervention(idDrug=10, idPrescription=100) == {}
+
+    def test_returns_highest_id_among_matches(self):
+        """When several match, the one with the highest id wins."""
+        drug_list = _make_drug_list(
+            interventions=[
+                _intervention(1, id_prescription="50"),
+                _intervention(5, id_prescription="60"),
+                _intervention(3, id_prescription="40"),
+            ]
+        )
+        result = drug_list.getPrevIntervention(idDrug=10, idPrescription=100)
+        assert result["id"] == 5
+
+
+class TestGetExistIntervention:
+    """Tests for DrugList.getExistIntervention (any prior intervention exists)."""
+
+    def test_true_for_any_prior_intervention_regardless_of_status(self):
+        """A prior intervention on the same drug/admission counts even if not accepted."""
+        drug_list = _make_drug_list(interventions=[_intervention(1, status="0")])
+        assert drug_list.getExistIntervention(idDrug=10, idPrescription=100) is True
+
+    def test_false_without_earlier_prescription(self):
+        """No earlier prescription means no prior intervention exists."""
+        drug_list = _make_drug_list(
+            interventions=[_intervention(1, id_prescription="50")]
+        )
+        assert drug_list.getExistIntervention(idDrug=10, idPrescription=40) is False
+
+    def test_false_for_other_admission(self):
+        """A prior intervention from another admission does not count."""
+        drug_list = _make_drug_list(
+            interventions=[_intervention(1, admission_number=222)]
+        )
+        assert drug_list.getExistIntervention(idDrug=10, idPrescription=100) is False
+
+
+class TestGetIntervention:
+    """Tests for DrugList.getIntervention (lookup by prescription-drug id)."""
+
+    def test_returns_matching_intervention(self):
+        """The intervention whose id matches the prescription-drug id is returned."""
+        drug_list = _make_drug_list(
+            interventions=[_intervention(5), _intervention(7)]
+        )
+        assert drug_list.getIntervention(5)["id"] == 5
+
+    def test_no_match_returns_empty_dict(self):
+        """A missing id yields an empty dict."""
+        drug_list = _make_drug_list(interventions=[_intervention(5)])
+        assert drug_list.getIntervention(999) == {}
+
+
+class TestGetDrugsBySource:
+    """Tests for DrugList.get_drugs_by_source (filter processed drugs by source)."""
+
+    def test_filters_by_requested_sources(self):
+        """Only drugs whose source is in the requested list are returned."""
+        drug_list = _make_drug_list(
+            drug_results=[
+                {"source": "Medicamentos"},
+                {"source": "Dietas"},
+                {"source": "Soluções"},
+            ]
+        )
+        result = drug_list.get_drugs_by_source(["Medicamentos", "Dietas"])
+        assert [d["source"] for d in result] == ["Medicamentos", "Dietas"]
+
+    def test_no_match_returns_empty_list(self):
+        """No matching source yields an empty list."""
+        drug_list = _make_drug_list(drug_results=[{"source": "Medicamentos"}])
+        assert drug_list.get_drugs_by_source(["Procedimentos"]) == []
+
+
+class TestSortDrugs:
+    """Tests for DrugList.sortDrugs (accent-insensitive drug sort key)."""
+
+    def test_returns_lowercased_accent_stripped_key(self):
+        """The key is the accent-stripped, lowercased drug name (bytes)."""
+        assert DrugList.sortDrugs({"drug": "Ácido"}) == b"acido"
+
+    def test_orders_names_accent_insensitively(self):
+        """Sorting by the key orders names ignoring accents and case."""
+        drugs = [{"drug": "Zinco"}, {"drug": "Ácido"}, {"drug": "bromo"}]
+        ordered = [d["drug"] for d in sorted(drugs, key=DrugList.sortDrugs)]
+        assert ordered == ["Ácido", "bromo", "Zinco"]
+
+
+class TestCpoeDrugs:
+    """Tests for DrugList.cpoeDrugs (rewrite ids for CPOE prescriptions)."""
+
+    def test_moves_prescription_id_into_cpoe(self):
+        """The original idPrescription is preserved under 'cpoe' and replaced."""
+        drugs = [{"idPrescription": 20, "name": "x"}]
+        result = DrugList.cpoeDrugs(drugs, idPrescription=99)
+        assert result[0]["cpoe"] == 20
+        assert result[0]["idPrescription"] == 99
+
+    def test_rewrites_every_drug(self):
+        """Every drug in the list gets the shared prescription id."""
+        drugs = [{"idPrescription": 20}, {"idPrescription": 30}]
+        result = DrugList.cpoeDrugs(drugs, idPrescription=99)
+        assert [d["idPrescription"] for d in result] == [99, 99]
+        assert [d["cpoe"] for d in result] == [20, 30]
+
+
+class TestScheduleToArray:
+    """Tests for DrugList.schedule_to_array (serialize a schedule to sorted iso pairs)."""
+
+    def test_empty_schedule_returns_empty_list(self):
+        """A falsy schedule returns an empty list."""
+        assert DrugList.schedule_to_array(None) == []
+        assert DrugList.schedule_to_array([]) == []
+
+    def test_serializes_and_sorts_descending(self):
+        """Datetime pairs become iso strings ordered most-recent first."""
+        schedule = [
+            (datetime(2024, 1, 1, 8, 0), datetime(2024, 1, 1, 9, 0)),
+            (datetime(2024, 1, 2, 8, 0), datetime(2024, 1, 2, 9, 0)),
+        ]
+        result = DrugList.schedule_to_array(schedule)
+        assert result == [
+            ["2024-01-02T08:00:00", "2024-01-02T09:00:00"],
+            ["2024-01-01T08:00:00", "2024-01-01T09:00:00"],
+        ]
+
+    def test_limits_to_ten_entries(self):
+        """No more than ten schedule entries are returned."""
+        schedule = [
+            (datetime(2024, 1, day, 8, 0), datetime(2024, 1, day, 9, 0))
+            for day in range(1, 16)
+        ]
+        result = DrugList.schedule_to_array(schedule)
+        assert len(result) == 10
+        # The most recent day (15) is kept, the oldest (day 1) is dropped.
+        assert result[0][0] == "2024-01-15T08:00:00"


### PR DESCRIPTION
## Summary

Increases test coverage by adding tests for two previously untested features.

### 1. `/protocol/list` endpoint (integration)

`protocol_service.list_protocols` had no test coverage. New integration tests in `tests/integration/test_protocol.py` cover:

- Permission gating (`READ_BASIC_FEATURES` → `401` for a user without it)
- Schema visibility: global (schema-less) and same-schema protocols are returned, other-schema protocols are hidden
- Filtering by `protocolType`, `statusType`, and the `active` flag
- Response shape (`id`, `name`, `protocolType`, `status`) and alphabetical ordering by name

The tests seed distinctive `public.protocolo` rows (high id range) via a fixture and remove them afterwards, so they are re-runnable and never collide with seed data — matching the pattern already used by `test_lists.py`.

### 2. `DrugList` intervention-matching & helpers (unit)

The intervention-matching and normalization logic in `utils/drug_list.py` was untested. New unit tests in `tests/unit/test_drug_list_intervention.py` cover:

- `getPrevIntervention` — most recent accepted prior intervention (drug/admission/prescription matching, highest-id wins)
- `getExistIntervention` — whether any prior intervention exists
- `getIntervention` — lookup by prescription-drug id
- `get_drugs_by_source` — source filtering
- `sortDrugs`, `cpoeDrugs`, `schedule_to_array` — sort key, CPOE id rewrite, schedule serialization

The tests build a bare `DrugList` via `__new__` to exercise the pure logic without the database/feature-flag work in the constructor.

## Testing

Full suite run locally against a PostgreSQL database seeded from `noharm-ai/database` (same SQL as CI):

- `ENV=test python -m pytest` → **819 passed** (28 new: 7 integration + 21 unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015QKVfEBS695seaTrTHJtfs)_