### PR TITLE
test: add unit tests for user role validation and drug match diff

### DIFF
--- a/tests/unit/test_prescription_drug_match_diff.py
+++ b/tests/unit/test_prescription_drug_match_diff.py
@@ -1,0 +1,215 @@
+"""Unit tests for prescription_drug_service._get_match_diff.
+
+``_get_match_diff`` compares a ``checkedindex`` row (``r``) against the current
+values of a ``PrescriptionDrug`` (``pd``) and returns the list of field names
+that differ. An empty list means the checked snapshot still matches the drug.
+
+The function is pure (no database access) and only reads attributes off the two
+objects, so the row and the prescription drug are stand-ins built with
+``SimpleNamespace``. Notable behaviors under test:
+
+- ``notes`` is compared as an md5 hex digest (``complemento``);
+- ``None`` solution fields are coalesced to ``0``;
+- ``route`` coalesces ``None`` to an empty string;
+- ``interval`` is truncated to its first 50 characters before comparison.
+"""
+
+import hashlib
+from types import SimpleNamespace
+
+from services import prescription_drug_service
+
+
+def _md5(text: str) -> str:
+    """Return the md5 hex digest the service uses to compare notes."""
+    return hashlib.md5(text.encode()).hexdigest()
+
+
+def _make_pd(**overrides):
+    """Build a PrescriptionDrug-like object with sensible matching defaults."""
+    pd = SimpleNamespace(
+        doseconv=10.0,
+        frequency=3,
+        solutionPhase=1,
+        solutionTime=2,
+        solutionTotalTime=30,
+        solutionDose=5,
+        route="IV",
+        interval="06:00 12:00 18:00",
+        dose=100.0,
+        notes="observacao",
+    )
+    for key, value in overrides.items():
+        setattr(pd, key, value)
+    return pd
+
+
+def _make_matching_row(pd):
+    """Build a checkedindex-like row that fully matches the given PrescriptionDrug."""
+    return SimpleNamespace(
+        doseconv=pd.doseconv,
+        frequenciadia=pd.frequency,
+        sletapas=(pd.solutionPhase or 0),
+        slhorafase=(pd.solutionTime or 0),
+        sltempoaplicacao=(pd.solutionTotalTime or 0),
+        sldosagem=(pd.solutionDose or 0),
+        via=(pd.route or ""),
+        horario=(pd.interval[:50] if pd.interval else ""),
+        dose=pd.dose,
+        complemento=(_md5(pd.notes) if pd.notes else ""),
+    )
+
+
+class TestFullMatch:
+    """Teste _get_match_diff - matching snapshots yield no differences"""
+
+    def test_full_match_returns_empty_list(self):
+        """A row equal to the drug on every field returns an empty diff."""
+        pd = _make_pd()
+        row = _make_matching_row(pd)
+        assert prescription_drug_service._get_match_diff(row, pd) == []
+
+
+class TestSingleFieldDifferences:
+    """Teste _get_match_diff - a single differing field is reported"""
+
+    def test_dose_difference(self):
+        """A changed dose is reported."""
+        pd = _make_pd()
+        row = _make_matching_row(pd)
+        row.dose = 999.0
+        assert prescription_drug_service._get_match_diff(row, pd) == ["dose"]
+
+    def test_doseconv_difference(self):
+        """A changed converted dose is reported."""
+        pd = _make_pd()
+        row = _make_matching_row(pd)
+        row.doseconv = 0.1
+        assert prescription_drug_service._get_match_diff(row, pd) == ["doseconv"]
+
+    def test_frequency_difference(self):
+        """A changed daily frequency is reported under 'frequenciadia'."""
+        pd = _make_pd()
+        row = _make_matching_row(pd)
+        row.frequenciadia = 99
+        assert prescription_drug_service._get_match_diff(row, pd) == ["frequenciadia"]
+
+    def test_route_difference(self):
+        """A changed route is reported under 'via'."""
+        pd = _make_pd()
+        row = _make_matching_row(pd)
+        row.via = "ORAL"
+        assert prescription_drug_service._get_match_diff(row, pd) == ["via"]
+
+    def test_interval_difference(self):
+        """A changed schedule is reported under 'horario'."""
+        pd = _make_pd()
+        row = _make_matching_row(pd)
+        row.horario = "23:00"
+        assert prescription_drug_service._get_match_diff(row, pd) == ["horario"]
+
+
+class TestNoneCoalescing:
+    """Teste _get_match_diff - None solution/route fields coalesce to defaults"""
+
+    def test_none_solution_fields_match_zero_row(self):
+        """None solution fields on the drug match a row carrying 0."""
+        pd = _make_pd(
+            solutionPhase=None,
+            solutionTime=None,
+            solutionTotalTime=None,
+            solutionDose=None,
+        )
+        row = _make_matching_row(pd)  # helper coalesces None -> 0
+        # sanity: the row really is holding zeros for these fields
+        assert row.sletapas == 0 and row.sldosagem == 0
+        assert prescription_drug_service._get_match_diff(row, pd) == []
+
+    def test_none_solution_field_differs_when_row_nonzero(self):
+        """A None solution field differs from a non-zero row value."""
+        pd = _make_pd(solutionPhase=None)
+        row = _make_matching_row(pd)
+        row.sletapas = 4
+        assert prescription_drug_service._get_match_diff(row, pd) == ["sletapas"]
+
+    def test_none_route_matches_empty_string_row(self):
+        """A None route coalesces to '' and matches an empty-string row."""
+        pd = _make_pd(route=None)
+        row = _make_matching_row(pd)
+        assert row.via == ""
+        assert prescription_drug_service._get_match_diff(row, pd) == []
+
+
+class TestNotesComplemento:
+    """Teste _get_match_diff - notes compared as md5 'complemento'"""
+
+    def test_matching_notes_digest(self):
+        """A row whose complemento is the md5 of the notes matches."""
+        pd = _make_pd(notes="alguma observacao")
+        row = _make_matching_row(pd)
+        assert row.complemento == _md5("alguma observacao")
+        assert prescription_drug_service._get_match_diff(row, pd) == []
+
+    def test_different_notes_digest_is_reported(self):
+        """A stale complemento digest is reported."""
+        pd = _make_pd(notes="nova observacao")
+        row = _make_matching_row(pd)
+        row.complemento = _md5("observacao antiga")
+        assert prescription_drug_service._get_match_diff(row, pd) == ["complemento"]
+
+    def test_empty_notes_match_empty_complemento(self):
+        """When the drug has no notes, an empty complemento matches."""
+        pd = _make_pd(notes=None)
+        row = _make_matching_row(pd)
+        assert row.complemento == ""
+        assert prescription_drug_service._get_match_diff(row, pd) == []
+
+    def test_none_complemento_row_treated_as_empty(self):
+        """A None complemento on the row is coalesced to '' and matches empty notes."""
+        pd = _make_pd(notes=None)
+        row = _make_matching_row(pd)
+        row.complemento = None
+        assert prescription_drug_service._get_match_diff(row, pd) == []
+
+    def test_notes_present_but_row_empty_is_reported(self):
+        """Notes present on the drug but absent on the row is a difference."""
+        pd = _make_pd(notes="observacao")
+        row = _make_matching_row(pd)
+        row.complemento = ""
+        assert prescription_drug_service._get_match_diff(row, pd) == ["complemento"]
+
+
+class TestIntervalTruncation:
+    """Teste _get_match_diff - interval is truncated to 50 chars before comparing"""
+
+    def test_only_first_50_chars_compared(self):
+        """Intervals differing only beyond char 50 are treated as equal."""
+        long_interval = "A" * 50 + "TAIL-THAT-IS-IGNORED"
+        pd = _make_pd(interval=long_interval)
+        row = _make_matching_row(pd)  # horario holds the 50-char prefix
+        assert row.horario == "A" * 50
+        assert prescription_drug_service._get_match_diff(row, pd) == []
+
+    def test_difference_within_first_50_chars_is_reported(self):
+        """A difference inside the first 50 chars is reported."""
+        pd = _make_pd(interval="B" * 60)
+        row = _make_matching_row(pd)
+        row.horario = "C" * 50
+        assert prescription_drug_service._get_match_diff(row, pd) == ["horario"]
+
+
+class TestMultipleDifferences:
+    """Teste _get_match_diff - multiple differing fields are all reported"""
+
+    def test_reports_all_differing_fields_in_order(self):
+        """Every differing field is returned, in the function's check order."""
+        pd = _make_pd()
+        row = _make_matching_row(pd)
+        row.doseconv = -1
+        row.via = "SC"
+        row.dose = 0
+        assert prescription_drug_service._get_match_diff(row, pd) == [
+            "doseconv",
+            "via",
+            "dose",
+        ]

--- a/tests/unit/test_user_admin_role_validation.py
+++ b/tests/unit/test_user_admin_role_validation.py
@@ -1,0 +1,135 @@
+"""Unit tests for the role/feature validation helpers in user_admin_service.
+
+These cover the pure functions used while upserting a user's configuration:
+
+- ``_remove_legacy_roles``   strips deprecated role names before persisting.
+- ``_has_valid_roles``       rejects any role that is not an assignable Role.
+- ``_has_valid_features``    rejects any feature outside the assignable set.
+
+All three are pure (no database / no request context), so they are exercised
+directly with plain Python lists.
+"""
+
+import pytest
+
+from models.enums import FeatureEnum
+from security.role import Role
+from services import user_admin_service
+
+
+class TestRemoveLegacyRoles:
+    """Teste user_admin_service - _remove_legacy_roles"""
+
+    def test_removes_known_legacy_roles(self):
+        """Deprecated role names are stripped from the list."""
+        roles = ["cpoe", "readonly", "userAdmin", "suporte"]
+        assert user_admin_service._remove_legacy_roles(roles) == []
+
+    def test_keeps_valid_roles(self):
+        """Assignable (non-legacy) roles are preserved."""
+        roles = [Role.PRESCRIPTION_ANALYST.value, Role.CONFIG_MANAGER.value]
+        assert user_admin_service._remove_legacy_roles(roles) == [
+            Role.PRESCRIPTION_ANALYST.value,
+            Role.CONFIG_MANAGER.value,
+        ]
+
+    def test_mixed_list_only_drops_legacy(self):
+        """A mix keeps valid roles and drops only the legacy ones, preserving order."""
+        roles = ["cpoe", Role.VIEWER.value, "readonly", Role.USER_MANAGER.value]
+        assert user_admin_service._remove_legacy_roles(roles) == [
+            Role.VIEWER.value,
+            Role.USER_MANAGER.value,
+        ]
+
+    def test_empty_list_returns_empty(self):
+        """An empty list stays empty."""
+        assert user_admin_service._remove_legacy_roles([]) == []
+
+    def test_returns_same_list_instance(self):
+        """The function mutates and returns the same list object it was given."""
+        roles = ["cpoe", Role.VIEWER.value]
+        result = user_admin_service._remove_legacy_roles(roles)
+        assert result is roles
+
+
+class TestHasValidRoles:
+    """Teste user_admin_service - _has_valid_roles"""
+
+    @pytest.mark.parametrize(
+        "role",
+        [
+            Role.PRESCRIPTION_ANALYST.value,
+            Role.CONFIG_MANAGER.value,
+            Role.DISCHARGE_MANAGER.value,
+            Role.USER_MANAGER.value,
+            Role.VIEWER.value,
+            Role.DISPENSING_MANAGER.value,
+            Role.REGULATOR.value,
+            Role.SUPPORT_REQUESTER.value,
+            Role.SUPPORT_MANAGER.value,
+        ],
+    )
+    def test_each_assignable_role_is_valid(self, role):
+        """Every assignable role passes validation on its own."""
+        assert user_admin_service._has_valid_roles([role]) is True
+
+    def test_all_assignable_roles_together_are_valid(self):
+        """A list containing only assignable roles is valid."""
+        roles = [
+            Role.PRESCRIPTION_ANALYST.value,
+            Role.CONFIG_MANAGER.value,
+            Role.VIEWER.value,
+        ]
+        assert user_admin_service._has_valid_roles(roles) is True
+
+    def test_empty_list_is_valid(self):
+        """An empty role list is trivially valid."""
+        assert user_admin_service._has_valid_roles([]) is True
+
+    def test_unknown_role_is_invalid(self):
+        """An unrecognized role name fails validation."""
+        assert user_admin_service._has_valid_roles(["not-a-role"]) is False
+
+    def test_special_non_assignable_role_is_invalid(self):
+        """A non-assignable special role (e.g. ADMIN) is rejected."""
+        assert user_admin_service._has_valid_roles([Role.ADMIN.value]) is False
+
+    def test_mix_of_valid_and_invalid_is_invalid(self):
+        """One invalid role makes the whole list invalid."""
+        roles = [Role.VIEWER.value, "bogus"]
+        assert user_admin_service._has_valid_roles(roles) is False
+
+
+class TestHasValidFeatures:
+    """Teste user_admin_service - _has_valid_features"""
+
+    @pytest.mark.parametrize(
+        "feature",
+        [FeatureEnum.DISABLE_CPOE.value, FeatureEnum.STAGING_ACCESS.value],
+    )
+    def test_each_assignable_feature_is_valid(self, feature):
+        """Each individually assignable feature passes validation."""
+        assert user_admin_service._has_valid_features([feature]) is True
+
+    def test_both_assignable_features_together_are_valid(self):
+        """Both assignable features together are valid."""
+        features = [
+            FeatureEnum.DISABLE_CPOE.value,
+            FeatureEnum.STAGING_ACCESS.value,
+        ]
+        assert user_admin_service._has_valid_features(features) is True
+
+    def test_empty_list_is_valid(self):
+        """An empty feature list is trivially valid."""
+        assert user_admin_service._has_valid_features([]) is True
+
+    def test_unknown_feature_is_invalid(self):
+        """A feature outside the assignable set is rejected."""
+        assert user_admin_service._has_valid_features(["SOME_OTHER_FEATURE"]) is False
+
+    def test_non_assignable_known_feature_is_invalid(self):
+        """A real FeatureEnum value that is not user-assignable is rejected."""
+        assert (
+            user_admin_service._has_valid_features([FeatureEnum.CONCILIATION.value])
+            is False
+        )


### PR DESCRIPTION
## Summary

Increases test coverage by adding unit tests for two previously untested, pure-logic helpers. Both were chosen because they encode non-obvious business rules (role/feature allow-lists, snapshot diffing with hashing and coalescing) yet had no dedicated coverage.

## What's covered

**`services/user_admin_service.py` — role & feature validation** (`tests/unit/test_user_admin_role_validation.py`)
- `_remove_legacy_roles` — strips deprecated role names, preserves valid ones and ordering, mutates in place.
- `_has_valid_roles` — accepts every assignable `Role`, rejects unknown names and non-assignable special roles (e.g. `ADMIN`).
- `_has_valid_features` — accepts the assignable feature set (`DISABLE_CPOE`, `STAGING_ACCESS`), rejects everything else including real-but-non-assignable `FeatureEnum` values.

**`services/prescription_drug_service.py` — `_get_match_diff`** (`tests/unit/test_prescription_drug_match_diff.py`)
- Full match returns an empty diff.
- Each field difference is reported under its correct key (`dose`, `doseconv`, `frequenciadia`, `via`, `horario`, …).
- `notes` comparison via md5 `complemento` digest (match, stale digest, empty notes, `None` row value).
- `None` coalescing for solution fields (→ `0`) and route (→ `""`).
- `interval` truncation to 50 chars before comparison.
- Multiple simultaneous differences are all reported, in check order.

Both helpers are pure (no DB / request context), so the tests exercise them directly with plain lists and `SimpleNamespace` stand-ins — no fixtures or database rows required.

## Testing

- 42 new unit tests pass.
- Full suite green locally against a PostgreSQL instance seeded from `noharm-ai/database`: **1172 passed** (1130 baseline + 42 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWc242XmLXjWPfveWDYehX)_