### PR TITLE
test: cover RBAC role resolution and ICD search endpoints

### DIFF
--- a/tests/integration/test_lists_search.py
+++ b/tests/integration/test_lists_search.py
@@ -1,0 +1,146 @@
+"""Integration tests for the ICD search endpoints.
+
+Covers lists_service.find_icds (GET /lists/icds/find) and
+lists_service.find_icds_by_ids (GET /lists/icds/resolve) — both previously
+untested. Rows are inserted into the shared public.tb_cid10 table using a high
+co_cid10 range with distinctive names so they never collide with real seed
+data and are trivial to clean up.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import get_access, make_headers, session, session_commit
+
+from security.role import Role
+
+# (co_cid10, nu_cid10 code, no_cid10 name, st_ativo). nu_cid10 is capped at 4 chars.
+_ICD_ACTIVE_A = (999101, "YZ1", "YZTest Malaria", 1)
+_ICD_ACTIVE_B = (999102, "YZ2", "YZTest Dengue", 1)
+_ICD_INACTIVE = (999103, "YZ3", "YZTest Retired", 0)
+
+_ALL_IDS = (_ICD_ACTIVE_A[0], _ICD_ACTIVE_B[0], _ICD_INACTIVE[0])
+
+
+@pytest.fixture
+def seed_icds():
+    """Insert distinctive tb_cid10 rows and remove them after the test."""
+    for co, nu, no, active in (_ICD_ACTIVE_A, _ICD_ACTIVE_B, _ICD_INACTIVE):
+        session.execute(
+            text(
+                "INSERT INTO public.tb_cid10 "
+                "(co_cid10, nu_cid10, tp_agravo, no_cid10, no_cid10_filtro, st_ativo) "
+                "VALUES (:co, :nu, 0, :no, :no, :active)"
+            ),
+            {"co": co, "nu": nu, "no": no, "active": active},
+        )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM public.tb_cid10 WHERE co_cid10 IN (:a, :b, :c)"),
+        {"a": _ALL_IDS[0], "b": _ALL_IDS[1], "c": _ALL_IDS[2]},
+    )
+    session_commit()
+
+
+def _data(response):
+    """Extract the data list from a successful response envelope."""
+    return response.get_json()["data"]
+
+
+# --- find (search by term) -------------------------------------------------
+
+
+def test_find_icds_permission_denied(client):
+    """A user without READ_BASIC_FEATURES cannot search ICDs [401]."""
+    headers = make_headers(get_access(client, roles=[Role.SUPPORT_REQUESTER.value]))
+    response = client.get("/lists/icds/find?term=YZTest", headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_find_icds_by_description(client, analyst_headers, seed_icds):
+    """A term matching the ICD name returns the active row as {id, name}."""
+    response = client.get("/lists/icds/find?term=YZTest Malaria", headers=analyst_headers)
+
+    assert response.status_code == 200
+    by_id = {item["id"]: item["name"] for item in _data(response)}
+    assert by_id.get(_ICD_ACTIVE_A[1]) == _ICD_ACTIVE_A[2]
+
+
+def test_find_icds_by_code(client, analyst_headers, seed_icds):
+    """A term matching the ICD code (nu_cid10) resolves the row."""
+    response = client.get(f"/lists/icds/find?term={_ICD_ACTIVE_B[1]}", headers=analyst_headers)
+
+    assert response.status_code == 200
+    ids = {item["id"] for item in _data(response)}
+    assert _ICD_ACTIVE_B[1] in ids
+
+
+def test_find_icds_is_case_insensitive(client, analyst_headers, seed_icds):
+    """Search matches regardless of term casing (ilike)."""
+    response = client.get("/lists/icds/find?term=yztest dengue", headers=analyst_headers)
+
+    assert response.status_code == 200
+    ids = {item["id"] for item in _data(response)}
+    assert _ICD_ACTIVE_B[1] in ids
+
+
+def test_find_icds_excludes_inactive_rows(client, analyst_headers, seed_icds):
+    """Inactive ICDs (st_ativo != 1) are never returned by search."""
+    response = client.get("/lists/icds/find?term=YZTest", headers=analyst_headers)
+
+    assert response.status_code == 200
+    ids = {item["id"] for item in _data(response)}
+    assert _ICD_INACTIVE[1] not in ids
+    assert _ICD_ACTIVE_A[1] in ids
+    assert _ICD_ACTIVE_B[1] in ids
+
+
+def test_find_icds_empty_term_is_rejected(client, analyst_headers):
+    """An empty search term is a business-rule error [400]."""
+    response = client.get("/lists/icds/find?term=", headers=analyst_headers)
+
+    assert response.status_code == 400
+    assert response.get_json()["status"] == "error"
+
+
+# --- resolve (lookup by codes) --------------------------------------------
+
+
+def test_resolve_icds_permission_denied(client):
+    """A user without READ_BASIC_FEATURES cannot resolve ICDs [401]."""
+    headers = make_headers(get_access(client, roles=[Role.SUPPORT_REQUESTER.value]))
+    response = client.get(f"/lists/icds/resolve?ids={_ICD_ACTIVE_A[1]}", headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_resolve_icds_returns_matching_codes(client, analyst_headers, seed_icds):
+    """Codes passed in ids resolve to their {id, name} records."""
+    ids = f"{_ICD_ACTIVE_A[1]},{_ICD_ACTIVE_B[1]}"
+    response = client.get(f"/lists/icds/resolve?ids={ids}", headers=analyst_headers)
+
+    assert response.status_code == 200
+    by_id = {item["id"]: item["name"] for item in _data(response)}
+    assert by_id.get(_ICD_ACTIVE_A[1]) == _ICD_ACTIVE_A[2]
+    assert by_id.get(_ICD_ACTIVE_B[1]) == _ICD_ACTIVE_B[2]
+
+
+def test_resolve_icds_includes_inactive(client, analyst_headers, seed_icds):
+    """Resolve looks up by code without filtering on status, unlike find."""
+    response = client.get(f"/lists/icds/resolve?ids={_ICD_INACTIVE[1]}", headers=analyst_headers)
+
+    assert response.status_code == 200
+    ids = {item["id"] for item in _data(response)}
+    assert _ICD_INACTIVE[1] in ids
+
+
+def test_resolve_icds_empty_returns_empty_list(client, analyst_headers):
+    """No ids yields an empty list rather than an error."""
+    response = client.get("/lists/icds/resolve?ids=", headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert _data(response) == []

--- a/tests/unit/test_role_permissions.py
+++ b/tests/unit/test_role_permissions.py
@@ -1,0 +1,114 @@
+"""Unit tests for the RBAC role/permission resolution in security.role.Role.
+
+These cover Role.get_permissions_from_user (how a user's configured role names
+are turned into a flat permission list) and Role.get_special_roles (the set of
+non-assignable roles). Both are pure functions with no database access.
+"""
+
+import pytest
+
+from models.main import User
+from security.permission import Permission
+from security.role import Role
+
+
+def _user_with_roles(roles):
+    """Build an in-memory User whose config carries the given role names."""
+    user = User()
+    user.config = {"roles": roles}
+    return user
+
+
+class TestGetPermissionsFromUser:
+    """Teste security.role - get_permissions_from_user"""
+
+    def test_single_known_role_returns_its_permissions(self):
+        """A user with one valid role gets exactly that role's permissions."""
+        user = _user_with_roles([Role.SUPPORT_REQUESTER.value])
+
+        result = Role.get_permissions_from_user(user)
+
+        assert result == Role.SUPPORT_REQUESTER.permissions
+
+    def test_role_name_is_case_insensitive(self):
+        """Lower-case role names resolve the same as their canonical form."""
+        user = _user_with_roles(["support_requester"])
+
+        result = Role.get_permissions_from_user(user)
+
+        assert result == Role.SUPPORT_REQUESTER.permissions
+
+    def test_multiple_roles_concatenate_permissions(self):
+        """Permissions from every valid role are combined into one list."""
+        user = _user_with_roles(
+            [Role.SUPPORT_REQUESTER.value, Role.VIEWER.value]
+        )
+
+        result = Role.get_permissions_from_user(user)
+
+        expected = Role.SUPPORT_REQUESTER.permissions + Role.VIEWER.permissions
+        assert result == expected
+
+    def test_unknown_role_is_ignored(self):
+        """An unrecognized role name contributes nothing and raises no error."""
+        user = _user_with_roles(["NOT_A_REAL_ROLE"])
+
+        assert Role.get_permissions_from_user(user) == []
+
+    def test_known_and_unknown_roles_mixed(self):
+        """Only the valid roles contribute; invalid ones are skipped."""
+        user = _user_with_roles(
+            ["NOT_A_REAL_ROLE", Role.SUPPORT_REQUESTER.value]
+        )
+
+        result = Role.get_permissions_from_user(user)
+
+        assert result == Role.SUPPORT_REQUESTER.permissions
+
+    def test_empty_roles_list_returns_empty(self):
+        """A user with an empty roles list has no permissions."""
+        assert Role.get_permissions_from_user(_user_with_roles([])) == []
+
+    def test_config_without_roles_key_returns_empty(self):
+        """A config dict lacking the 'roles' key yields no permissions."""
+        user = User()
+        user.config = {"features": []}
+
+        assert Role.get_permissions_from_user(user) == []
+
+    @pytest.mark.parametrize("config", [None, {}])
+    def test_missing_or_empty_config_returns_empty(self, config):
+        """A user with no usable config resolves to no permissions."""
+        user = User()
+        user.config = config
+
+        assert Role.get_permissions_from_user(user) == []
+
+    def test_result_contains_expected_permission(self):
+        """Resolved permissions include the concrete Permission enum members."""
+        user = _user_with_roles([Role.SUPPORT_REQUESTER.value])
+
+        result = Role.get_permissions_from_user(user)
+
+        assert Permission.READ_SUPPORT in result
+        assert Permission.WRITE_SUPPORT in result
+
+
+class TestGetSpecialRoles:
+    """Teste security.role - get_special_roles (non-assignable roles)"""
+
+    def test_returns_expected_role_values(self):
+        """The special-role list matches the documented non-assignable set."""
+        assert Role.get_special_roles() == [
+            Role.ADMIN.value,
+            Role.CURATOR.value,
+            Role.ORGANIZATION_MANAGER.value,
+            Role.STATIC_USER.value,
+            Role.SERVICE_INTEGRATOR.value,
+            Role.NAVIGATOR.value,
+            Role.TRAINING.value,
+        ]
+
+    def test_assignable_role_is_not_special(self):
+        """A regular assignable role is absent from the special list."""
+        assert Role.SUPPORT_REQUESTER.value not in Role.get_special_roles()


### PR DESCRIPTION
## Summary

Increases test coverage by adding tests for two previously untested features.

### 1. RBAC role → permission resolution (unit)
`tests/unit/test_role_permissions.py` covers `security.role.Role`:
- `get_permissions_from_user`: single/multiple role resolution, case-insensitive role names, unknown roles ignored, mixed valid/invalid, empty roles list, config missing the `roles` key, and `None`/empty config.
- `get_special_roles`: exact non-assignable role set, and that an assignable role is excluded.

These are pure functions (no DB access) central to authorization.

### 2. ICD search endpoints (integration)
`tests/integration/test_lists_search.py` covers the previously untested endpoints:
- `GET /lists/icds/find` (`lists_service.find_icds`): permission gating, matching by description and by code, case-insensitivity (ilike), exclusion of inactive rows, and rejection of an empty term (400).
- `GET /lists/icds/resolve` (`lists_service.find_icds_by_ids`): permission gating, resolving multiple codes to records, inclusion of inactive rows (resolve does not filter on status, unlike find), and empty-input returning an empty list.

Test rows are inserted into `public.tb_cid10` in a high `co_cid10` range with distinctive names and cleaned up after each test, following the pattern already used in `tests/integration/test_lists.py`.

## Testing
Full suite run locally against a PostgreSQL database loaded from the `noharm-ai/database` seed (same SQL as CI): **841 passed** (22 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHviFsm3RrNWoxRZGvkobk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHviFsm3RrNWoxRZGvkobk)_