### PR TITLE
test: add unit tests for prioritization and memory service helpers

### DIFF
--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -1,0 +1,92 @@
+import pytest
+
+from models.enums import MemoryEnum
+from services.memory_service import is_admin_memory, is_private
+
+
+class TestIsAdminMemory:
+    """Teste memory_service - is_admin_memory.
+
+    Returns True only for memory kinds that are restricted to admin
+    operations. Matching is exact (full-key equality), so unrelated or
+    slightly malformed keys must not be treated as admin-only.
+    """
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            MemoryEnum.FEATURES.value,
+            MemoryEnum.GETNAME.value,
+            MemoryEnum.PRESMED_FORM.value,
+            MemoryEnum.SUMMARY_CONFIG.value,
+            MemoryEnum.MAP_IV.value,
+        ],
+    )
+    def test_admin_restricted_keys_return_true(self, key):
+        """Known admin-restricted memory kinds are recognized"""
+        assert is_admin_memory(key) is True
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "user-preferences",
+            "config-signature",
+            "unknown-kind",
+            "",
+        ],
+    )
+    def test_non_admin_keys_return_false(self, key):
+        """Keys that are not in the admin-restricted list are rejected"""
+        assert is_admin_memory(key) is False
+
+    def test_match_is_exact_not_substring(self):
+        """Matching is exact: a key with extra characters is not admin-restricted"""
+        assert is_admin_memory(MemoryEnum.FEATURES.value + " ") is False
+        assert is_admin_memory("x" + MemoryEnum.FEATURES.value) is False
+
+
+class TestIsPrivate:
+    """Teste memory_service - is_private.
+
+    Returns True when the memory kind is user-scoped (private to its owner).
+    Matching is by substring, so any key that contains one of the private
+    tokens is considered private.
+    """
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "config-signature",
+            "filter-private",
+            "user-preferences",
+            "clinical-notes-private",
+        ],
+    )
+    def test_exact_private_keys_return_true(self, key):
+        """The canonical private memory kinds are recognized as private"""
+        assert is_private(key) is True
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "user-preferences-42",
+            "prefix-config-signature",
+            "clinical-notes-private-2024",
+        ],
+    )
+    def test_substring_match_returns_true(self, key):
+        """A key that merely contains a private token is treated as private"""
+        assert is_private(key) is True
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "features",
+            "getnameurl",
+            "summary-config",
+            "",
+        ],
+    )
+    def test_non_private_keys_return_false(self, key):
+        """Keys without any private token are not private"""
+        assert is_private(key) is False

--- a/tests/unit/test_prioritization_service.py
+++ b/tests/unit/test_prioritization_service.py
@@ -1,0 +1,70 @@
+import pytest
+
+from services.prioritization_service import _get_first_administration_hour
+
+
+class TestGetFirstAdministrationHour:
+    """Teste prioritization_service - _get_first_administration_hour.
+
+    Extracts the first administration hour (0-23) from a sorted intervals
+    list. It is used to prioritize the pharmacist work queue, so it must be
+    strict about what counts as a valid hour and never raise on odd input.
+    """
+
+    @pytest.mark.parametrize(
+        "intervals",
+        [
+            None,
+            [],
+            "",
+        ],
+    )
+    def test_falsy_intervals_return_none(self, intervals):
+        """None, empty list and empty string all yield None"""
+        assert _get_first_administration_hour(intervals) is None
+
+    @pytest.mark.parametrize(
+        "intervals, expected",
+        [
+            (["8"], 8),
+            (["08"], 8),
+            (["00"], 0),
+            (["23"], 23),
+            (["14", "20"], 14),
+        ],
+    )
+    def test_valid_first_hour_is_returned(self, intervals, expected):
+        """A valid digit string as the first item is parsed to its hour value"""
+        assert _get_first_administration_hour(intervals) == expected
+
+    def test_only_first_interval_is_considered(self):
+        """The hour is taken from the first item; later items are ignored"""
+        assert _get_first_administration_hour(["06", "12", "18"]) == 6
+
+    @pytest.mark.parametrize(
+        "intervals",
+        [
+            [8],  # not a string
+            [None],  # not a string
+            ["8.5"],  # not a pure digit string
+            [" 8"],  # leading space is not a digit
+            ["-1"],  # sign makes isdigit() false
+            ["abc"],  # non-numeric
+            [""],  # empty first item
+        ],
+    )
+    def test_non_digit_first_interval_returns_none(self, intervals):
+        """A first item that is not a plain digit string yields None"""
+        assert _get_first_administration_hour(intervals) is None
+
+    @pytest.mark.parametrize(
+        "intervals",
+        [
+            ["24"],
+            ["25"],
+            ["99"],
+        ],
+    )
+    def test_hour_out_of_range_returns_none(self, intervals):
+        """A numeric first item outside the 0-23 range yields None"""
+        assert _get_first_administration_hour(intervals) is None


### PR DESCRIPTION
## Summary

Increases test coverage by adding unit tests for two previously untested pure helper functions in the services layer. Both functions are pure (no DB or external dependencies), so they are covered with fast, isolated unit tests.

## What's covered

### `prioritization_service._get_first_administration_hour`
Extracts the first administration hour (0–23) from a sorted intervals list, used to prioritize the pharmacist work queue. New tests (`tests/unit/test_prioritization_service.py`) assert:
- Falsy input (`None`, `[]`, `""`) returns `None`
- Valid digit strings (`"8"`, `"08"`, `"00"`, `"23"`) are parsed to their hour value
- Only the first interval is considered
- Non-digit first items (`int`, `None`, `"8.5"`, `" 8"`, `"-1"`, `"abc"`, `""`) return `None`
- Numeric values outside `0–23` (`"24"`, `"25"`, `"99"`) return `None`

### `memory_service.is_admin_memory` / `memory_service.is_private`
Classify memory kinds as admin-restricted (exact match) or user-private (substring match). New tests (`tests/unit/test_memory_service.py`) assert:
- `is_admin_memory` recognizes known admin kinds and rejects unknown/malformed keys, matching exactly (not by substring)
- `is_private` recognizes the canonical private kinds, matches by substring, and rejects non-private keys

## Testing

All tests pass locally against PostgreSQL, run with `ENV=test`:
- 40 new tests pass
- Full suite: 917 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rBfLXcWJehQfWqKwAXHT2

---
_Generated by [Claude Code](https://claude.ai/code/session_012rBfLXcWJehQfWqKwAXHT2)_