### PR TITLE
test: cover DrugList infusion-dose and alert-stats aggregation

### DIFF
--- a/tests/unit/test_drug_list_alerts.py
+++ b/tests/unit/test_drug_list_alerts.py
@@ -1,0 +1,150 @@
+"""Unit tests for DrugList.sumAlerts (prescription alert-statistics aggregation).
+
+``sumAlerts`` folds two independent alert sources into the ``alertStats`` summary
+shown on the prescription header:
+
+* ``relations`` — drug/drug interaction alerts, whose short codes are mapped to
+  legacy keys (``it`` -> ``int``, ``dt``/``dm`` -> ``dup``, ...);
+* ``alerts`` — clinical alerts (kidney/liver/platelets, max dose, ...).
+
+It also derives a few composite fields (``dup`` legacy total, ``maxDose``,
+``exams``) and escalates the overall severity ``level`` from the individual alert
+levels. The method only reads ``self.relations``, ``self.alerts`` and mutates
+``self.alertStats``, so the tests build a bare ``DrugList`` via ``__new__`` and
+seed those attributes, avoiding the DB-heavy constructor.
+"""
+
+from utils.drug_list import DrugList
+
+
+def _default_alert_stats():
+    """A fresh copy of the alertStats structure DrugList.__init__ builds."""
+    return {
+        "dup": 0,
+        "int": 0,
+        "inc": 0,
+        "rea": 0,
+        "isl": 0,
+        "maxTime": 0,
+        "maxDose": 0,
+        "kidney": 0,
+        "liver": 0,
+        "elderly": 0,
+        "platelets": 0,
+        "tube": 0,
+        "exams": 0,
+        "allergy": 0,
+        "interactions": {},
+        "total": 0,
+        "level": "low",
+    }
+
+
+def _make_drug_list(relations_stats=None, relations_alerts=None, alerts_stats=None, alerts_alerts=None):
+    """Build a DrugList with only the attributes sumAlerts reads."""
+    instance = DrugList.__new__(DrugList)
+    instance.alertStats = _default_alert_stats()
+    instance.relations = {
+        "stats": relations_stats or {},
+        "alerts": relations_alerts or {},
+    }
+    instance.alerts = {
+        "stats": alerts_stats or {},
+        "alerts": alerts_alerts or {},
+    }
+    return instance
+
+
+class TestSumAlertsEmpty:
+    """Behaviour when there are no alerts at all."""
+
+    def test_empty_sources_leave_defaults(self):
+        """With no alerts the totals stay at zero and the level stays 'low'."""
+        drug_list = _make_drug_list()
+        drug_list.sumAlerts()
+        assert drug_list.alertStats["total"] == 0
+        assert drug_list.alertStats["maxDose"] == 0
+        assert drug_list.alertStats["exams"] == 0
+        assert drug_list.alertStats["level"] == "low"
+
+
+class TestSumAlertsRelations:
+    """Aggregation of drug/drug interaction (relations) statistics."""
+
+    def test_maps_short_codes_to_legacy_keys(self):
+        """Interaction short codes are copied to their legacy keys."""
+        drug_list = _make_drug_list(relations_stats={"it": 2, "iy": 1, "sl": 4})
+        drug_list.sumAlerts()
+        assert drug_list.alertStats["int"] == 2
+        assert drug_list.alertStats["inc"] == 1
+        assert drug_list.alertStats["isl"] == 4
+
+    def test_records_raw_codes_and_running_total(self):
+        """Raw short codes are preserved under 'interactions' and summed into total."""
+        drug_list = _make_drug_list(relations_stats={"it": 2, "iy": 1})
+        drug_list.sumAlerts()
+        assert drug_list.alertStats["interactions"] == {"it": 2, "iy": 1}
+        assert drug_list.alertStats["total"] == 3
+
+    def test_duplicate_legacy_total_combines_dm_and_dt(self):
+        """When both duplicate codes are present, 'dup' is their combined count."""
+        drug_list = _make_drug_list(relations_stats={"dm": 1, "dt": 3})
+        drug_list.sumAlerts()
+        assert drug_list.alertStats["dup"] == 4
+        assert drug_list.alertStats["total"] == 4
+
+
+class TestSumAlertsClinical:
+    """Aggregation of clinical (alerts) statistics and composite fields."""
+
+    def test_clinical_stats_are_copied_and_summed(self):
+        """Each clinical stat is copied through and added to the running total."""
+        drug_list = _make_drug_list(alerts_stats={"kidney": 1, "liver": 2, "tube": 3})
+        drug_list.sumAlerts()
+        assert drug_list.alertStats["kidney"] == 1
+        assert drug_list.alertStats["liver"] == 2
+        assert drug_list.alertStats["tube"] == 3
+        assert drug_list.alertStats["total"] == 6
+
+    def test_max_dose_combines_base_and_plus(self):
+        """maxDose is the sum of the maxDose and maxDosePlus clinical counts."""
+        drug_list = _make_drug_list(alerts_stats={"maxDose": 2, "maxDosePlus": 5})
+        drug_list.sumAlerts()
+        assert drug_list.alertStats["maxDose"] == 7
+
+    def test_exams_is_composite_of_organ_alerts(self):
+        """exams aggregates its own base plus kidney, liver and platelet alerts."""
+        drug_list = _make_drug_list(
+            alerts_stats={"exams": 1, "kidney": 2, "liver": 3, "platelets": 4}
+        )
+        drug_list.sumAlerts()
+        assert drug_list.alertStats["exams"] == 10
+
+
+class TestSumAlertsLevel:
+    """Severity-level escalation from individual alert levels."""
+
+    def test_medium_level_escalates_from_low(self):
+        """A single medium alert escalates the overall level to medium."""
+        drug_list = _make_drug_list(
+            relations_alerts={"1": [{"level": "medium"}]}
+        )
+        drug_list.sumAlerts()
+        assert drug_list.alertStats["level"] == "medium"
+
+    def test_high_level_wins_over_medium(self):
+        """A high alert takes precedence over medium alerts."""
+        drug_list = _make_drug_list(
+            relations_alerts={"1": [{"level": "medium"}]},
+            alerts_alerts={"2": [{"level": "high"}]},
+        )
+        drug_list.sumAlerts()
+        assert drug_list.alertStats["level"] == "high"
+
+    def test_only_low_alerts_keep_level_low(self):
+        """When every alert is low severity the overall level stays low."""
+        drug_list = _make_drug_list(
+            alerts_alerts={"1": [{"level": "low"}, {"level": "low"}]}
+        )
+        drug_list.sumAlerts()
+        assert drug_list.alertStats["level"] == "low"

--- a/tests/unit/test_drug_list_infusion.py
+++ b/tests/unit/test_drug_list_infusion.py
@@ -1,0 +1,173 @@
+"""Unit tests for the infusion/solution-dose helpers of utils.drug_list.DrugList.
+
+These helpers power the Solution Calculator: ``get_solution_dose`` normalizes a
+prescribed dose to millilitres (the unit total-volume math depends on), and
+``getInfusionKey`` groups the items that make up a single solution/infusion.
+
+The methods are pure with respect to the object's own attributes, so the tests
+build a bare ``DrugList`` via ``__new__`` and set only the attributes each method
+reads, avoiding the database/feature-flag work in ``DrugList.__init__``. The
+prescription rows the methods consume are SQLAlchemy ``Row`` objects that support
+both positional indexing (``pd[0]``) and attribute access (``pd.MeasureUnit``);
+``_FakeRow`` reproduces just that dual interface.
+"""
+
+from types import SimpleNamespace
+
+from utils.drug_list import DrugList
+
+
+class _FakeRow:
+    """Minimal stand-in for a SQLAlchemy Row: positional + attribute access."""
+
+    def __init__(self, items, **attrs):
+        self._items = list(items)
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+    def __getitem__(self, index):
+        return self._items[index]
+
+
+def _make_drug_list(is_cpoe=False):
+    """Build a DrugList without running the DB-heavy constructor."""
+    instance = DrugList.__new__(DrugList)
+    instance.is_cpoe = is_cpoe
+    return instance
+
+
+def _solution_row(
+    dose=0,
+    doseconv=0,
+    prescribed_unit=None,
+    default_unit=None,
+    division=False,
+    default_convert_factor=None,
+    solution_convert_factor=None,
+):
+    """Build a prescription row shaped like the ones get_solution_dose consumes.
+
+    Index 0 carries the raw doses; index 6 carries drug attributes (dose ranges).
+    The remaining positions are unused by the method but must exist so pd[6] is
+    addressable.
+    """
+    prescription_drug = SimpleNamespace(dose=dose, doseconv=doseconv)
+    drug_attributes = SimpleNamespace(division=division)
+    measure_unit = (
+        SimpleNamespace(measureunit_nh=prescribed_unit)
+        if prescribed_unit is not None
+        else None
+    )
+    items = [prescription_drug, None, None, None, None, None, drug_attributes]
+    return _FakeRow(
+        items,
+        MeasureUnit=measure_unit,
+        default_measure_unit_nh=default_unit,
+        measure_unit_convert_factor=default_convert_factor,
+        measure_unit_solution_convert_factor=solution_convert_factor,
+    )
+
+
+class TestGetSolutionDose:
+    """Tests for DrugList.get_solution_dose (normalizes a dose to millilitres)."""
+
+    def test_prescribed_unit_already_ml_returns_raw_dose(self):
+        """When the item is prescribed in ml, its raw dose is returned as-is."""
+        drug_list = _make_drug_list()
+        row = _solution_row(dose=100, doseconv=5, prescribed_unit="ml")
+        assert drug_list.get_solution_dose(row) == 100
+
+    def test_default_unit_ml_returns_converted_dose(self):
+        """When the default unit is ml, the pre-converted dose (doseconv) is used."""
+        drug_list = _make_drug_list()
+        row = _solution_row(dose=100, doseconv=50, prescribed_unit="mg", default_unit="ml")
+        assert drug_list.get_solution_dose(row) == 50
+
+    def test_missing_measure_unit_falls_back_to_default_unit(self):
+        """A row without a measure unit still resolves via the default unit."""
+        drug_list = _make_drug_list()
+        row = _solution_row(dose=100, doseconv=30, prescribed_unit=None, default_unit="ml")
+        assert drug_list.get_solution_dose(row) == 30
+
+    def test_uses_solution_convert_factor_when_no_ml_unit(self):
+        """With no ml unit, the converted dose is divided by the solution factor."""
+        drug_list = _make_drug_list()
+        row = _solution_row(
+            doseconv=20,
+            prescribed_unit="mg",
+            default_unit="mg",
+            solution_convert_factor=4,
+        )
+        assert drug_list.get_solution_dose(row) == 5.0
+
+    def test_no_ml_unit_and_no_factor_returns_zero(self):
+        """When conversion to ml is impossible, the dose is reported as 0."""
+        drug_list = _make_drug_list()
+        row = _solution_row(
+            doseconv=20,
+            prescribed_unit="mg",
+            default_unit="mg",
+            solution_convert_factor=None,
+        )
+        assert drug_list.get_solution_dose(row) == 0
+
+    def test_dose_ranges_recompute_conversion_from_raw_dose(self):
+        """With dose ranges, doseconv is recomputed from dose * default factor."""
+        drug_list = _make_drug_list()
+        row = _solution_row(
+            dose=10,
+            doseconv=999,  # ignored: dose ranges force a recompute
+            prescribed_unit="mg",
+            default_unit="ml",
+            division=True,
+            default_convert_factor=2,
+        )
+        assert drug_list.get_solution_dose(row) == 20
+
+    def test_dose_ranges_without_factor_yield_zero(self):
+        """Dose ranges with no default convert factor collapse the dose to 0."""
+        drug_list = _make_drug_list()
+        row = _solution_row(
+            dose=10,
+            doseconv=999,
+            prescribed_unit="mg",
+            default_unit="mg",
+            division=True,
+            default_convert_factor=None,
+        )
+        assert drug_list.get_solution_dose(row) == 0
+
+    def test_dose_ranges_then_solution_factor(self):
+        """Dose ranges recompute the dose, then the solution factor scales it."""
+        drug_list = _make_drug_list()
+        row = _solution_row(
+            dose=10,
+            prescribed_unit="mg",
+            default_unit="mg",
+            division=True,
+            default_convert_factor=3,  # doseconv := 10 * 3 = 30
+            solution_convert_factor=6,  # 30 / 6 = 5
+        )
+        assert drug_list.get_solution_dose(row) == 5.0
+
+
+class TestGetInfusionKey:
+    """Tests for DrugList.getInfusionKey (groups items of one solution)."""
+
+    def test_non_cpoe_concatenates_prescription_and_solution_group(self):
+        """Outside CPOE the key is prescription id concatenated with solution group."""
+        drug_list = _make_drug_list(is_cpoe=False)
+        row = _FakeRow([SimpleNamespace(idPrescription=10, solutionGroup=3)])
+        assert drug_list.getInfusionKey(row) == "103"
+
+    def test_cpoe_prefers_cpoe_group(self):
+        """In CPOE mode the cpoe_group, when present, is the grouping key."""
+        drug_list = _make_drug_list(is_cpoe=True)
+        row = _FakeRow([SimpleNamespace(cpoe_group="G1", solutionGroup=3)])
+        assert drug_list.getInfusionKey(row) == "G1"
+
+    def test_cpoe_falls_back_to_solution_group(self):
+        """In CPOE mode without a cpoe_group the solution group is used instead."""
+        drug_list = _make_drug_list(is_cpoe=True)
+        row = _FakeRow([SimpleNamespace(cpoe_group=None, solutionGroup=3)])
+        assert drug_list.getInfusionKey(row) == 3


### PR DESCRIPTION
## Summary

Increases unit-test coverage by adding tests for two previously untested `utils.drug_list.DrugList` features. Both are pure with respect to the object's own attributes, so the tests build a bare `DrugList` via `__new__` and seed only what each method reads — no database or app context required.

## Features covered

### 1. Solution / infusion dose (`get_solution_dose`, `getInfusionKey`)
Powers the Solution Calculator. `get_solution_dose` normalizes a prescribed dose to millilitres; `getInfusionKey` groups the items of a single solution.

- `tests/unit/test_drug_list_infusion.py`
- ml passthrough, default-unit conversion (`doseconv`), missing measure unit, solution-factor conversion, the "cannot convert → 0" fallback
- dose-range (`division`) recomputation from `dose * default_factor`, including the no-factor and then-solution-factor paths
- CPOE vs non-CPOE grouping keys, plus the CPOE `cpoe_group` → `solutionGroup` fallback

### 2. Alert-statistics aggregation (`sumAlerts`)
Folds drug/drug interaction (`relations`) and clinical (`alerts`) sources into the `alertStats` summary shown on the prescription header.

- `tests/unit/test_drug_list_alerts.py`
- interaction short-code → legacy-key mapping (`it`→`int`, `iy`→`inc`, `sl`→`isl`)
- raw codes preserved under `interactions` and summed into `total`
- duplicate legacy total (`dm` + `dt` → `dup`)
- `maxDose` (base + plus) and `exams` (base + kidney + liver + platelets) composites
- severity-level escalation (low → medium → high)

## Testing

- `make test-setup` (local PostgreSQL 16 loaded with the same SQL from `noharm-ai/database` that CI uses)
- Full unit suite green: **768 passed** (was 747; +21 new tests)
- The two new files pass in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8fo9nnLhMY94TGRU2uexU)_