### PR TITLE
test: cover intervention economy calc and outlier manual-score update

### DIFF
--- a/tests/integration/test_outlier.py
+++ b/tests/integration/test_outlier.py
@@ -1,0 +1,90 @@
+"""Integration tests for the outlier update endpoint (PUT /outliers/<id>).
+
+Exercises ``outlier_service.update_outlier``, which lets a user holding
+``WRITE_DRUG_SCORE`` store a manual score on an outlier. The endpoint had no
+prior coverage in the suite.
+
+The drug/outlier fixtures use IDs in the reserved ``>= 90000`` range so the
+session-scoped ``clean_test_artifacts`` fixture removes them afterwards.
+"""
+
+import pytest
+
+from models.main import Outlier
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_unit_conversion import (
+    create_test_drug,
+    create_test_outlier,
+    create_test_substance,
+)
+
+# IDs reserved for this module (>= 90000, distinct from other modules' ranges).
+_SCTID = 90050
+_DRUG_ID = 90050
+_OUTLIER_ID = 90050
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_outlier_test_data(clean_test_artifacts):  # noqa: ARG001
+    """Create the drug + outlier to update, after the global cleanup fixture runs."""
+    create_test_substance(_SCTID, "Test Outlier Drug", "mg")
+    create_test_drug(_DRUG_ID, "Test Outlier Drug", _SCTID)
+    create_test_outlier(_OUTLIER_ID, _DRUG_ID)
+
+
+def _read_outlier() -> Outlier:
+    """Return a fresh copy of the test outlier (commit first to drop any snapshot)."""
+    session_commit()
+    return session.query(Outlier).filter(Outlier.id == _OUTLIER_ID).first()
+
+
+def test_update_outlier_sets_manual_score(client, config_manager_headers):
+    """A WRITE_DRUG_SCORE user sets a manual score and it is persisted [200 OK]."""
+    response = client.put(
+        f"/outliers/{_OUTLIER_ID}",
+        headers=config_manager_headers,
+        json={"manualScore": 3},
+    )
+
+    assert response.status_code == 200
+
+    outlier = _read_outlier()
+    assert outlier.manualScore == 3
+    # the update stamps who changed it and when
+    assert outlier.update is not None
+    assert outlier.user is not None
+
+
+def test_update_outlier_overwrites_manual_score(client, config_manager_headers):
+    """A second update replaces the previously stored manual score."""
+    client.put(
+        f"/outliers/{_OUTLIER_ID}",
+        headers=config_manager_headers,
+        json={"manualScore": 2},
+    )
+
+    response = client.put(
+        f"/outliers/{_OUTLIER_ID}",
+        headers=config_manager_headers,
+        json={"manualScore": 4},
+    )
+
+    assert response.status_code == 200
+    assert _read_outlier().manualScore == 4
+
+
+def test_update_outlier_permission_denied(client, analyst_headers):
+    """Without WRITE_DRUG_SCORE the update is rejected [401] and nothing changes."""
+    before = _read_outlier().manualScore
+
+    response = client.put(
+        f"/outliers/{_OUTLIER_ID}",
+        headers=analyst_headers,
+        json={"manualScore": 99},
+    )
+
+    assert response.status_code == 401
+    # the rejected write must leave the stored score untouched
+    after = _read_outlier().manualScore
+    assert after == before
+    assert after != 99

--- a/tests/unit/test_intervention_outcome_economy.py
+++ b/tests/unit/test_intervention_outcome_economy.py
@@ -1,0 +1,113 @@
+"""Unit tests for intervention_outcome_service._calc_economy.
+
+``_calc_economy`` is the pure money calculation behind an intervention's daily
+economy. It multiplies price-per-dose by the daily frequency for the origin
+prescription item and, when a substitute (destiny) item exists, subtracts the
+substitute's own price × frequency. All values pass through
+``numberutils.none2zero`` first, so ``None``/invalid values behave as zero.
+
+The function is otherwise only exercised indirectly through the DB-backed
+outcome endpoint; these tests pin its arithmetic and coercion rules directly.
+"""
+
+import pytest
+
+from services import intervention_outcome_service
+
+
+def _item(price_per_dose, frequency_day):
+    """Build the minimal origin/destiny structure _calc_economy reads."""
+    return {"item": {"pricePerDose": price_per_dose, "frequencyDay": frequency_day}}
+
+
+class TestCalcEconomyOriginOnly:
+    """No substitute: economy is simply pricePerDose * frequencyDay."""
+
+    @pytest.mark.parametrize(
+        "price_per_dose, frequency_day, expected",
+        [
+            ("10", 2, 20.0),
+            ("2.5", 4, 10.0),
+            (7, 3, 21.0),
+            ("0", 5, 0.0),
+            ("10", 0, 0.0),
+            ("1.5", 1, 1.5),
+        ],
+    )
+    def test_origin_only_multiplies_price_by_frequency(
+        self, price_per_dose, frequency_day, expected
+    ):
+        """With destiny=None the result is the origin's price × daily frequency."""
+        result = intervention_outcome_service._calc_economy(
+            origin=_item(price_per_dose, frequency_day),
+            destiny=None,
+        )
+        assert result == expected
+
+
+class TestCalcEconomyWithDestiny:
+    """Substitution: origin cost minus destiny cost."""
+
+    def test_positive_economy_when_substitute_is_cheaper(self):
+        """Origin 10*3=30 minus destiny 5*2=10 yields a 20 economy."""
+        result = intervention_outcome_service._calc_economy(
+            origin=_item("10", 3),
+            destiny=_item("5", 2),
+        )
+        assert result == 20.0
+
+    def test_zero_economy_when_costs_match(self):
+        """Equal origin and destiny costs produce no economy."""
+        result = intervention_outcome_service._calc_economy(
+            origin=_item("8", 2),
+            destiny=_item("4", 4),
+        )
+        assert result == 0.0
+
+    def test_negative_economy_when_substitute_is_more_expensive(self):
+        """A pricier substitute results in a negative (added-cost) economy."""
+        result = intervention_outcome_service._calc_economy(
+            origin=_item("5", 2),
+            destiny=_item("10", 3),
+        )
+        assert result == 10.0 - 30.0
+
+
+class TestCalcEconomyCoercion:
+    """None / invalid values are coerced to zero via none2zero."""
+
+    def test_origin_none_returns_zero(self):
+        """A missing origin short-circuits to a zero economy."""
+        assert intervention_outcome_service._calc_economy(origin=None, destiny=None) == 0
+
+    def test_none_price_in_origin_counts_as_zero(self):
+        """A None price makes the origin contribute nothing."""
+        result = intervention_outcome_service._calc_economy(
+            origin=_item(None, 5),
+            destiny=None,
+        )
+        assert result == 0.0
+
+    def test_none_frequency_in_origin_counts_as_zero(self):
+        """A None frequency makes the origin contribute nothing."""
+        result = intervention_outcome_service._calc_economy(
+            origin=_item("10", None),
+            destiny=None,
+        )
+        assert result == 0.0
+
+    def test_invalid_destiny_values_count_as_zero(self):
+        """Non-numeric destiny values collapse to zero, leaving only origin cost."""
+        result = intervention_outcome_service._calc_economy(
+            origin=_item("10", 2),
+            destiny=_item("abc", None),
+        )
+        assert result == 20.0
+
+    def test_numeric_strings_are_parsed(self):
+        """Numeric strings (as emitted by _outcome_calc) are parsed as floats."""
+        result = intervention_outcome_service._calc_economy(
+            origin=_item("2.5", 4),
+            destiny=_item("1.25", 2),
+        )
+        assert result == 2.5 * 4 - 1.25 * 2


### PR DESCRIPTION
## Summary

Increases test coverage by adding tests for two previously untested features.

### 1. Unit — `intervention_outcome_service._calc_economy`
`tests/unit/test_intervention_outcome_economy.py`

The pure money calculation behind an intervention's daily economy
(`pricePerDose × frequencyDay` for the origin item, minus the substitute's
own cost when a destiny item exists). It was only exercised indirectly through
the DB-backed outcome endpoint. The new tests pin its arithmetic and
`numberutils.none2zero` coercion directly:
- origin-only cases (`destiny=None`) → price × frequency
- substitution cases → positive, zero, and negative (added-cost) economy
- coercion rules: `None` origin short-circuits to `0`; `None`/invalid
  price or frequency count as zero; numeric strings are parsed as floats

### 2. Integration — `PUT /outliers/<id>` (`outlier_service.update_outlier`)
`tests/integration/test_outlier.py`

This write endpoint (setting an outlier's manual score) had no prior coverage.
The new tests use reserved `>= 90000` drug/outlier IDs so the session-scoped
`clean_test_artifacts` fixture removes them:
- a `WRITE_DRUG_SCORE` user sets a manual score and it is persisted, stamping
  `update_at` / `update_by`
- a second update overwrites the stored score
- a user without `WRITE_DRUG_SCORE` is rejected with `401` and the stored
  score is left untouched

## Testing

Full suite run locally against a PostgreSQL-16 database seeded from
`noharm-ai/database` (same SQL as CI): **1072 passed** (17 in the two new
files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013e9yyMBo1yAhAU5updKDvG)_