### PR TITLE
test: cover clinical-notes conversion and unit-conversion factor logic

### DIFF
--- a/tests/unit/test_clinical_notes_convert.py
+++ b/tests/unit/test_clinical_notes_convert.py
@@ -1,0 +1,272 @@
+"""Unit tests for clinical_notes_service note-conversion helpers.
+
+``convert_notes`` and ``convert_prescription_note`` shape database rows into
+the dictionary format returned by the clinical-notes endpoints. They are pure
+transforms: the only external dependency is ``feature_service.has_user_feature``
+(the HIDE_NAMES flag), which is patched here so no request context, database or
+network is required.
+
+The two helpers must produce a compatible dict shape, mask the prescriber name
+when HIDE_NAMES is on, gate the primary-care fields, truncate very long note
+text, and project tag annotation counts onto both the tag name and its legacy
+column alias.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from services import clinical_notes_service
+
+
+def _patch_hide_names(value: bool):
+    """Patch feature_service.has_user_feature (HIDE_NAMES) to the given value."""
+    return patch.object(
+        clinical_notes_service.feature_service,
+        "has_user_feature",
+        return_value=value,
+    )
+
+
+def _note(
+    *,
+    id=1,
+    admission_number=555,
+    text="a short note",
+    form={"f": 1},
+    template={"t": 2},
+    date=datetime(2024, 1, 2, 3, 4, 5),
+    prescriber="Dr. House",
+    position="ENFERMARIA",
+    annotations=None,
+):
+    """Build a ClinicalNotes-like row for convert_notes."""
+    return SimpleNamespace(
+        id=id,
+        admissionNumber=admission_number,
+        text=text,
+        form=form,
+        template=template,
+        date=date,
+        prescriber=prescriber,
+        position=position,
+        annotations=annotations,
+    )
+
+
+def _prescription_note(
+    *,
+    id=9,
+    admission_number=777,
+    text="prescription evolution",
+    updatedAt=datetime(2024, 5, 6, 7, 8, 9),
+    tpStatus="s",
+    idPrescription=42,
+):
+    """Build a PrescriptionClinicalNote-like row for convert_prescription_note."""
+    return SimpleNamespace(
+        id=id,
+        admission_number=admission_number,
+        text=text,
+        updatedAt=updatedAt,
+        tpStatus=tpStatus,
+        idPrescription=idPrescription,
+    )
+
+
+class TestConvertNotes:
+    """Tests for clinical_notes_service.convert_notes."""
+
+    def test_basic_shape_and_types(self):
+        """The id is stringified and scalar fields are copied verbatim."""
+        note = _note()
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(note, True, [])
+
+        assert result["id"] == "1"
+        assert result["id"] == str(note.id)
+        assert result["admissionNumber"] == 555
+        assert result["text"] == "a short note"
+        assert result["date"] == "2024-01-02T03:04:05"
+        assert result["position"] == "ENFERMARIA"
+
+    def test_prescriber_shown_when_hide_names_off(self):
+        """With HIDE_NAMES off the real prescriber name is returned."""
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(_note(), False, [])
+        assert result["prescriber"] == "Dr. House"
+
+    def test_prescriber_masked_when_hide_names_on(self):
+        """With HIDE_NAMES on the prescriber name is masked."""
+        with _patch_hide_names(True):
+            result = clinical_notes_service.convert_notes(_note(), False, [])
+        assert result["prescriber"] == "***"
+
+    def test_primary_care_fields_included_when_enabled(self):
+        """form/template are passed through when has_primary_care is True."""
+        note = _note(form={"f": 1}, template={"t": 2})
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(note, True, [])
+        assert result["form"] == {"f": 1}
+        assert result["template"] == {"t": 2}
+
+    def test_primary_care_fields_nulled_when_disabled(self):
+        """form/template are None when has_primary_care is False."""
+        note = _note(form={"f": 1}, template={"t": 2})
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(note, False, [])
+        assert result["form"] is None
+        assert result["template"] is None
+
+    def test_short_text_is_not_truncated(self):
+        """Text at or below the limit is returned unchanged."""
+        note = _note(text="x" * 100)
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(note, False, [])
+        assert result["text"] == "x" * 100
+
+    def test_long_text_is_truncated_with_marker(self):
+        """Text beyond 700000 chars is truncated and gets the cut marker."""
+        note = _note(text="y" * 700_001)
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(note, False, [])
+        assert result["text"].startswith("y" * 700_000)
+        assert result["text"].endswith(
+            "<p>Evolução cortada por texto muito longo.</p>"
+        )
+        assert len(result["text"]) == 700_000 + len(
+            "<p>Evolução cortada por texto muito longo.</p>"
+        )
+
+    def test_none_text_stays_none(self):
+        """A missing text is left as-is (the length guard is skipped)."""
+        note = _note(text=None)
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(note, False, [])
+        assert result["text"] is None
+
+    def test_tag_count_from_annotations(self):
+        """A tag maps to its ``<name>_count`` value in annotations."""
+        note = _note(annotations={"dados_count": 3})
+        tags = [{"name": "dados", "column": "info"}]
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(note, False, tags)
+        assert result["dados"] == 3
+        # legacy column alias mirrors the value
+        assert result["info"] == 3
+
+    def test_tag_defaults_to_zero_when_annotation_missing(self):
+        """A tag with no matching annotation key defaults to zero."""
+        note = _note(annotations={"other_count": 9})
+        tags = [{"name": "dados", "column": "info"}]
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(note, False, tags)
+        assert result["dados"] == 0
+        assert result["info"] == 0
+
+    def test_tag_defaults_to_zero_when_annotations_none(self):
+        """A None annotations blob yields zero for every tag."""
+        note = _note(annotations=None)
+        tags = [{"name": "dados", "column": "info"}]
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(note, False, tags)
+        assert result["dados"] == 0
+
+    def test_tag_without_column_sets_only_name(self):
+        """A tag with column=None sets the name key but no alias key."""
+        note = _note(annotations={"acesso_count": 5})
+        tags = [{"name": "acesso", "column": None}]
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_notes(note, False, tags)
+        assert result["acesso"] == 5
+        assert None not in result
+
+
+class TestConvertPrescriptionNote:
+    """Tests for clinical_notes_service.convert_prescription_note."""
+
+    def test_fixed_source_and_position(self):
+        """Prescription notes carry a fixed source and position marker."""
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_prescription_note(
+                _prescription_note(), "Nurse Joy", []
+            )
+        assert result["source"] == "prescription"
+        assert result["position"] == "EVOLUÇÃO CRIADA NA NOHARM"
+        assert result["form"] is None
+        assert result["template"] is None
+
+    def test_scalar_fields_copied(self):
+        """Identifier, status and prescription id are copied through."""
+        note = _prescription_note(
+            id=9, admission_number=777, tpStatus="s", idPrescription=42
+        )
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_prescription_note(
+                note, "Nurse Joy", []
+            )
+        assert result["id"] == "9"
+        assert result["admissionNumber"] == 777
+        assert result["integrationStatus"] == "s"
+        assert result["idPrescription"] == 42
+        assert result["date"] == "2024-05-06T07:08:09"
+
+    def test_creator_name_shown_when_hide_names_off(self):
+        """With HIDE_NAMES off the creator name is used as prescriber."""
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_prescription_note(
+                _prescription_note(), "Nurse Joy", []
+            )
+        assert result["prescriber"] == "Nurse Joy"
+
+    def test_missing_creator_name_becomes_empty_string(self):
+        """A None creator name falls back to an empty string, not None."""
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_prescription_note(
+                _prescription_note(), None, []
+            )
+        assert result["prescriber"] == ""
+
+    def test_creator_name_masked_when_hide_names_on(self):
+        """With HIDE_NAMES on the creator name is masked."""
+        with _patch_hide_names(True):
+            result = clinical_notes_service.convert_prescription_note(
+                _prescription_note(), "Nurse Joy", []
+            )
+        assert result["prescriber"] == "***"
+
+    def test_tags_always_zero(self):
+        """Prescription notes have no annotations, so every tag is zero."""
+        tags = [
+            {"name": "dados", "column": "info"},
+            {"name": "acesso", "column": None},
+        ]
+        with _patch_hide_names(False):
+            result = clinical_notes_service.convert_prescription_note(
+                _prescription_note(), "Nurse Joy", tags
+            )
+        assert result["dados"] == 0
+        assert result["info"] == 0
+        assert result["acesso"] == 0
+
+    def test_shares_core_keys_with_convert_notes(self):
+        """The two converters agree on the shared core key set."""
+        with _patch_hide_names(False):
+            pn = clinical_notes_service.convert_prescription_note(
+                _prescription_note(), "Nurse Joy", []
+            )
+            cn = clinical_notes_service.convert_notes(_note(), True, [])
+        core_keys = {
+            "id",
+            "admissionNumber",
+            "text",
+            "form",
+            "template",
+            "date",
+            "prescriber",
+            "position",
+        }
+        assert core_keys.issubset(pn.keys())
+        assert core_keys.issubset(cn.keys())

--- a/tests/unit/test_unit_conversion_service.py
+++ b/tests/unit/test_unit_conversion_service.py
@@ -1,0 +1,301 @@
+"""Unit tests for unit_conversion_service.get_unit_conversion_for_drug.
+
+The function decides, for a single drug, which measure-unit conversion factors
+to expose to the UI. Its logic is deterministic given two repository queries:
+
+* the drug's configured default measure unit(s) (``medatributos``), and
+* the list of possible conversions (one row per measure unit).
+
+From those it computes three things per row: whether the row is the drug's
+default unit, whether raw factors should be shown at all (``show_factors``),
+and the ``factor`` value itself. It also synthesises a default row when the
+substance's default unit is not already present in the conversion list.
+
+These tests drive every branch by patching the two repository calls with
+lightweight namespace rows — no database or request context is required. The
+``@has_permission`` decorator is bypassed via ``__wrapped__`` so the business
+logic is exercised directly.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from exception.validation_error import ValidationError
+from models.enums import DefaultMeasureUnitEnum
+from services import unit_conversion_service
+
+# The undecorated business logic (skips the permission gate).
+_get = unit_conversion_service.get_unit_conversion_for_drug.__wrapped__
+
+
+def _conv_row(
+    *,
+    id=100,
+    name="Dipirona",
+    id_measure_unit,
+    factor,
+    description,
+    measureunit_nh,
+    default_measureunit,
+):
+    """Build a conversion-list row as returned by the repository query."""
+    return SimpleNamespace(
+        id=id,
+        name=name,
+        idMeasureUnit=id_measure_unit,
+        factor=factor,
+        description=description,
+        measureunit_nh=measureunit_nh,
+        default_measureunit=default_measureunit,
+    )
+
+
+def _configured_row(*, measureunit_nh):
+    """Build a configured default-measure-unit row (medatributos)."""
+    return SimpleNamespace(measureunit_nh=measureunit_nh)
+
+
+def _run(configured, conversion_list, id_drug=100):
+    """Invoke the function with both repository calls patched."""
+    repo = unit_conversion_service.unit_conversion_repository
+    with patch.object(
+        repo,
+        "get_drugattributes_default_measure_unit_for_drug",
+        return_value=configured,
+    ), patch.object(
+        repo,
+        "get_unit_conversion_for_drug",
+        return_value=conversion_list,
+    ):
+        return _get(id_drug=id_drug)
+
+
+class TestEmptyConversionList:
+    """An empty conversion list is a business error."""
+
+    def test_raises_validation_error(self):
+        """No conversions available raises a 400 ValidationError."""
+        with pytest.raises(ValidationError) as exc:
+            _run(configured=[], conversion_list=[])
+        assert exc.value.httpStatus == 400
+        assert exc.value.code == "errors.businessRules"
+
+
+class TestFactorSelection:
+    """Per-row factor selection across the default / show_factors branches."""
+
+    def test_default_row_gets_factor_one(self):
+        """The row matching the substance default unit is marked default, factor 1."""
+        rows = [
+            _conv_row(
+                id_measure_unit=1,
+                factor=0.5,
+                description="milligram",
+                measureunit_nh="mg",
+                default_measureunit="mg",
+            ),
+        ]
+        result = _run(configured=[], conversion_list=rows)
+
+        assert result["substanceMeasureUnit"] == "mg"
+        assert len(result["conversionList"]) == 1
+        row = result["conversionList"][0]
+        assert row["default"] is True
+        assert row["factor"] == 1
+        assert row["id"] == "100-1"
+        assert row["measureUnit"] == "milligram"
+
+    def test_non_default_shows_factor_when_show_factors_true(self):
+        """With no configured override, non-default rows expose their raw factor."""
+        rows = [
+            _conv_row(
+                id_measure_unit=1,
+                factor=1,
+                description="milligram",
+                measureunit_nh="mg",
+                default_measureunit="mg",
+            ),
+            _conv_row(
+                id_measure_unit=2,
+                factor=1000,
+                description="gram",
+                measureunit_nh="g",
+                default_measureunit="mg",
+            ),
+        ]
+        result = _run(configured=[], conversion_list=rows)
+
+        by_unit = {r["drugMeasureUnitNh"]: r for r in result["conversionList"]}
+        assert by_unit["mg"]["factor"] == 1
+        assert by_unit["mg"]["default"] is True
+        assert by_unit["g"]["factor"] == 1000
+        assert by_unit["g"]["default"] is False
+
+    def test_multiple_configured_units_hide_factors(self):
+        """More than one configured unit forces non-default factors to None."""
+        rows = [
+            _conv_row(
+                id_measure_unit=1,
+                factor=1,
+                description="milligram",
+                measureunit_nh="mg",
+                default_measureunit="mg",
+            ),
+            _conv_row(
+                id_measure_unit=2,
+                factor=1000,
+                description="gram",
+                measureunit_nh="g",
+                default_measureunit="mg",
+            ),
+        ]
+        configured = [
+            _configured_row(measureunit_nh="mg"),
+            _configured_row(measureunit_nh="g"),
+        ]
+        result = _run(configured=configured, conversion_list=rows)
+
+        by_unit = {r["drugMeasureUnitNh"]: r for r in result["conversionList"]}
+        # default row still forced to 1 regardless of show_factors
+        assert by_unit["mg"]["factor"] == 1
+        # non-default hidden because show_factors is False
+        assert by_unit["g"]["factor"] is None
+
+    def test_single_matching_configured_unit_keeps_factors(self):
+        """One configured unit equal to the default keeps show_factors on."""
+        rows = [
+            _conv_row(
+                id_measure_unit=1,
+                factor=1,
+                description="milligram",
+                measureunit_nh="mg",
+                default_measureunit="mg",
+            ),
+            _conv_row(
+                id_measure_unit=2,
+                factor=1000,
+                description="gram",
+                measureunit_nh="g",
+                default_measureunit="mg",
+            ),
+        ]
+        configured = [_configured_row(measureunit_nh="mg")]
+        result = _run(configured=configured, conversion_list=rows)
+
+        by_unit = {r["drugMeasureUnitNh"]: r for r in result["conversionList"]}
+        assert by_unit["g"]["factor"] == 1000
+
+    def test_single_mismatching_configured_unit_hides_factors(self):
+        """One configured unit different from the default turns show_factors off."""
+        rows = [
+            _conv_row(
+                id_measure_unit=1,
+                factor=1,
+                description="milligram",
+                measureunit_nh="mg",
+                default_measureunit="mg",
+            ),
+            _conv_row(
+                id_measure_unit=2,
+                factor=1000,
+                description="gram",
+                measureunit_nh="g",
+                default_measureunit="mg",
+            ),
+        ]
+        configured = [_configured_row(measureunit_nh="g")]
+        result = _run(configured=configured, conversion_list=rows)
+
+        by_unit = {r["drugMeasureUnitNh"]: r for r in result["conversionList"]}
+        assert by_unit["g"]["factor"] is None
+
+
+class TestSubstanceUnitFallback:
+    """When the substance has no default unit it falls back to 'un'."""
+
+    def test_none_default_falls_back_to_un_and_hides_factors(self):
+        """A null substance default becomes 'un' with factors hidden."""
+        rows = [
+            _conv_row(
+                id_measure_unit=1,
+                factor=500,
+                description="milligram",
+                measureunit_nh="mg",
+                default_measureunit=None,
+            ),
+        ]
+        result = _run(configured=[], conversion_list=rows)
+
+        assert result["substanceMeasureUnit"] == DefaultMeasureUnitEnum.UN.value
+        # the mg row is not the default (un != mg) and factors are hidden
+        first = result["conversionList"][0]
+        assert first["drugMeasureUnitNh"] == "mg"
+        assert first["default"] is False
+        assert first["factor"] is None
+
+
+class TestSyntheticDefaultRow:
+    """A default row is appended when the substance unit is absent from the list."""
+
+    def test_synthetic_default_appended_when_absent(self):
+        """If no row is the default unit, a synthetic default row is added."""
+        rows = [
+            _conv_row(
+                id_measure_unit=2,
+                factor=1000,
+                description="gram",
+                measureunit_nh="g",
+                default_measureunit="mg",
+            ),
+        ]
+        result = _run(configured=[], conversion_list=rows, id_drug=100)
+
+        defaults = [r for r in result["conversionList"] if r["default"]]
+        assert len(defaults) == 1
+        synth = defaults[0]
+        assert synth["drugMeasureUnitNh"] == "mg"
+        assert synth["idMeasureUnit"] == "mg"
+        assert synth["factor"] == 1
+        assert synth["id"] == "100-mg"
+
+    def test_no_synthetic_row_when_default_present(self):
+        """When a real default row exists, no synthetic row is appended."""
+        rows = [
+            _conv_row(
+                id_measure_unit=1,
+                factor=1,
+                description="milligram",
+                measureunit_nh="mg",
+                default_measureunit="mg",
+            ),
+        ]
+        result = _run(configured=[], conversion_list=rows)
+
+        assert len(result["conversionList"]) == 1
+        assert result["conversionList"][0]["default"] is True
+
+
+class TestEnvelope:
+    """The returned envelope echoes the drug identity."""
+
+    def test_envelope_fields(self):
+        """name and idDrug come from the first conversion row."""
+        rows = [
+            _conv_row(
+                id=100,
+                name="Dipirona",
+                id_measure_unit=1,
+                factor=1,
+                description="milligram",
+                measureunit_nh="mg",
+                default_measureunit="mg",
+            ),
+        ]
+        result = _run(configured=[], conversion_list=rows)
+
+        assert result["name"] == "Dipirona"
+        assert result["idDrug"] == 100
+        assert result["substanceMeasureUnit"] == "mg"
+        assert isinstance(result["conversionList"], list)


### PR DESCRIPTION
## Summary

Adds unit tests for two previously untested service features, raising coverage of deterministic business logic that had no dedicated tests.

### 1. `clinical_notes_service` — note conversion (`tests/unit/test_clinical_notes_convert.py`)

Covers `convert_notes` and `convert_prescription_note`, the helpers that shape DB rows into the dict returned by the clinical-notes endpoints:

- id stringification and scalar field copy-through
- `HIDE_NAMES` prescriber/creator name masking (`***`)
- primary-care `form`/`template` gating on `has_primary_care`
- long-text truncation at 700 000 chars with the "Evolução cortada" marker (plus the short-text and `None`-text paths)
- tag annotation-count projection onto both the tag name and its legacy `column` alias, defaulting to `0` when the annotation is missing or `annotations` is `None`
- the empty-string creator fallback and shared core-key shape between the two converters

### 2. `unit_conversion_service.get_unit_conversion_for_drug` (`tests/unit/test_unit_conversion_service.py`)

Drives every branch of the factor-selection logic:

- `ValidationError` when no conversions exist
- the `show_factors` decision across zero / one-matching / one-mismatching / multiple configured measure units
- per-row `factor` selection: default → `1`, shown → raw factor, hidden → `None`
- the `un` fallback when the substance has no default unit
- synthesis of a default row when the substance unit is absent from the conversion list (and no synthesis when a default row is already present)
- the returned envelope fields

## Testing

Both suites patch only their external dependencies (the `HIDE_NAMES` feature flag; the two `unit_conversion_repository` queries) and run without a database or request context. The `@has_permission` gate on the unit-conversion function is bypassed via `__wrapped__` so the business logic is exercised directly.

Full suite run locally against the seed database: **1055 passed** (1026 baseline + 29 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pnqC4m3XGrt1gLAMPYs5r

---
_Generated by [Claude Code](https://claude.ai/code/session_011pnqC4m3XGrt1gLAMPYs5r)_