### PR TITLE
test: cover the S3 report cache and the culture report

### DIFF
--- a/tests/integration/test_reports_culture.py
+++ b/tests/integration/test_reports_culture.py
@@ -1,0 +1,289 @@
+"""Tests: GET /reports/culture
+
+The culture report joins microbiology headers with their antibiogram rows and
+groups them per (header, microorganism). Grouping, ordering and the prediction
+thresholds are the parts worth pinning down.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import session, session_commit
+from utils import status
+
+URL = "/reports/culture"
+
+# Dedicated ids so the rows never collide with seed data (both tables are empty
+# in the seed dump, but the >= 900000 range keeps that true if that changes).
+PATIENT_ID = 900001
+
+HEADER_TWO_MICROORGANISMS = 900001  # newest collection date
+HEADER_WITH_PREDICTIONS = 900002
+HEADER_WITHOUT_CULTURES = 900003  # oldest collection date
+
+DATE_TWO_MICROORGANISMS = "2024-03-12T00:00:00"
+DATE_WITH_PREDICTIONS = "2024-03-10T00:00:00"
+DATE_WITHOUT_CULTURES = "2024-03-01T00:00:00"
+
+
+def _add_header(
+    id_header: int,
+    collection_date: str,
+    exam_name: str = "HEMOCULTURA",
+    material_name: str = "SANGUE",
+    gram: str = "GRAM NEGATIVO",
+):
+    """Insert a culture header (demo.cultura_cabecalho) for the test patient.
+
+    The exam and exam-item ids mirror the header id, which is what the service
+    joins on.
+    """
+    session.execute(
+        text(
+            "INSERT INTO demo.cultura_cabecalho "
+            "(idculturacab, fkpessoa, fkexame, fkitemexame, nomeexame, nomematerial, "
+            " dtcoleta, dtliberacao, gram, dscolonia, resultprevio, complemento) "
+            "VALUES (:id, :patient, :id, :id, :exam_name, :material, "
+            " :collection_date, :release_date, :gram, 'COLONIA A', 'PREVIO A', 'OBS A')"
+        ),
+        {
+            "id": id_header,
+            "patient": PATIENT_ID,
+            "exam_name": exam_name,
+            "material": material_name,
+            "collection_date": collection_date,
+            "release_date": collection_date,
+            "gram": gram,
+        },
+    )
+
+
+def _add_culture(
+    id_header: int,
+    id_drug: int,
+    drug: str,
+    id_microorganism: int,
+    microorganism: str,
+    result: str = "S",
+    prediction: str = None,
+    predict_proba: float = None,
+    drug_proba: float = None,
+):
+    """Insert an antibiogram row (demo.cultura) attached to a header."""
+    session.execute(
+        text(
+            "INSERT INTO demo.cultura "
+            "(fkexame, fkitemexame, fkmedicamento, nomemedicamento, fkmicroorganismo, "
+            " nomemicroorganismo, qtmicroorganismo, resultado, predict, predict_proba, "
+            " medicamento_proba) "
+            "VALUES (:id, :id, :id_drug, :drug, :id_micro, :micro, '10^5', :result, "
+            " :prediction, :predict_proba, :drug_proba)"
+        ),
+        {
+            "id": id_header,
+            "id_drug": id_drug,
+            "drug": drug,
+            "id_micro": id_microorganism,
+            "micro": microorganism,
+            "result": result,
+            "prediction": prediction,
+            "predict_proba": predict_proba,
+            "drug_proba": drug_proba,
+        },
+    )
+
+
+def _cleanup():
+    """Remove every row created by this module."""
+    session.execute(
+        text("DELETE FROM demo.cultura WHERE fkexame >= 900000"),
+    )
+    session.execute(
+        text("DELETE FROM demo.cultura_cabecalho WHERE fkpessoa = :patient"),
+        {"patient": PATIENT_ID},
+    )
+    session_commit()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def culture_data():
+    """Three headers covering grouping, prediction thresholds and the empty join."""
+    _cleanup()
+
+    # --- newest header: two microorganisms under the same exam item ---
+    _add_header(HEADER_TWO_MICROORGANISMS, DATE_TWO_MICROORGANISMS)
+    _add_culture(
+        HEADER_TWO_MICROORGANISMS,
+        id_drug=1,
+        drug="VANCOMICINA",
+        id_microorganism=10,
+        microorganism="STAPHYLOCOCCUS AUREUS",
+    )
+    _add_culture(
+        HEADER_TWO_MICROORGANISMS,
+        id_drug=2,
+        drug="OXACILINA",
+        id_microorganism=20,
+        microorganism="KLEBSIELLA PNEUMONIAE",
+        result="R",
+    )
+
+    # --- middle header: one microorganism, three antibiograms with predictions ---
+    _add_header(HEADER_WITH_PREDICTIONS, DATE_WITH_PREDICTIONS)
+    _add_culture(
+        HEADER_WITH_PREDICTIONS,
+        id_drug=1,
+        drug="MEROPENEM",
+        id_microorganism=30,
+        microorganism="ESCHERICHIA COLI",
+        prediction="R",
+        predict_proba=0.9,
+        drug_proba=0.5,
+    )
+    # predict_proba below the 0.6 cutoff — prediction must be dropped
+    _add_culture(
+        HEADER_WITH_PREDICTIONS,
+        id_drug=2,
+        drug="AMPICILINA",
+        id_microorganism=30,
+        microorganism="ESCHERICHIA COLI",
+        result="R",
+        prediction="R",
+        predict_proba=0.4,
+        drug_proba=0.5,
+    )
+    # drug_proba below the 0.007 cutoff — prediction must be dropped
+    _add_culture(
+        HEADER_WITH_PREDICTIONS,
+        id_drug=3,
+        drug="CEFEPIMA",
+        id_microorganism=30,
+        microorganism="ESCHERICHIA COLI",
+        prediction="S",
+        predict_proba=0.9,
+        drug_proba=0.001,
+    )
+
+    # --- oldest header: no antibiogram rows at all (outer join) ---
+    _add_header(HEADER_WITHOUT_CULTURES, DATE_WITHOUT_CULTURES)
+
+    session_commit()
+
+    yield
+
+    _cleanup()
+
+
+def _get_report(client, headers, id_patient=PATIENT_ID):
+    return client.get(f"{URL}?idPatient={id_patient}", headers=headers)
+
+
+def _by_key(data):
+    return {item["key"]: item for item in data}
+
+
+def test_culture_report_requires_read_reports(client, navigator_headers):
+    """GET /reports/culture - returns 401 for a role without READ_REPORTS"""
+    response = _get_report(client, navigator_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_culture_report_without_patient_returns_400(client, analyst_headers):
+    """GET /reports/culture - idPatient is mandatory"""
+    response = client.get(URL, headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_culture_report_returns_empty_for_unknown_patient(client, analyst_headers):
+    """GET /reports/culture - a patient with no cultures yields an empty list"""
+    response = _get_report(client, analyst_headers, id_patient=999999999)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == []
+
+
+def test_culture_report_orders_by_collection_date_desc(client, analyst_headers):
+    """GET /reports/culture - newest collection date comes first"""
+    response = _get_report(client, analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.get_json()["data"]
+
+    assert [item["collectionDate"] for item in data] == [
+        DATE_TWO_MICROORGANISMS,
+        DATE_TWO_MICROORGANISMS,
+        DATE_WITH_PREDICTIONS,
+        DATE_WITHOUT_CULTURES,
+    ]
+
+
+def test_culture_report_splits_groups_per_microorganism(client, analyst_headers):
+    """GET /reports/culture - one header with two microorganisms yields two groups"""
+    data = _get_report(client, analyst_headers).get_json()["data"]
+    groups = _by_key(data)
+
+    staph = groups[f"{HEADER_TWO_MICROORGANISMS}-STAPHYLOCOCCUS AUREUS"]
+    klebsiella = groups[f"{HEADER_TWO_MICROORGANISMS}-KLEBSIELLA PNEUMONIAE"]
+
+    assert staph["microorganism"] == "STAPHYLOCOCCUS AUREUS"
+    assert [c["drug"] for c in staph["cultures"]] == ["VANCOMICINA"]
+
+    assert klebsiella["microorganism"] == "KLEBSIELLA PNEUMONIAE"
+    assert [c["drug"] for c in klebsiella["cultures"]] == ["OXACILINA"]
+    assert klebsiella["cultures"][0]["result"] == "R"
+
+    # both groups still describe the same header
+    assert staph["id"] == klebsiella["id"] == HEADER_TWO_MICROORGANISMS
+
+
+def test_culture_report_exposes_header_fields(client, analyst_headers):
+    """GET /reports/culture - header columns are carried into every group"""
+    data = _get_report(client, analyst_headers).get_json()["data"]
+    group = _by_key(data)[f"{HEADER_WITH_PREDICTIONS}-ESCHERICHIA COLI"]
+
+    assert group["idExamItem"] == HEADER_WITH_PREDICTIONS
+    assert group["examName"] == "HEMOCULTURA"
+    assert group["examMaterialName"] == "SANGUE"
+    assert group["gram"] == "GRAM NEGATIVO"
+    assert group["colony"] == "COLONIA A"
+    assert group["previousResult"] == "PREVIO A"
+    assert group["extraInfo"] == "OBS A"
+    assert group["releaseDate"] == DATE_WITH_PREDICTIONS
+
+
+def test_culture_report_sorts_antibiograms_by_drug(client, analyst_headers):
+    """GET /reports/culture - antibiograms inside a group are sorted by drug name"""
+    data = _get_report(client, analyst_headers).get_json()["data"]
+    group = _by_key(data)[f"{HEADER_WITH_PREDICTIONS}-ESCHERICHIA COLI"]
+
+    assert [c["drug"] for c in group["cultures"]] == [
+        "AMPICILINA",
+        "CEFEPIMA",
+        "MEROPENEM",
+    ]
+    assert group["cultures"][0]["microorganismAmount"] == "10^5"
+
+
+def test_culture_report_keeps_only_confident_predictions(client, analyst_headers):
+    """GET /reports/culture - a prediction needs predict_proba > 0.6 and drug_proba > 0.007"""
+    data = _get_report(client, analyst_headers).get_json()["data"]
+    group = _by_key(data)[f"{HEADER_WITH_PREDICTIONS}-ESCHERICHIA COLI"]
+
+    # AMPICILINA fails the predict_proba cutoff, CEFEPIMA fails the drug_proba one
+    assert len(group["predictions"]) == 1
+    assert group["predictions"][0]["drug"] == "MEROPENEM"
+    assert group["predictions"][0]["prediction"] == "R"
+    assert group["predictions"][0]["probability"] == pytest.approx(0.9, abs=1e-6)
+
+
+def test_culture_report_keeps_headers_without_antibiogram(client, analyst_headers):
+    """GET /reports/culture - a header with no culture rows is still reported"""
+    data = _get_report(client, analyst_headers).get_json()["data"]
+    group = _by_key(data)[f"{HEADER_WITHOUT_CULTURES}-None"]
+
+    assert group["id"] == HEADER_WITHOUT_CULTURES
+    assert group["microorganism"] is None
+    assert group["cultures"] == []
+    assert group["predictions"] == []

--- a/tests/unit/test_reports_cache_service.py
+++ b/tests/unit/test_reports_cache_service.py
@@ -1,0 +1,343 @@
+"""Tests: services/reports/reports_cache_service.py
+
+The S3 report cache. Every entry point validates the resource path before it
+touches S3, so the traversal guard is exercised alongside the listing and
+presigned-link behaviour.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from exception.validation_error import ValidationError
+from services.reports import reports_cache_service
+from utils import status
+
+BUCKET = "test-cache-bucket"
+
+# Paths rejected by utils.stringutils.is_valid_filename
+INVALID_PATHS = [
+    "reports/demo/../../etc/passwd",  # plain traversal
+    "reports%2fdemo%2fx",  # url-encoded separator
+    "reports/%2e%2e/demo",  # url-encoded traversal
+    "reports\\demo\\x",  # backslash separator
+    "reports/demo/x\x00.csv",  # null byte
+    "reports/demo/x y.csv",  # space (outside the allowed charset)
+    "",  # empty
+]
+
+
+@pytest.fixture
+def s3_mock():
+    """Replace the boto3 client used by the service and pin the bucket name"""
+    client = MagicMock()
+    with (
+        patch.object(reports_cache_service, "_get_client", return_value=client),
+        patch.object(reports_cache_service.Config, "CACHE_BUCKET_NAME", BUCKET),
+    ):
+        yield client
+
+
+def _head_object_response(last_modified: str):
+    """Shape of the head_object payload the service reads the timestamp from"""
+    return {"ResponseMetadata": {"HTTPHeaders": {"last-modified": last_modified}}}
+
+
+def _client_error():
+    return ClientError({"Error": {"Code": "404"}}, "HeadObject")
+
+
+# ---------------------------------------------------------------------------
+# resource path validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("resource_path", INVALID_PATHS)
+def test_generate_link_rejects_invalid_path(s3_mock, resource_path):
+    """generate_link refuses a path that fails the filename guard"""
+    with pytest.raises(ValidationError) as exc:
+        reports_cache_service.generate_link(resource_path=resource_path)
+
+    assert exc.value.code == "errors.invalidFilename"
+    assert exc.value.httpStatus == status.HTTP_400_BAD_REQUEST
+    s3_mock.generate_presigned_url.assert_not_called()
+    s3_mock.head_object.assert_not_called()
+
+
+@pytest.mark.parametrize("resource_path", INVALID_PATHS)
+def test_get_cache_data_rejects_invalid_path(s3_mock, resource_path):
+    """get_cache_data refuses a path that fails the filename guard"""
+    with pytest.raises(ValidationError) as exc:
+        reports_cache_service.get_cache_data(resource_path=resource_path)
+
+    assert exc.value.code == "errors.invalidFilename"
+    s3_mock.head_object.assert_not_called()
+
+
+@pytest.mark.parametrize("report", INVALID_PATHS)
+def test_list_available_reports_rejects_invalid_report(s3_mock, report):
+    """list_available_reports refuses a report name that fails the filename guard"""
+    with pytest.raises(ValidationError) as exc:
+        reports_cache_service.list_available_reports(schema="demo", report=report)
+
+    assert exc.value.code == "errors.invalidFilename"
+    s3_mock.list_objects_v2.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_cache_data
+# ---------------------------------------------------------------------------
+
+
+def test_get_cache_data_returns_timestamp_shifted_to_local_time(s3_mock):
+    """The S3 last-modified header (UTC) is reported 3 hours back, without a tzinfo"""
+    s3_mock.head_object.return_value = _head_object_response(
+        "Wed, 15 May 2024 12:30:00 GMT"
+    )
+
+    result = reports_cache_service.get_cache_data(
+        resource_path="reports/demo/GENERAL/current.gz"
+    )
+
+    assert result == {"exists": True, "updatedAt": "2024-05-15T09:30:00"}
+    s3_mock.head_object.assert_called_once_with(
+        Bucket=BUCKET, Key="reports/demo/GENERAL/current.gz"
+    )
+
+
+def test_get_cache_data_reports_missing_object(s3_mock):
+    """A ClientError from head_object means the cached report is not there yet"""
+    s3_mock.head_object.side_effect = _client_error()
+
+    result = reports_cache_service.get_cache_data(
+        resource_path="reports/demo/GENERAL/current.gz"
+    )
+
+    assert result == {"exists": False, "updatedAt": None}
+
+
+# ---------------------------------------------------------------------------
+# generate_link
+# ---------------------------------------------------------------------------
+
+
+def test_generate_link_returns_presigned_url_when_object_exists(s3_mock):
+    """An existing object yields a short-lived presigned GET url"""
+    s3_mock.head_object.return_value = _head_object_response(
+        "Wed, 15 May 2024 12:30:00 GMT"
+    )
+    s3_mock.generate_presigned_url.return_value = "https://s3.example/signed"
+
+    link = reports_cache_service.generate_link(
+        resource_path="reports/demo/GENERAL/current.gz"
+    )
+
+    assert link == "https://s3.example/signed"
+    s3_mock.generate_presigned_url.assert_called_once_with(
+        "get_object",
+        Params={"Bucket": BUCKET, "Key": "reports/demo/GENERAL/current.gz"},
+        ExpiresIn=100,
+    )
+
+
+def test_generate_link_returns_none_when_object_is_missing(s3_mock):
+    """No cached object means no link — and no signing call"""
+    s3_mock.head_object.side_effect = _client_error()
+
+    link = reports_cache_service.generate_link(
+        resource_path="reports/demo/GENERAL/current.gz"
+    )
+
+    assert link is None
+    s3_mock.generate_presigned_url.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# list_available_reports
+# ---------------------------------------------------------------------------
+
+
+def _s3_object(key: str, last_modified: datetime = datetime(2024, 5, 15, 10, 0, 0)):
+    return {"Key": key, "LastModified": last_modified}
+
+
+def test_list_available_reports_drops_current_parquet_and_newest(s3_mock):
+    """Only dated .gz snapshots are listed, newest first, minus the most recent one.
+
+    The newest snapshot is dropped because it is already served as `current`.
+    """
+    s3_mock.list_objects_v2.return_value = {
+        "Contents": [
+            _s3_object("reports/demo/GENERAL/2024-05-01.gz"),
+            _s3_object("reports/demo/GENERAL/2024-05-03.gz"),
+            _s3_object("reports/demo/GENERAL/2024-05-02.gz"),
+            _s3_object("reports/demo/GENERAL/current.gz"),
+            _s3_object("reports/demo/GENERAL/2024-05-04.parquet"),
+        ]
+    }
+
+    reports = reports_cache_service.list_available_reports(
+        schema="demo", report="GENERAL"
+    )
+
+    assert [r["name"] for r in reports] == ["2024-05-02", "2024-05-01"]
+    s3_mock.list_objects_v2.assert_called_once_with(
+        Bucket=BUCKET, Prefix="reports/demo/GENERAL/"
+    )
+
+
+def test_list_available_reports_exposes_last_modified_as_iso(s3_mock):
+    """Each entry carries the S3 LastModified timestamp in ISO format"""
+    s3_mock.list_objects_v2.return_value = {
+        "Contents": [
+            _s3_object("reports/demo/GENERAL/2024-05-02.gz"),
+            _s3_object(
+                "reports/demo/GENERAL/2024-05-01.gz", datetime(2024, 5, 1, 7, 15, 0)
+            ),
+        ]
+    }
+
+    reports = reports_cache_service.list_available_reports(
+        schema="demo", report="GENERAL"
+    )
+
+    assert reports == [{"name": "2024-05-01", "updateAt": "2024-05-01T07:15:00"}]
+
+
+def test_list_available_reports_returns_empty_when_only_current_exists(s3_mock):
+    """A bucket holding just `current` has no historical snapshots to offer"""
+    s3_mock.list_objects_v2.return_value = {
+        "Contents": [_s3_object("reports/demo/GENERAL/current.gz")]
+    }
+
+    assert (
+        reports_cache_service.list_available_reports(schema="demo", report="GENERAL")
+        == []
+    )
+
+
+def test_list_available_reports_returns_empty_for_single_snapshot(s3_mock):
+    """A lone snapshot is the current one, so nothing is left to list"""
+    s3_mock.list_objects_v2.return_value = {
+        "Contents": [_s3_object("reports/demo/GENERAL/2024-05-01.gz")]
+    }
+
+    assert (
+        reports_cache_service.list_available_reports(schema="demo", report="GENERAL")
+        == []
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_available_custom_reports
+# ---------------------------------------------------------------------------
+
+
+# The service builds this placeholder for the not-yet-generated report of the
+# current day. NOTE: it is wrapped in a 1-tuple by a trailing comma in
+# reports_cache_service.list_available_custom_reports, so it reaches the caller
+# as a tuple rather than a dict. The assertions below pin the shape that
+# currently ships; the tuple looks unintended given the sibling entries are
+# plain dicts.
+def _pending_today():
+    return (
+        {
+            "name": datetime.now().strftime("%Y-%m-%d"),
+            "filename": None,
+            "updateAt": None,
+            "ready": False,
+        },
+    )
+
+
+def test_list_available_custom_reports_without_contents_returns_pending_today(s3_mock):
+    """An empty prefix still advertises today's report as pending"""
+    s3_mock.list_objects_v2.return_value = {}
+
+    reports = reports_cache_service.list_available_custom_reports(
+        schema="demo", id_report=7
+    )
+
+    assert reports == [_pending_today()]
+    s3_mock.list_objects_v2.assert_called_once_with(
+        Bucket=BUCKET, Prefix="reports/demo/CUSTOM/7/"
+    )
+
+
+def test_list_available_custom_reports_ignores_non_csv_entries(s3_mock):
+    """Entries that are not csv exports are not reports the user can download"""
+    s3_mock.list_objects_v2.return_value = {
+        "Contents": [
+            _s3_object("reports/demo/CUSTOM/7/data.parquet"),
+            _s3_object("reports/demo/CUSTOM/7/meta.json"),
+        ]
+    }
+
+    assert (
+        reports_cache_service.list_available_custom_reports(schema="demo", id_report=7)
+        == []
+    )
+
+
+def test_list_available_custom_reports_strips_prefix_and_extension(s3_mock):
+    """The display name drops the csv_ prefix and the .csv/.gz extensions"""
+    s3_mock.list_objects_v2.return_value = {
+        "Contents": [
+            _s3_object(
+                "reports/demo/CUSTOM/7/csv_2024-05-01.csv.gz",
+                datetime(2024, 5, 1, 7, 15, 0),
+            )
+        ]
+    }
+
+    reports = reports_cache_service.list_available_custom_reports(
+        schema="demo", id_report=7
+    )
+
+    # today's pending placeholder is prepended because the newest file is older
+    assert reports[0] == _pending_today()
+    assert reports[1] == {
+        "name": "2024-05-01",
+        "filename": "csv_2024-05-01.csv.gz",
+        "updateAt": "2024-05-01T07:15:00",
+        "ready": True,
+    }
+
+
+def test_list_available_custom_reports_sorts_newest_first(s3_mock):
+    """Generated reports are listed newest first"""
+    s3_mock.list_objects_v2.return_value = {
+        "Contents": [
+            _s3_object("reports/demo/CUSTOM/7/csv_2024-05-01.csv"),
+            _s3_object("reports/demo/CUSTOM/7/csv_2024-05-03.csv"),
+            _s3_object("reports/demo/CUSTOM/7/csv_2024-05-02.csv"),
+        ]
+    }
+
+    reports = reports_cache_service.list_available_custom_reports(
+        schema="demo", id_report=7
+    )
+
+    assert [r["name"] for r in reports[1:]] == [
+        "2024-05-03",
+        "2024-05-02",
+        "2024-05-01",
+    ]
+
+
+def test_list_available_custom_reports_skips_placeholder_when_today_is_ready(s3_mock):
+    """No pending placeholder once today's report has been generated"""
+    today = datetime.now().strftime("%Y-%m-%d")
+    s3_mock.list_objects_v2.return_value = {
+        "Contents": [_s3_object(f"reports/demo/CUSTOM/7/csv_{today}.csv")]
+    }
+
+    reports = reports_cache_service.list_available_custom_reports(
+        schema="demo", id_report=7
+    )
+
+    assert len(reports) == 1
+    assert reports[0]["name"] == today
+    assert reports[0]["ready"] is True


### PR DESCRIPTION
## Summary

Adds test coverage for two features that were effectively untested (21% statement coverage each). No production code is changed — this PR is tests only.

| Module | Before | After |
| --- | --- | --- |
| `services/reports/reports_cache_service.py` | 21% | 98% |
| `services/reports/reports_culture_service.py` | 21% | 98% |

Suite goes from 1172 to 1215 tests, all green.

## 1. S3 report cache — unit tests

`tests/unit/test_reports_cache_service.py` (34 tests). The S3 client is isolated behind `_get_client()`, so the whole module unit-tests cleanly with a stubbed client and no DB.

- **Resource-path guard.** Every entry point (`generate_link`, `get_cache_data`, `list_available_reports`) is checked against path traversal, URL-encoded traversal and separators, backslashes, null bytes, out-of-charset characters, and the empty string — asserting both the `errors.invalidFilename` / 400 `ValidationError` **and** that no S3 call is made.
- **`get_cache_data`.** The `last-modified` header is parsed and shifted back 3 hours with the tzinfo stripped; a `ClientError` degrades to `{"exists": False, "updatedAt": None}`.
- **`generate_link`.** Returns a presigned GET url (bucket/key/`ExpiresIn=100` asserted) when the object exists, and `None` — with no signing call — when it does not.
- **`list_available_reports`.** `current` and parquet entries are filtered out, `.gz` is stripped, entries are sorted newest-first and the newest is dropped (it is already served as `current`); the empty cases return `[]`.
- **`list_available_custom_reports`.** Non-csv keys are ignored, the `csv_` prefix and `.csv`/`.gz` extensions are stripped, entries sort newest-first, and today's pending placeholder is prepended only when today's report has not been generated yet.

## 2. Microbiology culture report — integration tests

`tests/integration/test_reports_culture.py` (9 tests) drive `GET /reports/culture` end to end, so the outer join, the ordering in the query, and the grouping in `_group_culture_results` are all exercised together. A module-scoped fixture seeds three headers (ids ≥ 900000, patient 900001) and cleans up after itself, so the suite stays re-runnable — the culture tables are empty in the seed dump.

- Permission gating (401 for a role without `READ_REPORTS`) and the mandatory `idPatient` (400).
- An unknown patient returns an empty list.
- Groups are ordered by collection date descending.
- One header carrying two microorganisms splits into two groups keyed `{header}-{microorganism}`, both still pointing at the same header id.
- Header columns (exam name, material, gram, colony, previous result, extra info, release date) are carried into every group.
- Antibiograms inside a group are sorted by drug name.
- The prediction thresholds hold: of three rows with a prediction, only the one clearing both `predict_proba > 0.6` and `drug_proba > 0.007` is kept.
- A header with no antibiogram rows is still reported, keyed `{header}-None` with empty `cultures`/`predictions`.

## Verification

Tests were run against a local PostgreSQL 16 instance loaded from `noharm-ai/database` (same SQL files as CI): full suite green, and re-running the new integration module twice in a row passes, confirming cleanup works. Each new test file was also mutation-checked — loosening the prediction threshold and reversing the report sort order both make the new tests fail, so they are not vacuous.

## Note for the reviewer

`reports_cache_service.list_available_custom_reports` builds its "pending today" placeholder with a trailing comma:

```python
current_report = (
    {"name": ..., "filename": None, "updateAt": None, "ready": False},
)
```

That makes it a 1-tuple, so it reaches the caller wrapped in an extra array while its siblings in the same list are plain dicts. It looks unintended, but it is existing shipped behaviour that the frontend may already work around, so this PR pins the current shape and flags it rather than changing it. Happy to fix it in a follow-up if you confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQpfFxjJMo5gwdLByV4BZn)_