### PR TITLE
test: cover examutils.formatExam and static_context helpers

### DIFF
--- a/tests/integration/test_static_context.py
+++ b/tests/integration/test_static_context.py
@@ -1,0 +1,131 @@
+"""Integration tests for utils.static_context.
+
+``static_context`` is the plumbing used by the ``/static`` event endpoints
+(see ``static.py``): it spins up a real Flask app context, mints a JWT for a
+synthetic ``STATIC_USER`` (id 0), verifies it, runs an operation with that
+user context injected, and serialises the result into the standard NoHarm
+response envelope. Because it commits against the database session and relies
+on the JWT extension, it is exercised here as an integration test rather than
+a pure unit test.
+"""
+
+import json
+
+import pytest
+
+from exception.authorization_error import AuthorizationError
+from exception.validation_error import ValidationError
+from utils import status
+from utils.static_context import execute_with_static_context, static_user_context
+
+SCHEMA = "demo"
+
+
+class TestStaticUserContext:
+    """static_user_context - the synthetic authenticated user it yields."""
+
+    def test_yields_static_user_for_requested_schema(self):
+        """The yielded user is the id-0 STATIC_USER bound to the schema."""
+        with static_user_context(SCHEMA) as user_context:
+            assert user_context.id == 0
+            assert user_context.schema == SCHEMA
+            assert user_context.config == {"roles": ["STATIC_USER"]}
+
+
+class TestExecuteWithStaticContextSuccess:
+    """execute_with_static_context - the happy path envelope."""
+
+    def test_returns_success_envelope_with_operation_result(self):
+        """A successful operation is wrapped as status=success / httpCode=200."""
+
+        def operation(user_context):
+            return {"schema": user_context.schema, "value": 42}
+
+        raw = execute_with_static_context(SCHEMA, operation, {})
+        payload = json.loads(raw)
+
+        assert payload["status"] == "success"
+        assert payload["httpCode"] == status.HTTP_200_OK
+        assert payload["data"] == {"schema": SCHEMA, "value": 42}
+
+    def test_injects_user_context_and_forwards_extra_params(self):
+        """The operation receives the static user plus any caller params."""
+
+        def operation(user_context, factor):
+            return {"id": user_context.id, "result": factor * 2}
+
+        raw = execute_with_static_context(SCHEMA, operation, {"factor": 21})
+        payload = json.loads(raw)
+
+        assert payload["status"] == "success"
+        assert payload["data"] == {"id": 0, "result": 42}
+
+
+class TestExecuteWithStaticContextErrors:
+    """execute_with_static_context - exception handling branches."""
+
+    def test_validation_error_maps_to_its_http_status(self):
+        """A ValidationError surfaces its message and configured http status."""
+
+        def operation(user_context):
+            raise ValidationError(
+                "campo obrigatório",
+                "errors.invalidParams",
+                status.HTTP_400_BAD_REQUEST,
+            )
+
+        payload = json.loads(execute_with_static_context(SCHEMA, operation, {}))
+
+        assert payload["status"] == "error"
+        assert payload["message"] == "campo obrigatório"
+        assert payload["httpCode"] == status.HTTP_400_BAD_REQUEST
+
+    def test_validation_error_preserves_custom_http_status(self):
+        """The httpStatus carried by the ValidationError is not overwritten."""
+
+        def operation(user_context):
+            raise ValidationError(
+                "não autorizado",
+                "errors.businessRules",
+                status.HTTP_401_UNAUTHORIZED,
+            )
+
+        payload = json.loads(execute_with_static_context(SCHEMA, operation, {}))
+
+        assert payload["httpCode"] == status.HTTP_401_UNAUTHORIZED
+
+    def test_authorization_error_maps_to_401(self):
+        """An AuthorizationError becomes a generic 401 'invalid user' response."""
+
+        def operation(user_context):
+            raise AuthorizationError()
+
+        payload = json.loads(execute_with_static_context(SCHEMA, operation, {}))
+
+        assert payload["status"] == "error"
+        assert payload["message"] == "Usuário inválido"
+        assert payload["httpCode"] == status.HTTP_401_UNAUTHORIZED
+
+    def test_unexpected_exception_maps_to_500(self):
+        """Any other exception is masked as a generic 500 error."""
+
+        def operation(user_context):
+            raise RuntimeError("boom")
+
+        payload = json.loads(execute_with_static_context(SCHEMA, operation, {}))
+
+        assert payload["status"] == "error"
+        assert payload["message"] == "Erro inesperado"
+        assert payload["httpCode"] == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    def test_error_response_is_json_serialisable_string(self):
+        """The envelope is always returned as a JSON string, even on error."""
+
+        def operation(user_context):
+            raise RuntimeError("boom")
+
+        raw = execute_with_static_context(SCHEMA, operation, {})
+
+        assert isinstance(raw, str)
+        # round-trips without raising
+        assert json.loads(raw)["status"] == "error"

--- a/tests/unit/test_examutils_format.py
+++ b/tests/unit/test_examutils_format.py
@@ -1,0 +1,198 @@
+"""Unit tests for utils.examutils.formatExam and _skinChar.
+
+``formatExam`` is the pure helper that turns a raw lab-exam value into the
+dict the frontend renders: it coerces the value to a number, decides whether
+it falls outside the segment's reference range (``alert``) and computes the
+percentage variation against the previous value (``delta``). ``_skinChar``
+normalises a skin-colour string to the single upper-case initial used by the
+renal-function estimators.
+
+These are pure functions, so we validate them by re-deriving the expected
+result from the formula rather than hitting the database.
+"""
+
+import pytest
+
+from utils import examutils
+
+
+class _Ref:
+    """Minimal stand-in for a segment exam reference row.
+
+    ``formatExam`` only reads ``min``/``max``/``ref``/``initials``/``name``/
+    ``tp_exam_ref`` off the reference object, so a plain attribute holder is
+    enough to drive it.
+    """
+
+    def __init__(self, min_val, max_val, ref="ref-text", initials="INI",
+                 name="Exam Name", tp_exam_ref=7):
+        self.min = min_val
+        self.max = max_val
+        self.ref = ref
+        self.initials = initials
+        self.name = name
+        self.tp_exam_ref = tp_exam_ref
+
+
+class TestFormatExamAlert:
+    """formatExam - out-of-range detection against the segment reference."""
+
+    def test_value_inside_range_does_not_alert(self):
+        """A value within [min, max] is not flagged."""
+        seg = {"tgo": _Ref(min_val=5, max_val=40)}
+        result = examutils.formatExam(
+            value=20, typeExam="tgo", unit="U/L", date=None, segExam=seg
+        )
+        assert result["alert"] is False
+        assert result["value"] == 20
+        assert result["unit"] == "U/L"
+
+    def test_value_on_boundary_does_not_alert(self):
+        """The range is inclusive on both ends."""
+        seg = {"tgo": _Ref(min_val=5, max_val=40)}
+        low = examutils.formatExam(
+            value=5, typeExam="tgo", unit="U/L", date=None, segExam=seg
+        )
+        high = examutils.formatExam(
+            value=40, typeExam="tgo", unit="U/L", date=None, segExam=seg
+        )
+        assert low["alert"] is False
+        assert high["alert"] is False
+
+    @pytest.mark.parametrize("value", [4.9, 41, 100])
+    def test_value_outside_range_alerts(self, value):
+        """A value below min or above max raises an alert."""
+        seg = {"tgo": _Ref(min_val=5, max_val=40)}
+        result = examutils.formatExam(
+            value=value, typeExam="tgo", unit="U/L", date=None, segExam=seg
+        )
+        assert result["alert"] is True
+
+    def test_reference_metadata_is_passed_through(self):
+        """When a reference exists its metadata is echoed into the payload."""
+        ref = _Ref(min_val=5, max_val=40, ref="5 a 40", initials="TGO",
+                   name="Transaminase", tp_exam_ref=3)
+        result = examutils.formatExam(
+            value=10, typeExam="tgo", unit="U/L", date=None, segExam={"tgo": ref}
+        )
+        assert result["ref"] == "5 a 40"
+        assert result["initials"] == "TGO"
+        assert result["min"] == 5
+        assert result["max"] == 40
+        assert result["name"] == "Transaminase"
+        assert result["tp_exam_ref"] == 3
+        assert result["manual"] is False
+
+
+class TestFormatExamUnknownType:
+    """formatExam - behaviour when the exam type has no reference."""
+
+    def test_unknown_type_never_alerts(self):
+        """Without a reference range there is nothing to compare against."""
+        result = examutils.formatExam(
+            value=999, typeExam="unknown", unit="mg", date=None, segExam={}
+        )
+        assert result["alert"] is False
+
+    def test_unknown_type_uses_type_as_name_and_initials(self):
+        """The exam type becomes both the display name and the initials."""
+        result = examutils.formatExam(
+            value=1, typeExam="unknown", unit="mg", date=None, segExam={}
+        )
+        assert result["name"] == "unknown"
+        assert result["initials"] == "unknown"
+        assert result["min"] == ""
+        assert result["max"] == ""
+        assert result["tp_exam_ref"] is None
+
+
+class TestFormatExamValueCoercion:
+    """formatExam - value coercion via numberutils.none2zero."""
+
+    def test_numeric_string_is_coerced_to_float(self):
+        """A numeric string is stored as its float value."""
+        seg = {"tgo": _Ref(min_val=0, max_val=100)}
+        result = examutils.formatExam(
+            value="12.5", typeExam="tgo", unit="U/L", date=None, segExam=seg
+        )
+        assert result["value"] == 12.5
+
+    def test_non_numeric_value_becomes_zero(self):
+        """A non-numeric value defaults to 0 (and 0 is below min -> alert)."""
+        seg = {"tgo": _Ref(min_val=5, max_val=40)}
+        result = examutils.formatExam(
+            value="abc", typeExam="tgo", unit="U/L", date=None, segExam=seg
+        )
+        assert result["value"] == 0
+        assert result["alert"] is True
+
+    def test_none_unit_is_rendered_as_empty_string(self):
+        """A missing unit is normalised to an empty string, never None."""
+        seg = {"tgo": _Ref(min_val=0, max_val=100)}
+        result = examutils.formatExam(
+            value=10, typeExam="tgo", unit=None, date=None, segExam=seg
+        )
+        assert result["unit"] == ""
+
+
+class TestFormatExamDelta:
+    """formatExam - percentage variation against the previous value."""
+
+    def test_no_previous_value_yields_none_delta(self):
+        """With no prior measurement there is no variation to report."""
+        seg = {"tgo": _Ref(min_val=0, max_val=100)}
+        result = examutils.formatExam(
+            value=10, typeExam="tgo", unit="U/L", date=None, segExam=seg
+        )
+        assert result["delta"] is None
+        assert result["prev"] == 0
+
+    def test_increase_produces_positive_delta(self):
+        """A rise from 10 to 12 is a +20% variation."""
+        seg = {"tgo": _Ref(min_val=0, max_val=100)}
+        result = examutils.formatExam(
+            value=12, typeExam="tgo", unit="U/L", date=None, segExam=seg,
+            prevValue=10,
+        )
+        assert result["delta"] == 20.0
+        assert result["prev"] == 10
+
+    def test_decrease_produces_negative_delta(self):
+        """A drop from 10 to 8 is a -20% variation."""
+        seg = {"tgo": _Ref(min_val=0, max_val=100)}
+        result = examutils.formatExam(
+            value=8, typeExam="tgo", unit="U/L", date=None, segExam=seg,
+            prevValue=10,
+        )
+        assert result["delta"] == -20.0
+
+    def test_zero_previous_value_yields_none_delta(self):
+        """A previous value of 0 cannot be a denominator, so delta is None."""
+        seg = {"tgo": _Ref(min_val=0, max_val=100)}
+        result = examutils.formatExam(
+            value=10, typeExam="tgo", unit="U/L", date=None, segExam=seg,
+            prevValue=0,
+        )
+        assert result["delta"] is None
+
+
+class TestSkinChar:
+    """_skinChar - normalise a skin-colour string to its upper-case initial."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("negra", "N"),
+            ("Parda", "P"),
+            ("branca", "B"),
+            ("amarela", "A"),
+            (5, "5"),
+        ],
+    )
+    def test_returns_first_upper_char(self, value, expected):
+        """The first character of the stringified value, upper-cased."""
+        assert examutils._skinChar(value) == expected
+
+    def test_none_returns_space(self):
+        """A missing skin colour maps to a space sentinel, not an error."""
+        assert examutils._skinChar(None) == " "


### PR DESCRIPTION
## Summary

Increases test coverage by adding tests for two previously untested features.

### 1. `utils/examutils.py` — `formatExam` / `_skinChar` (unit tests)
`formatExam` turns a raw lab value into the dict the frontend renders. The prior test suite only covered the renal-function estimators (MDRD, CG, CKD, Schwartz), leaving `formatExam` and the `_skinChar` helper (lines 34–54 / 273–274) with no direct coverage.

New file `tests/unit/test_examutils_format.py` covers:
- reference-range alerting (inside range, inclusive boundaries, below/above range)
- pass-through of reference metadata (`ref`, `initials`, `min`, `max`, `name`, `tp_exam_ref`)
- fallback behaviour when the exam type has no reference
- value coercion via `numberutils.none2zero` (numeric strings, non-numeric → 0, `None` unit → `""`)
- `delta` percentage variation (none/positive/negative, zero previous value)
- `_skinChar` initial normalisation, including the `None` sentinel

### 2. `utils/static_context.py` — static user context helpers (integration tests)
This module (0% coverage) powers the `/static` event endpoints: it builds a Flask app context, mints and verifies a JWT for a synthetic `STATIC_USER`, runs an operation, and serialises the result into the standard NoHarm response envelope. Because it commits against the DB session and relies on the JWT extension, it is covered as an integration test.

New file `tests/integration/test_static_context.py` covers:
- `static_user_context` yields the id-0 `STATIC_USER` bound to the requested schema
- `execute_with_static_context` success envelope, user-context injection and param forwarding
- the `ValidationError` (with preserved http status), `AuthorizationError` → 401, and generic-exception → 500 branches
- the envelope is always a JSON-serialisable string

## Testing
Full suite run locally against PostgreSQL with `ENV=test`: **996 passed** (29 new). No production code changed — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbSVd1Ysf17a8EsgtJUeDe)_