### PR TITLE
test: add unit coverage for SOAP prompt building and dose aggregation

### DIFF
--- a/tests/unit/test_alert_service_dose.py
+++ b/tests/unit/test_alert_service_dose.py
@@ -1,0 +1,170 @@
+"""Unit tests for services.alert_service dose-aggregation helpers.
+
+`_get_dose_conv` and `_get_dose_total` compute the converted daily dose of
+each prescribed drug and aggregate it per drug/day (and per kg of body
+weight). They are pure functions over prescription rows, so they can be
+exercised with lightweight stand-in objects and no database.
+"""
+
+import pytest
+
+from services import alert_service
+
+SPECIAL_FREQUENCIES = [33, 44, 55, 66, 99]
+
+
+class _Drug:
+    """Minimal stand-in for a PrescriptionDrug row."""
+
+    def __init__(self, id_drug=1, frequency=2, dose=10, doseconv=5):
+        self.idDrug = id_drug
+        self.frequency = frequency
+        self.dose = dose
+        self.doseconv = doseconv
+
+
+class _Attr:
+    """Minimal stand-in for a DrugAttributes row (only 'division' is read)."""
+
+    def __init__(self, division=None):
+        self.division = division
+
+
+class _Row:
+    """Row-like object supporting both positional indexing and the
+    ``measure_unit_convert_factor`` attribute, mirroring the SQLAlchemy Row
+    that _get_dose_total consumes.
+
+    Positions used by _get_dose_total: [0]=PrescriptionDrug, [6]=DrugAttributes,
+    [10]=prescription_expire_date.
+    """
+
+    def __init__(self, prescription_drug, drug_attributes, expire_date, factor):
+        self._cols = [None] * 11
+        self._cols[0] = prescription_drug
+        self._cols[6] = drug_attributes
+        self._cols[10] = expire_date
+        self.measure_unit_convert_factor = factor
+
+    def __getitem__(self, index):
+        return self._cols[index]
+
+
+class _ExpireDate:
+    """Stand-in for a datetime whose only read attribute is ``.day``."""
+
+    def __init__(self, day):
+        self.day = day
+
+
+class TestGetDoseConv:
+    """Tests for alert_service._get_dose_conv (single-item converted dose)."""
+
+    def test_without_division_uses_doseconv_times_frequency(self):
+        """When drug_attributes is None the pre-converted dose is multiplied by frequency."""
+        drug = _Drug(frequency=3, doseconv=5)
+        assert alert_service._get_dose_conv(drug, None, 1) == 15.0
+
+    def test_without_division_ignores_convert_factor(self):
+        """The measure-unit factor is not applied on the doseconv branch."""
+        drug = _Drug(frequency=2, doseconv=5)
+        # factor of 10 is ignored because there is no division attribute
+        assert alert_service._get_dose_conv(drug, None, 10) == 10.0
+
+    def test_with_division_uses_dose_factor_and_frequency(self):
+        """With a division attribute the raw dose is scaled by factor and frequency."""
+        drug = _Drug(frequency=2, dose=10)
+        attr = _Attr(division=1)
+        assert alert_service._get_dose_conv(drug, attr, 2) == 40.0
+
+    def test_with_division_none_factor_defaults_to_one(self):
+        """A None convert factor on the division branch defaults to 1."""
+        drug = _Drug(frequency=2, dose=10)
+        attr = _Attr(division=1)
+        assert alert_service._get_dose_conv(drug, attr, None) == 20.0
+
+    def test_division_none_falls_back_to_doseconv_branch(self):
+        """An attributes row whose division is None uses the doseconv branch."""
+        drug = _Drug(frequency=2, dose=10, doseconv=5)
+        attr = _Attr(division=None)
+        # doseconv (5) * frequency (2) = 10, dose/factor path not taken
+        assert alert_service._get_dose_conv(drug, attr, 99) == 10.0
+
+    @pytest.mark.parametrize("special", SPECIAL_FREQUENCIES)
+    def test_special_frequencies_count_as_one(self, special):
+        """Special frequency codes are treated as a frequency of 1."""
+        drug = _Drug(frequency=special, doseconv=7)
+        assert alert_service._get_dose_conv(drug, None, 1) == 7.0
+
+    def test_non_numeric_doseconv_is_zeroed(self):
+        """A non-numeric dose value is coerced to zero (via none2zero)."""
+        drug = _Drug(frequency=2, doseconv=None)
+        assert alert_service._get_dose_conv(drug, None, 1) == 0
+
+
+class TestGetDoseTotal:
+    """Tests for alert_service._get_dose_total (per drug/day aggregation)."""
+
+    def _row(self, drug, expire_day=5, attr=None, factor=1):
+        return _Row(drug, attr, _ExpireDate(expire_day), factor)
+
+    def test_single_drug_totals_and_per_kg(self):
+        """A single row yields both an absolute total and a per-kg entry."""
+        drug = _Drug(id_drug=1, frequency=2, doseconv=10)
+        result = alert_service._get_dose_total([self._row(drug)], {"weight": 2})
+        assert result["1_5"] == {"value": 20.0, "count": 1}
+        # per kg: 20 / 2 = 10
+        assert result["1_5kg"] == {"value": 10.0, "count": 1}
+
+    def test_same_drug_same_day_accumulates(self):
+        """Two rows of the same drug on the same day sum values and counts."""
+        drug_a = _Drug(id_drug=1, frequency=1, doseconv=10)
+        drug_b = _Drug(id_drug=1, frequency=1, doseconv=5)
+        result = alert_service._get_dose_total(
+            [self._row(drug_a), self._row(drug_b)], {"weight": 1}
+        )
+        assert result["1_5"] == {"value": 15.0, "count": 2}
+
+    def test_different_expire_days_are_separate_buckets(self):
+        """The same drug on different expiry days lands in distinct buckets."""
+        drug = _Drug(id_drug=1, frequency=1, doseconv=10)
+        result = alert_service._get_dose_total(
+            [self._row(drug, expire_day=5), self._row(drug, expire_day=6)],
+            {"weight": 1},
+        )
+        assert result["1_5"]["count"] == 1
+        assert result["1_6"]["count"] == 1
+
+    def test_frequency_66_is_excluded(self):
+        """Frequency 66 (AGORA) rows are skipped entirely from the totals."""
+        drug = _Drug(id_drug=1, frequency=66, doseconv=10)
+        result = alert_service._get_dose_total([self._row(drug)], {"weight": 1})
+        assert result == {}
+
+    def test_missing_expire_date_uses_day_zero(self):
+        """A row without an expiry date is bucketed under day 0."""
+        drug = _Drug(id_drug=7, frequency=1, doseconv=4)
+        row = _Row(drug, None, None, 1)
+        result = alert_service._get_dose_total([row], {"weight": 1})
+        assert "7_0" in result
+
+    def test_zero_weight_defaults_to_one(self):
+        """A non-positive weight is treated as 1 kg to avoid division by zero."""
+        drug = _Drug(id_drug=1, frequency=1, doseconv=8)
+        result = alert_service._get_dose_total([self._row(drug)], {"weight": 0})
+        # value unchanged because weight defaults to 1
+        assert result["1_5kg"]["value"] == 8.0
+
+    def test_none_convert_factor_defaults_to_one(self):
+        """A None measure-unit factor on a division drug defaults to 1."""
+        drug = _Drug(id_drug=1, frequency=2, dose=10)
+        attr = _Attr(division=1)
+        result = alert_service._get_dose_total(
+            [self._row(drug, attr=attr, factor=None)], {"weight": 1}
+        )
+        # dose (10) * factor (defaulted 1) * frequency (2) = 20
+        assert result["1_5"]["value"] == 20.0
+
+    def test_empty_drug_list_returns_empty_dict(self):
+        """An empty drug list produces an empty aggregation."""
+        assert alert_service._get_dose_total([], {"weight": 1}) == {}

--- a/tests/unit/test_soap_service.py
+++ b/tests/unit/test_soap_service.py
@@ -1,0 +1,172 @@
+"""Unit tests for services.soap_service pure content-building helpers.
+
+These cover the pure, side-effect-free helpers that assemble the LLM prompt
+input from a clinical note and clean up the model output. They do not touch
+the database or the Bedrock client, so they run as fast unit tests.
+"""
+
+import json
+
+from services import soap_service
+
+
+class _Note:
+    """Minimal stand-in for a ClinicalNotes row used by _get_note_content."""
+
+    def __init__(self, date="", position="", prescriber="", form=None, template=None, text=None):
+        self.date = date
+        self.position = position
+        self.prescriber = prescriber
+        self.form = form
+        self.template = template
+        self.text = text
+
+
+class TestStripCodeFences:
+    """Tests for soap_service._strip_code_fences (LLM markdown fence removal)."""
+
+    def test_plain_text_unchanged(self):
+        """Text without fences is returned trimmed but otherwise intact."""
+        assert soap_service._strip_code_fences("  <p>hello</p>  ") == "<p>hello</p>"
+
+    def test_language_fence_is_removed(self):
+        """A leading ```html fence line and trailing fence are stripped."""
+        text = "```html\n<p>x</p>\n```"
+        assert soap_service._strip_code_fences(text) == "<p>x</p>"
+
+    def test_bare_fence_is_removed(self):
+        """A bare ``` opening fence (no language) drops the first line."""
+        text = "```\ncontent here\n```"
+        assert soap_service._strip_code_fences(text) == "content here"
+
+    def test_only_opening_fence_line_returns_empty(self):
+        """A string that is only an opening fence with no newline becomes empty."""
+        assert soap_service._strip_code_fences("```html") == ""
+
+    def test_trailing_fence_only(self):
+        """A trailing fence with no opening fence is still removed."""
+        assert soap_service._strip_code_fences("some text```") == "some text"
+
+    def test_multiline_body_preserved(self):
+        """Inner newlines of the fenced body are preserved."""
+        text = "```html\n<p>a</p>\n<p>b</p>\n```"
+        assert soap_service._strip_code_fences(text) == "<p>a</p>\n<p>b</p>"
+
+
+class TestGetFormContent:
+    """Tests for soap_service._get_form_content (form answers -> Q/A text)."""
+
+    def test_no_template_returns_pretty_json(self):
+        """Without a template the raw form is dumped as indented JSON."""
+        form = {"q1": "resposta"}
+        result = soap_service._get_form_content(form=form, template=None)
+        assert result == json.dumps(form, ensure_ascii=False, indent=2)
+
+    def test_no_template_keeps_unicode(self):
+        """The JSON fallback preserves accented characters (ensure_ascii=False)."""
+        result = soap_service._get_form_content(form={"q": "avaliação"}, template=[])
+        assert "avaliação" in result
+
+    def test_renders_group_and_question_answer(self):
+        """Answered questions are rendered under their group heading."""
+        template = [
+            {
+                "group": "Anamnese",
+                "questions": [{"id": "q1", "label": "Queixa principal"}],
+            }
+        ]
+        form = {"q1": "dor de cabeça"}
+        result = soap_service._get_form_content(form=form, template=template)
+        assert "### Anamnese" in result
+        assert "Pergunta: Queixa principal" in result
+        assert "Resposta: dor de cabeça" in result
+
+    def test_unanswered_questions_are_skipped(self):
+        """Questions with empty/None/[] answers produce no output and no group."""
+        template = [
+            {
+                "group": "Vazio",
+                "questions": [
+                    {"id": "a", "label": "A"},
+                    {"id": "b", "label": "B"},
+                ],
+            }
+        ]
+        form = {"a": "", "b": None}
+        result = soap_service._get_form_content(form=form, template=template)
+        assert result == ""
+
+    def test_list_answer_is_joined_with_commas(self):
+        """A list-valued answer is rendered as a comma-separated string."""
+        template = [
+            {"group": "G", "questions": [{"id": "s", "label": "Sintomas"}]}
+        ]
+        form = {"s": ["febre", "tosse"]}
+        result = soap_service._get_form_content(form=form, template=template)
+        assert "Resposta: febre, tosse" in result
+
+    def test_extra_form_keys_not_in_template_are_appended(self):
+        """Answered keys absent from the template are appended by their raw key."""
+        template = [
+            {"group": "G", "questions": [{"id": "known", "label": "Conhecida"}]}
+        ]
+        form = {"known": "sim", "extra": "valor extra"}
+        result = soap_service._get_form_content(form=form, template=template)
+        assert "Resposta: sim" in result
+        # extra key rendered using the key itself as the question label
+        assert "Pergunta: extra" in result
+        assert "Resposta: valor extra" in result
+
+    def test_extra_empty_keys_are_ignored(self):
+        """Extra form keys with empty answers are not appended."""
+        template = [
+            {"group": "G", "questions": [{"id": "known", "label": "Conhecida"}]}
+        ]
+        form = {"known": "sim", "empty": ""}
+        result = soap_service._get_form_content(form=form, template=template)
+        assert "Pergunta: empty" not in result
+
+
+class TestGetNoteContent:
+    """Tests for soap_service._get_note_content (build LLM user message)."""
+
+    def test_includes_consultation_metadata(self):
+        """The header always carries date, position and prescriber."""
+        note = _Note(date="2024-01-01", position="Farmacêutico", prescriber="Ana")
+        result = soap_service._get_note_content(note)
+        assert "## Dados da consulta" in result
+        assert "Data: 2024-01-01" in result
+        assert "Cargo/Origem: Farmacêutico" in result
+        assert "Responsável: Ana" in result
+
+    def test_form_section_added_when_form_present(self):
+        """A form section is appended when the note has form answers."""
+        note = _Note(
+            form={"q1": "resposta"},
+            template=[{"group": "G", "questions": [{"id": "q1", "label": "Q"}]}],
+        )
+        result = soap_service._get_note_content(note)
+        assert "## Formulário da consulta (perguntas e respostas)" in result
+        assert "Resposta: resposta" in result
+
+    def test_text_section_added_when_text_present(self):
+        """The free-text evolution is appended under its own heading."""
+        note = _Note(text="evolução livre")
+        result = soap_service._get_note_content(note)
+        assert "## Texto da evolução" in result
+        assert "evolução livre" in result
+
+    def test_text_is_truncated_to_max_chars(self):
+        """Overly long note text is capped at SOAP_INPUT_MAX_CHARS characters."""
+        long_text = "a" * (soap_service.SOAP_INPUT_MAX_CHARS + 500)
+        note = _Note(text=long_text)
+        result = soap_service._get_note_content(note)
+        assert "a" * soap_service.SOAP_INPUT_MAX_CHARS in result
+        assert "a" * (soap_service.SOAP_INPUT_MAX_CHARS + 1) not in result
+
+    def test_optional_sections_absent_when_empty(self):
+        """With no form and no text only the metadata header is produced."""
+        note = _Note(date="2024-01-01")
+        result = soap_service._get_note_content(note)
+        assert "## Formulário da consulta (perguntas e respostas)" not in result
+        assert "## Texto da evolução" not in result


### PR DESCRIPTION
## Summary

Increases test coverage by adding unit tests for two previously untested features. Both suites exercise pure logic with lightweight stand-in objects, so they need no database, LLM, or AWS access and run as fast unit tests.

### 1. `services/soap_service` — SOAP prompt building (`tests/unit/test_soap_service.py`)

Covers the pure helpers that assemble the LLM prompt input from a clinical note and clean up the generated output:

- `_strip_code_fences` — removes markdown ```` ```html ```` / bare fences wrapping the model output.
- `_get_form_content` — renders form answers as question/answer text using the note template, with JSON fallback when no template is present, list-answer joining, skipping of empty answers, and appending of extra keys not in the template.
- `_get_note_content` — builds the LLM user message, including consultation metadata, optional form and free-text sections, and truncation to `SOAP_INPUT_MAX_CHARS`.

### 2. `services/alert_service` — dose aggregation (`tests/unit/test_alert_service_dose.py`)

Covers the clinical dose-aggregation helpers:

- `_get_dose_conv` — per-item converted daily dose, covering the division vs. `doseconv` branches, the measure-unit convert factor, special frequency codes (33/44/55/66/99) counting as 1, and non-numeric coercion.
- `_get_dose_total` — aggregation per drug/day and per kg of body weight, covering accumulation across rows, separate buckets per expiry day, exclusion of frequency 66 (AGORA), missing expiry date defaulting to day 0, and zero-weight defaulting to 1 kg.

## Testing

Ran the full suite locally against a PostgreSQL 16 database seeded from `noharm-ai/database` (the same SQL files CI uses): **1109 passed** (37 new). No existing tests were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143R8h89znR1XG38ZkH37Ks

---
_Generated by [Claude Code](https://claude.ai/code/session_0143R8h89znR1XG38ZkH37Ks)_