### PR TITLE
test: cover admin substances and admin exam configuration

### DIFF
--- a/tests/integration/test_admin_exam.py
+++ b/tests/integration/test_admin_exam.py
@@ -1,0 +1,792 @@
+"""Integration tests for the /admin/exam endpoints (admin_exam_service).
+
+Covers the segment-exam configuration: listing, single lookup, upsert rules,
+ordering, copying between segments, the global exam catalog and the
+most-frequent helper.
+
+demo.segmentoexame has no seed data, so every row asserted here is created by
+this module. Segments use the 991x range and exam types the ``zzt`` prefix.
+"""
+
+import json
+
+import pytest
+
+from tests.utils.utils_test_admin_exam import (
+    create_test_global_exam,
+    create_test_segment,
+    create_test_segment_exam,
+    delete_global_exams,
+    delete_segment_exams,
+    delete_segment_exams_by_type,
+    delete_segments,
+    get_segment_exam_row,
+    get_segment_exam_types,
+)
+from utils import status
+
+LIST_URL = "/admin/exam/list"
+GET_URL = "/admin/exam/get"
+UPSERT_URL = "/admin/exam/upsert"
+ORDER_URL = "/admin/exam/order"
+COPY_URL = "/admin/exam/copy"
+TYPES_URL = "/admin/exam/types"
+GLOBAL_URL = "/admin/exam/list-global"
+MOST_FREQUENT_URL = "/admin/exam/most-frequent"
+MOST_FREQUENT_ADD_URL = "/admin/exam/most-frequent/add"
+
+# Segments reserved for this module. 1 and 2 are seed segments and 9901/9902
+# belong to test_admin_protocol.py.
+_SEG_ORIGIN = 9911
+_SEG_ADULT = 9912  # copy destination, tp_segmento = 1
+_SEG_PEDIATRIC = 9913  # copy destination, tp_segmento = 2
+_SEG_UNAUTHORIZED = 9914  # no usuario_autorizacao row for the demo user
+_SEG_UPSERT = 9915
+
+_ALL_SEGMENTS = (
+    _SEG_ORIGIN,
+    _SEG_ADULT,
+    _SEG_PEDIATRIC,
+    _SEG_UNAUTHORIZED,
+    _SEG_UPSERT,
+)
+
+# Exam types owned by this module
+_TYPE_REFERENCED = "zzta"  # points at the global catalog through tpexame_ref
+_TYPE_PLAIN = "zztb"  # no reference, copied verbatim
+_TYPE_NEW = "zztnew"
+_GLOBAL_TYPE = "zztref"
+
+# Values stored on the origin segment, overwritten by the catalog on copy
+_ORIGIN_MIN = 50
+_ORIGIN_MAX = 60
+_ORIGIN_REF = "origin ref"
+
+# Values held by the global catalog entry
+_GLOBAL_MIN_ADULT = 1
+_GLOBAL_MAX_ADULT = 2
+_GLOBAL_REF_ADULT = "adult ref"
+_GLOBAL_MIN_PEDIATRIC = 3
+_GLOBAL_MAX_PEDIATRIC = 4
+_GLOBAL_REF_PEDIATRIC = "pediatric ref"
+
+# The types get_exam_types always reports, regardless of collected results
+_CALCULATED_TYPES = ["mdrd", "ckd", "ckd21", "cg", "swrtz2", "swrtz1"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def seed_exam_config():
+    """Create the segments, the global catalog entry and the origin exams."""
+    create_test_segment(_SEG_ORIGIN, "ZZTest Segment Origin", tp_segment=1)
+    create_test_segment(_SEG_ADULT, "ZZTest Segment Adult", tp_segment=1)
+    create_test_segment(_SEG_PEDIATRIC, "ZZTest Segment Pediatric", tp_segment=2)
+    create_test_segment(_SEG_UNAUTHORIZED, "ZZTest Segment Unauthorized", tp_segment=1)
+    create_test_segment(_SEG_UPSERT, "ZZTest Segment Upsert", tp_segment=1)
+
+    create_test_global_exam(
+        _GLOBAL_TYPE,
+        "ZZTest Global Exam",
+        min_adult=_GLOBAL_MIN_ADULT,
+        max_adult=_GLOBAL_MAX_ADULT,
+        ref_adult=_GLOBAL_REF_ADULT,
+        min_pediatric=_GLOBAL_MIN_PEDIATRIC,
+        max_pediatric=_GLOBAL_MAX_PEDIATRIC,
+        ref_pediatric=_GLOBAL_REF_PEDIATRIC,
+    )
+
+    # ordered by name: "ZZTest Exam A" then "ZZTest Exam B"
+    create_test_segment_exam(
+        _SEG_ORIGIN,
+        _TYPE_REFERENCED,
+        name="ZZTest Exam A",
+        initials="ZA",
+        min=_ORIGIN_MIN,
+        max=_ORIGIN_MAX,
+        ref=_ORIGIN_REF,
+        order=2,
+        tp_exam_ref=_GLOBAL_TYPE,
+    )
+    create_test_segment_exam(
+        _SEG_ORIGIN,
+        _TYPE_PLAIN,
+        name="ZZTest Exam B",
+        initials="ZB",
+        min=70,
+        max=80,
+        ref="origin ref b",
+        order=1,
+    )
+
+    yield
+
+    delete_segment_exams(_ALL_SEGMENTS)
+    delete_segment_exams_by_type((_TYPE_REFERENCED, _TYPE_PLAIN, _TYPE_NEW))
+    delete_segments(_ALL_SEGMENTS)
+    delete_global_exams((_GLOBAL_TYPE,))
+
+
+@pytest.fixture
+def clean_destinations():
+    """Empty the copy destinations before and after a copy test."""
+    delete_segment_exams((_SEG_ADULT, _SEG_PEDIATRIC))
+    yield
+    delete_segment_exams((_SEG_ADULT, _SEG_PEDIATRIC))
+
+
+@pytest.fixture
+def clean_upsert_segment():
+    """Empty the segment the upsert/order tests write to."""
+    delete_segment_exams((_SEG_UPSERT, _SEG_UNAUTHORIZED))
+    yield
+    delete_segment_exams((_SEG_UPSERT, _SEG_UNAUTHORIZED))
+
+
+def _post(client, headers, url, payload):
+    return client.post(url, data=json.dumps(payload), headers=headers)
+
+
+def _data(response):
+    return response.get_json()["data"]
+
+
+def _upsert(client, headers, **payload):
+    body = {"idSegment": _SEG_UPSERT, "type": _TYPE_NEW}
+    body.update(payload)
+
+    return _post(client, headers, UPSERT_URL, body)
+
+
+# ---------------------------------------------------------------------------
+# listing
+# ---------------------------------------------------------------------------
+
+
+def test_list_returns_segment_exams_ordered_by_name(client, admin_headers):
+    """List: a segment's exams come back ordered by name with the segment attached"""
+    response = _post(client, admin_headers, LIST_URL, {"idSegment": _SEG_ORIGIN})
+
+    assert response.status_code == status.HTTP_200_OK
+    exams = _data(response)
+    assert [e["type"] for e in exams] == [_TYPE_REFERENCED, _TYPE_PLAIN]
+
+    first = exams[0]
+    assert first["idSegment"] == _SEG_ORIGIN
+    assert first["segment"] == "ZZTest Segment Origin"
+    assert first["name"] == "ZZTest Exam A"
+    assert first["initials"] == "ZA"
+    assert first["min"] == _ORIGIN_MIN
+    assert first["max"] == _ORIGIN_MAX
+    assert first["ref"] == _ORIGIN_REF
+    assert first["order"] == 2
+    assert first["active"] is True
+    assert first["tpExamRef"] == _GLOBAL_TYPE
+
+
+def test_list_of_a_segment_without_exams_is_empty(client, admin_headers):
+    """List: a segment with no configured exams returns an empty list"""
+    response = _post(client, admin_headers, LIST_URL, {"idSegment": _SEG_UNAUTHORIZED})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response) == []
+
+
+def test_list_requires_a_read_config_exams_permission(client, viewer_headers):
+    """List: a role without READ_CONFIG_EXAMS is rejected"""
+    response = _post(client, viewer_headers, LIST_URL, {"idSegment": _SEG_ORIGIN})
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_get_returns_a_single_exam_matching_case_insensitively(client, admin_headers):
+    """Get: the requested exam type is matched lowercased"""
+    response = _post(
+        client,
+        admin_headers,
+        GET_URL,
+        {"idSegment": _SEG_ORIGIN, "examType": _TYPE_REFERENCED.upper()},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = _data(response)
+    assert data["type"] == _TYPE_REFERENCED
+    assert data["segment"] == "ZZTest Segment Origin"
+    assert data["tpExamRef"] == _GLOBAL_TYPE
+
+
+def test_get_unknown_exam_returns_not_found(client, admin_headers):
+    """Get: an exam type the segment does not configure returns 404"""
+    response = _post(
+        client,
+        admin_headers,
+        GET_URL,
+        {"idSegment": _SEG_ORIGIN, "examType": "zzt-unknown"},
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.get_json()["code"] == "errors.notFound"
+
+
+def test_get_rejects_a_payload_without_the_exam_type(client, admin_headers):
+    """Get: a payload missing examType fails pydantic validation"""
+    response = _post(client, admin_headers, GET_URL, {"idSegment": _SEG_ORIGIN})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["message"] == "Parâmetros inválidos"
+
+
+# ---------------------------------------------------------------------------
+# upsert
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_creates_a_segment_exam(client, admin_headers, clean_upsert_segment):
+    """Upsert: an exam the segment does not have yet is created"""
+    response = _upsert(
+        client,
+        admin_headers,
+        initials="NW",
+        name="ZZTest New Exam",
+        min=1,
+        max=9,
+        ref="new ref",
+        active=True,
+        tpExamRef=_GLOBAL_TYPE,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response)["segment"] == "ZZTest Segment Upsert"
+
+    row = get_segment_exam_row(_SEG_UPSERT, _TYPE_NEW)
+    assert row is not None
+    assert row.nome == "ZZTest New Exam"
+    assert row.abrev == "NW"
+    assert row.min == 1
+    assert row.max == 9
+    assert row.referencia == "new ref"
+    assert row.ativo is True
+    assert row.tpexame_ref == _GLOBAL_TYPE
+    # the insert path never assigns a position — ordering is a separate call
+    assert row.posicao is None
+
+
+def test_upsert_lowercases_the_exam_type(client, admin_headers, clean_upsert_segment):
+    """Upsert: the exam type is normalized to lowercase before being stored"""
+    response = _upsert(client, admin_headers, type=_TYPE_NEW.upper(), name="ZZTest Upper")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response)["type"] == _TYPE_NEW
+    assert get_segment_exam_row(_SEG_UPSERT, _TYPE_NEW) is not None
+
+
+def test_upsert_updates_an_existing_segment_exam(
+    client, admin_headers, clean_upsert_segment
+):
+    """Upsert: a second call on the same type edits the stored exam"""
+    create_test_segment_exam(
+        _SEG_UPSERT,
+        _TYPE_NEW,
+        name="ZZTest Before",
+        initials="BF",
+        min=1,
+        max=2,
+        ref="before",
+        order=7,
+        active=True,
+    )
+
+    response = _upsert(
+        client,
+        admin_headers,
+        name="ZZTest After",
+        initials="AF",
+        min=3,
+        max=4,
+        ref="after",
+        active=False,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    row = get_segment_exam_row(_SEG_UPSERT, _TYPE_NEW)
+    assert row.nome == "ZZTest After"
+    assert row.abrev == "AF"
+    assert row.min == 3
+    assert row.max == 4
+    assert row.referencia == "after"
+    assert row.ativo is False
+    # the update path leaves the position untouched
+    assert row.posicao == 7
+
+
+def test_upsert_keeps_omitted_fields_untouched(
+    client, admin_headers, clean_upsert_segment
+):
+    """Upsert: fields absent from the payload keep their stored value"""
+    create_test_segment_exam(
+        _SEG_UPSERT,
+        _TYPE_NEW,
+        name="ZZTest Keep",
+        initials="KP",
+        min=11,
+        max=22,
+        ref="keep ref",
+        active=True,
+    )
+
+    response = _upsert(client, admin_headers, name="ZZTest Renamed")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    row = get_segment_exam_row(_SEG_UPSERT, _TYPE_NEW)
+    assert row.nome == "ZZTest Renamed"
+    assert row.abrev == "KP"
+    assert row.min == 11
+    assert row.max == 22
+    assert row.referencia == "keep ref"
+    assert row.ativo is True
+
+
+def test_upsert_escapes_html_in_text_fields(
+    client, admin_headers, clean_upsert_segment
+):
+    """Upsert: html in the free text fields is escaped before being stored"""
+    response = _upsert(
+        client, admin_headers, name="<script>alert(1)</script>", initials="<b>"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    row = get_segment_exam_row(_SEG_UPSERT, _TYPE_NEW)
+    assert "<script>" not in row.nome
+    assert row.nome == "&lt;script&gt;alert(1)&lt;/script&gt;"
+    assert row.abrev == "&lt;b&gt;"
+
+
+@pytest.mark.parametrize(
+    "payload", [{"idSegment": None}, {"type": None}], ids=["no-segment", "no-type"]
+)
+def test_upsert_rejects_missing_parameters(client, admin_headers, payload):
+    """Upsert: idSegment and type are both required"""
+    response = _upsert(client, admin_headers, **payload)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_upsert_rejects_a_reference_longer_than_250_chars(
+    client, admin_headers, clean_upsert_segment
+):
+    """Upsert: the reference field is capped at 250 characters"""
+    response = _upsert(client, admin_headers, name="ZZTest Long Ref", ref="x" * 251)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+    assert get_segment_exam_row(_SEG_UPSERT, _TYPE_NEW) is None
+
+
+def test_upsert_accepts_a_reference_of_exactly_250_chars(
+    client, admin_headers, clean_upsert_segment
+):
+    """Upsert: a 250 character reference is still accepted"""
+    response = _upsert(client, admin_headers, name="ZZTest Max Ref", ref="x" * 250)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert get_segment_exam_row(_SEG_UPSERT, _TYPE_NEW).referencia == "x" * 250
+
+
+def test_upsert_rejects_recreating_an_active_exam(
+    client, admin_headers, clean_upsert_segment
+):
+    """Upsert: creating an exam the segment already has active is refused"""
+    create_test_segment_exam(
+        _SEG_UPSERT, _TYPE_NEW, name="ZZTest Already There", active=True
+    )
+
+    response = _upsert(client, admin_headers, new=True, name="ZZTest Duplicate")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.get_json()["code"] == "errors.businessRules"
+    assert get_segment_exam_row(_SEG_UPSERT, _TYPE_NEW).nome == "ZZTest Already There"
+
+
+def test_upsert_reactivates_an_inactive_exam(
+    client, admin_headers, clean_upsert_segment
+):
+    """Upsert: creating over an inactive exam reuses and reactivates the row"""
+    create_test_segment_exam(
+        _SEG_UPSERT, _TYPE_NEW, name="ZZTest Disabled", active=False
+    )
+
+    response = _upsert(
+        client, admin_headers, new=True, name="ZZTest Reactivated", active=True
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    row = get_segment_exam_row(_SEG_UPSERT, _TYPE_NEW)
+    assert row.nome == "ZZTest Reactivated"
+    assert row.ativo is True
+
+
+def test_upsert_rejects_an_unauthorized_segment(client, config_manager_headers):
+    """Upsert: a user without authorization on the segment is rejected"""
+    response = _post(
+        client,
+        config_manager_headers,
+        UPSERT_URL,
+        {
+            "idSegment": _SEG_UNAUTHORIZED,
+            "type": _TYPE_NEW,
+            "name": "ZZTest Forbidden",
+        },
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.get_json()["code"] == "errors.businessRules"
+    assert get_segment_exam_row(_SEG_UNAUTHORIZED, _TYPE_NEW) is None
+
+
+def test_upsert_requires_a_write_config_exams_permission(client, analyst_headers):
+    """Upsert: a read-only role cannot change the exam configuration"""
+    response = _post(
+        client,
+        analyst_headers,
+        UPSERT_URL,
+        {"idSegment": _SEG_UPSERT, "type": _TYPE_NEW, "name": "ZZTest Denied"},
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert get_segment_exam_row(_SEG_UPSERT, _TYPE_NEW) is None
+
+
+# ---------------------------------------------------------------------------
+# ordering
+# ---------------------------------------------------------------------------
+
+
+def test_set_exams_order_assigns_positions_in_the_given_order(
+    client, admin_headers, clean_upsert_segment
+):
+    """Order: the listed exams get positions following the payload order"""
+    create_test_segment_exam(_SEG_UPSERT, "zzt1", name="ZZTest One", order=5)
+    create_test_segment_exam(_SEG_UPSERT, "zzt2", name="ZZTest Two", order=5)
+    create_test_segment_exam(_SEG_UPSERT, "zzt3", name="ZZTest Three", order=5)
+
+    response = _post(
+        client,
+        admin_headers,
+        ORDER_URL,
+        {"idSegment": _SEG_UPSERT, "exams": ["zzt3", "zzt1"]},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert get_segment_exam_row(_SEG_UPSERT, "zzt3").posicao == 0
+    assert get_segment_exam_row(_SEG_UPSERT, "zzt1").posicao == 1
+    # everything left out of the payload is pushed to the end
+    assert get_segment_exam_row(_SEG_UPSERT, "zzt2").posicao == 99
+
+
+def test_set_exams_order_ignores_unknown_exam_types(
+    client, admin_headers, clean_upsert_segment
+):
+    """Order: an exam type the segment does not have is skipped"""
+    create_test_segment_exam(_SEG_UPSERT, "zzt1", name="ZZTest One", order=5)
+
+    response = _post(
+        client,
+        admin_headers,
+        ORDER_URL,
+        {"idSegment": _SEG_UPSERT, "exams": ["zzt-missing", "zzt1"]},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert get_segment_exam_row(_SEG_UPSERT, "zzt1").posicao == 1
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"idSegment": _SEG_UPSERT, "exams": []},
+        {"idSegment": None, "exams": ["zzt1"]},
+    ],
+    ids=["no-exams", "no-segment"],
+)
+def test_set_exams_order_rejects_missing_parameters(client, admin_headers, payload):
+    """Order: both the segment and a non-empty exam list are required"""
+    response = _post(client, admin_headers, ORDER_URL, payload)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_set_exams_order_rejects_an_unauthorized_segment(
+    client, config_manager_headers, clean_upsert_segment
+):
+    """Order: a user without authorization on the segment is rejected"""
+    create_test_segment_exam(_SEG_UNAUTHORIZED, "zzt1", name="ZZTest One", order=5)
+
+    response = _post(
+        client,
+        config_manager_headers,
+        ORDER_URL,
+        {"idSegment": _SEG_UNAUTHORIZED, "exams": ["zzt1"]},
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    # businessRules, not authorizationError: the role holds WRITE_CONFIG_EXAMS
+    # and is stopped by the segment authorization check
+    assert response.get_json()["code"] == "errors.businessRules"
+    assert get_segment_exam_row(_SEG_UNAUTHORIZED, "zzt1").posicao == 5
+
+
+# ---------------------------------------------------------------------------
+# copy between segments
+# ---------------------------------------------------------------------------
+
+
+def test_copy_exams_clones_the_configuration(
+    client, admin_headers, clean_destinations
+):
+    """Copy: every exam of the origin segment lands on the destination"""
+    response = _post(
+        client,
+        admin_headers,
+        COPY_URL,
+        {"idSegmentOrigin": _SEG_ORIGIN, "idSegmentDestiny": _SEG_ADULT},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response) == 2
+    assert sorted(get_segment_exam_types(_SEG_ADULT)) == sorted(
+        [_TYPE_REFERENCED, _TYPE_PLAIN]
+    )
+
+    # an exam without a catalog reference is copied verbatim
+    plain = get_segment_exam_row(_SEG_ADULT, _TYPE_PLAIN)
+    assert plain.min == 70
+    assert plain.max == 80
+    assert plain.referencia == "origin ref b"
+    assert plain.nome == "ZZTest Exam B"
+
+
+def test_copy_exams_applies_the_adult_catalog_range(
+    client, admin_headers, clean_destinations
+):
+    """Copy: a referenced exam takes the adult range of the global catalog"""
+    _post(
+        client,
+        admin_headers,
+        COPY_URL,
+        {"idSegmentOrigin": _SEG_ORIGIN, "idSegmentDestiny": _SEG_ADULT},
+    )
+
+    referenced = get_segment_exam_row(_SEG_ADULT, _TYPE_REFERENCED)
+    assert referenced.min == _GLOBAL_MIN_ADULT
+    assert referenced.max == _GLOBAL_MAX_ADULT
+    assert referenced.referencia == _GLOBAL_REF_ADULT
+    # the origin values are replaced, not carried over
+    assert referenced.min != _ORIGIN_MIN
+
+
+def test_copy_exams_applies_the_pediatric_catalog_range(
+    client, admin_headers, clean_destinations
+):
+    """Copy: a non-adult destination takes the pediatric range instead"""
+    _post(
+        client,
+        admin_headers,
+        COPY_URL,
+        {"idSegmentOrigin": _SEG_ORIGIN, "idSegmentDestiny": _SEG_PEDIATRIC},
+    )
+
+    referenced = get_segment_exam_row(_SEG_PEDIATRIC, _TYPE_REFERENCED)
+    assert referenced.min == _GLOBAL_MIN_PEDIATRIC
+    assert referenced.max == _GLOBAL_MAX_PEDIATRIC
+    assert referenced.referencia == _GLOBAL_REF_PEDIATRIC
+
+
+def test_copy_exams_keeps_exams_the_destination_already_has(
+    client, admin_headers, clean_destinations
+):
+    """Copy: exams already configured on the destination are left untouched"""
+    create_test_segment_exam(
+        _SEG_ADULT,
+        _TYPE_PLAIN,
+        name="ZZTest Preexisting",
+        min=999,
+        max=1000,
+        ref="preexisting",
+    )
+
+    response = _post(
+        client,
+        admin_headers,
+        COPY_URL,
+        {"idSegmentOrigin": _SEG_ORIGIN, "idSegmentDestiny": _SEG_ADULT},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response) == 1
+
+    kept = get_segment_exam_row(_SEG_ADULT, _TYPE_PLAIN)
+    assert kept.nome == "ZZTest Preexisting"
+    assert kept.min == 999
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"idSegmentOrigin": None, "idSegmentDestiny": _SEG_ADULT},
+        {"idSegmentOrigin": _SEG_ORIGIN, "idSegmentDestiny": _SEG_ORIGIN},
+    ],
+    ids=["no-origin", "same-segment"],
+)
+def test_copy_exams_rejects_invalid_segment_pairs(client, admin_headers, payload):
+    """Copy: the origin is required and must differ from the destination"""
+    response = _post(client, admin_headers, COPY_URL, payload)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.unauthorizedUser"
+
+
+def test_copy_exams_requires_the_copy_permission(client, config_manager_headers):
+    """Copy: a role without ADMIN_EXAMS__COPY is rejected"""
+    response = _post(
+        client,
+        config_manager_headers,
+        COPY_URL,
+        {"idSegmentOrigin": _SEG_ORIGIN, "idSegmentDestiny": _SEG_ADULT},
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert get_segment_exam_types(_SEG_ADULT) == []
+
+
+# ---------------------------------------------------------------------------
+# exam types and the global catalog
+# ---------------------------------------------------------------------------
+
+
+def test_exam_types_include_the_calculated_ones_and_recent_results(
+    client, admin_headers
+):
+    """Types: the calculated types come first, followed by recently collected ones"""
+    response = client.get(TYPES_URL, headers=admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    types = _data(response)
+    assert types[: len(_CALCULATED_TYPES)] == _CALCULATED_TYPES
+    # the seed data holds one creatinina result collected today
+    assert "cr" in types
+    # results older than 30 days are not offered
+    assert "tgo" not in types
+    assert "tgp" not in types
+    assert all(t == t.lower() for t in types)
+
+
+def test_global_exams_expose_both_age_ranges(client, admin_headers):
+    """Global: the catalog reports the adult and pediatric ranges of each exam"""
+    response = client.get(GLOBAL_URL, headers=admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    catalog = {e["tpexam"]: e for e in _data(response)}
+    assert _GLOBAL_TYPE in catalog
+
+    entry = catalog[_GLOBAL_TYPE]
+    assert entry["name"] == "ZZTest Global Exam"
+    assert entry["measureUnit"] == "mg/dL"
+    assert entry["min_adult"] == _GLOBAL_MIN_ADULT
+    assert entry["max_adult"] == _GLOBAL_MAX_ADULT
+    assert entry["ref_adult"] == _GLOBAL_REF_ADULT
+    assert entry["min_pediatric"] == _GLOBAL_MIN_PEDIATRIC
+    assert entry["max_pediatric"] == _GLOBAL_MAX_PEDIATRIC
+    assert entry["ref_pediatric"] == _GLOBAL_REF_PEDIATRIC
+
+
+def test_global_exams_omit_inactive_entries(client, admin_headers):
+    """Global: an inactive catalog entry is not offered"""
+    inactive_type = "zztoff"
+    create_test_global_exam(inactive_type, "ZZTest Inactive Global", active=False)
+
+    try:
+        response = client.get(GLOBAL_URL, headers=admin_headers)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert inactive_type not in [e["tpexam"] for e in _data(response)]
+    finally:
+        delete_global_exams((inactive_type,))
+
+
+# ---------------------------------------------------------------------------
+# most frequent exams
+# ---------------------------------------------------------------------------
+
+
+def test_most_frequent_ranks_collected_exams_by_volume(client, admin_headers):
+    """Most frequent: collected exam types are ranked by how many results they have"""
+    response = client.get(MOST_FREQUENT_URL, headers=admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    exams = _data(response)
+    assert exams != []
+    assert set(exams[0].keys()) == {"type", "count", "min", "max"}
+
+    counts = [e["count"] for e in exams]
+    assert counts == sorted(counts, reverse=True)
+
+    creatinina = next(e for e in exams if e["type"] == "CR")
+    assert creatinina["count"] > 0
+    assert creatinina["min"] <= creatinina["max"]
+
+
+def test_most_frequent_requires_its_own_permission(client, config_manager_headers):
+    """Most frequent: a role without ADMIN_EXAMS__MOST_FREQUENT is rejected"""
+    response = client.get(MOST_FREQUENT_URL, headers=config_manager_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_add_most_frequent_registers_only_the_missing_types(
+    client, admin_headers, clean_upsert_segment
+):
+    """Add most frequent: types the segment already has are not duplicated"""
+    create_test_segment_exam(
+        _SEG_UPSERT, "zzt1", name="ZZTest Existing", order=3, active=True
+    )
+
+    response = _post(
+        client,
+        admin_headers,
+        MOST_FREQUENT_ADD_URL,
+        {"idSegment": _SEG_UPSERT, "examTypes": ["ZZT1", "ZZT2"]},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert sorted(get_segment_exam_types(_SEG_UPSERT)) == ["zzt1", "zzt2"]
+
+    # the pre-existing exam keeps its configuration
+    existing = get_segment_exam_row(_SEG_UPSERT, "zzt1")
+    assert existing.nome == "ZZTest Existing"
+    assert existing.posicao == 3
+    assert existing.ativo is True
+
+    # new entries land disabled and last, waiting to be configured
+    added = get_segment_exam_row(_SEG_UPSERT, "zzt2")
+    assert added.nome == "ZZT2"
+    assert added.ativo is False
+    assert added.posicao == 99
+
+
+def test_add_most_frequent_requires_its_own_permission(
+    client, config_manager_headers, clean_upsert_segment
+):
+    """Add most frequent: a role without ADMIN_EXAMS__MOST_FREQUENT is rejected"""
+    response = _post(
+        client,
+        config_manager_headers,
+        MOST_FREQUENT_ADD_URL,
+        {"idSegment": _SEG_UPSERT, "examTypes": ["ZZT2"]},
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert get_segment_exam_types(_SEG_UPSERT) == []

--- a/tests/integration/test_admin_substance.py
+++ b/tests/integration/test_admin_substance.py
@@ -1,0 +1,453 @@
+"""Integration tests for the /admin/substance endpoints (admin_substance_service).
+
+Covers the listing filters, the single-substance lookup and the upsert
+business rules. Rows live in the shared public.substancia / public.classe
+tables; the 95000+ sctid range is reserved for this module.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_admin_substance import (
+    create_test_substance,
+    create_test_substance_class,
+    get_substance_row,
+    set_substance_handling,
+)
+from utils import status
+
+LIST_URL = "/admin/substance/list"
+GET_URL = "/admin/substance"
+UPSERT_URL = "/admin/substance"
+
+# sctid range reserved for this module (>= 90000 so the session-wide cleanup in
+# tests/conftest.py also catches leftovers, but clear of the unit-conversion ids)
+_ALPHA = 95001
+_BETA = 95002
+_GAMMA = 95003
+_NEW = 95010
+_EXISTING_TO_UPDATE = 95011
+
+_ALL_SEEDED = (_ALPHA, _BETA, _GAMMA)
+_ALL_UPSERTED = (_NEW, _EXISTING_TO_UPDATE)
+
+_CLASS_A = "ZZTA"
+_CLASS_B = "ZZTB"
+
+# every seeded substance name starts with this, so a single ilike isolates them
+_NAME_PREFIX = "ZZTest Subs"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def seed_substances():
+    """Create the classes and substances this module filters over."""
+    create_test_substance_class(_CLASS_A, "ZZTest Class A")
+    create_test_substance_class(_CLASS_B, "ZZTest Class B")
+
+    # Alpha: classified, active, curated, max dose (adult) + default unit, tagged
+    create_test_substance(
+        id=_ALPHA,
+        name="ZZTest Subs Alpha",
+        id_class=_CLASS_A,
+        active=True,
+        admin_text="curated text",
+        default_measureunit="mg",
+        maxdose_adult=100,
+        tags=["zzt-shared", "zzt-alpha"],
+        updated_by=1,
+    )
+    # Beta: unclassified, active, no curation, no max dose, handling filled
+    create_test_substance(
+        id=_BETA,
+        name="ZZTest Subs Beta",
+        active=True,
+        tags=["zzt-shared"],
+        updated_by=1,
+    )
+    set_substance_handling(_BETA, json.dumps({"chemo": "S"}))
+    # Gamma: classified, inactive, max dose (pediatric weight) + default unit
+    create_test_substance(
+        id=_GAMMA,
+        name="ZZTest Subs Gamma",
+        id_class=_CLASS_B,
+        active=False,
+        default_measureunit="mg",
+        maxdose_pediatric_weight=5,
+        updated_by=1,
+    )
+
+    yield
+
+    _delete_substances(_ALL_SEEDED + _ALL_UPSERTED)
+    session.execute(
+        text("DELETE FROM public.classe WHERE idclasse IN :ids").bindparams(
+            ids=(_CLASS_A, _CLASS_B)
+        )
+    )
+    session_commit()
+
+
+@pytest.fixture
+def substance_to_update():
+    """A substance that already exists, so upsert takes the update path."""
+    create_test_substance(
+        id=_EXISTING_TO_UPDATE,
+        name="ZZTest Subs Existing",
+        id_class=_CLASS_A,
+        active=True,
+        default_measureunit="mg",
+        maxdose_adult=10,
+        updated_by=1,
+    )
+    yield _EXISTING_TO_UPDATE
+    _delete_substances((_EXISTING_TO_UPDATE,))
+
+
+@pytest.fixture
+def cleanup_new_substance():
+    """Remove the substance created by the insert path of upsert."""
+    yield _NEW
+    _delete_substances((_NEW,))
+
+
+def _delete_substances(ids):
+    session.execute(
+        text("DELETE FROM public.substancia WHERE sctid IN :ids").bindparams(ids=tuple(ids))
+    )
+    session_commit()
+
+
+def _list(client, headers, **filters):
+    """POST the listing endpoint, always narrowed to this module's substances."""
+    payload = {"name": f"{_NAME_PREFIX}%", "limit": 50, "offset": 0}
+    payload.update(filters)
+
+    return client.post(LIST_URL, data=json.dumps(payload), headers=headers)
+
+
+def _result(response):
+    """The service payload of a listing response ({count, data})."""
+    return response.get_json()["data"]
+
+
+def _ids(response):
+    """Substance ids of a listing response, in the order returned."""
+    return [item["id"] for item in _result(response)["data"]]
+
+
+def _upsert_payload(**overrides):
+    payload = {"id": _NEW, "name": "ZZTest Subs Upserted", "active": True}
+    payload.update(overrides)
+
+    return payload
+
+
+def test_list_returns_substances_ordered_by_name(client, admin_headers):
+    """List: substances come back ordered by name with the total count"""
+    response = _list(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    result = _result(response)
+    data = result["data"]
+    assert _ids(response) == [str(_ALPHA), str(_BETA), str(_GAMMA)]
+    assert result["count"] == 3
+    assert data[0]["name"] == "ZZTest Subs Alpha"
+    assert data[0]["className"] == "ZZTest Class A"
+    assert data[0]["responsible"] == "Demonstração"
+    # an unclassified substance reports no class instead of failing the join
+    assert data[1]["className"] is None
+
+
+def test_list_without_matches_returns_empty_result(client, admin_headers):
+    """List: a filter matching nothing returns count 0 and no data"""
+    response = _list(client, admin_headers, name="ZZTest Subs Nonexistent%")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _result(response) == {"count": 0, "data": []}
+
+
+def test_list_count_ignores_pagination(client, admin_headers):
+    """List: count reflects every match while data honors limit and offset"""
+    response = _list(client, admin_headers, limit=1, offset=1)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _result(response)["count"] == 3
+    assert _ids(response) == [str(_BETA)]
+
+
+def test_list_filters_by_class_list(client, admin_headers):
+    """List: idClassList keeps only substances of the given classes"""
+    response = _list(client, admin_headers, idClassList=[_CLASS_B])
+
+    assert _ids(response) == [str(_GAMMA)]
+
+
+def test_list_filters_by_class_name(client, admin_headers):
+    """List: className matches the class id"""
+    response = _list(client, admin_headers, className=_CLASS_A)
+
+    assert _ids(response) == [str(_ALPHA)]
+
+
+@pytest.mark.parametrize(
+    "has_class,expected",
+    [(True, [str(_ALPHA), str(_GAMMA)]), (False, [str(_BETA)])],
+)
+def test_list_filters_by_presence_of_class(client, admin_headers, has_class, expected):
+    """List: hasClass splits classified from unclassified substances"""
+    response = _list(client, admin_headers, hasClass=has_class)
+
+    assert _ids(response) == expected
+
+
+@pytest.mark.parametrize(
+    "has_admin_text,expected",
+    [(True, [str(_ALPHA)]), (False, [str(_BETA), str(_GAMMA)])],
+)
+def test_list_filters_by_presence_of_admin_text(
+    client, admin_headers, has_admin_text, expected
+):
+    """List: hasAdminText splits curated from uncurated substances"""
+    response = _list(client, admin_headers, hasAdminText=has_admin_text)
+
+    assert _ids(response) == expected
+
+
+def test_list_filters_by_presence_of_max_dose(client, admin_headers):
+    """List: each max dose filter looks at its own column"""
+    adult = _list(client, admin_headers, hasMaxDoseAdult=True)
+    assert _ids(adult) == [str(_ALPHA)]
+
+    pediatric_weight = _list(client, admin_headers, hasMaxDosePediatricWeight=True)
+    assert _ids(pediatric_weight) == [str(_GAMMA)]
+
+    # Alpha carries an adult dose only, so the weight variants exclude it
+    adult_weight = _list(client, admin_headers, hasMaxDoseAdultWeight=True)
+    assert _ids(adult_weight) == []
+
+    pediatric = _list(client, admin_headers, hasMaxDosePediatric=True)
+    assert _ids(pediatric) == []
+
+
+def test_list_filters_by_active_flag(client, admin_headers):
+    """List: active filters out substances with the opposite flag"""
+    actives = _list(client, admin_headers, active=True)
+    assert _ids(actives) == [str(_ALPHA), str(_BETA)]
+
+    inactives = _list(client, admin_headers, active=False)
+    assert _ids(inactives) == [str(_GAMMA)]
+
+
+def test_list_filters_by_tags_overlap(client, admin_headers):
+    """List: tags keeps substances sharing at least one of the given tags"""
+    response = _list(client, admin_headers, tags=["zzt-alpha"])
+    assert _ids(response) == [str(_ALPHA)]
+
+    shared = _list(client, admin_headers, tags=["zzt-shared"])
+    assert _ids(shared) == [str(_ALPHA), str(_BETA)]
+
+
+def test_list_filters_by_tags_not_in(client, admin_headers):
+    """List: tpSubstanceTagList=notin excludes substances carrying the tags"""
+    response = _list(
+        client, admin_headers, tags=["zzt-alpha"], tpSubstanceTagList="notin"
+    )
+
+    # Gamma has no tags at all, and coalesce treats that as an empty array
+    assert _ids(response) == [str(_BETA), str(_GAMMA)]
+
+
+def test_list_filters_by_handling_filled_and_empty(client, admin_headers):
+    """List: handlingOption switches between filled and empty handling keys"""
+    filled = _list(
+        client, admin_headers, handlingTypeList=["chemo"], handlingOption="filled"
+    )
+    assert _ids(filled) == [str(_BETA)]
+
+    empty = _list(
+        client, admin_headers, handlingTypeList=["chemo"], handlingOption="empty"
+    )
+    assert _ids(empty) == [str(_ALPHA), str(_GAMMA)]
+
+
+def test_get_substance_returns_the_full_dto(client, admin_headers):
+    """Get: a known substance returns its attributes plus class and responsible"""
+    response = client.get(f"{GET_URL}/{_ALPHA}", headers=admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.get_json()["data"]
+    assert data["id"] == str(_ALPHA)
+    assert data["name"] == "ZZTest Subs Alpha"
+    assert data["idClass"] == _CLASS_A
+    assert data["className"] == "ZZTest Class A"
+    assert data["responsible"] == "Demonstração"
+    assert data["active"] is True
+    assert data["adminText"] == "curated text"
+    assert data["maxdoseAdult"] == 100
+    assert data["defaultMeasureUnit"] == "mg"
+    assert data["tags"] == ["zzt-shared", "zzt-alpha"]
+
+
+def test_get_unknown_substance_returns_not_found(client, admin_headers):
+    """Get: an unknown substance id returns 404"""
+    response = client.get(f"{GET_URL}/99999999", headers=admin_headers)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.get_json()["code"] == "errors.notFound"
+
+
+def test_upsert_creates_a_new_substance(client, admin_headers, cleanup_new_substance):
+    """Upsert: an unknown id inserts the substance and echoes it back"""
+    payload = _upsert_payload(
+        idClass=_CLASS_A,
+        adminText="new text",
+        defaultMeasureUnit="mg",
+        maxdoseAdult=250,
+        tags=["zzt-new"],
+        divisionRange=0.5,
+        handling={"chemo": "S"},
+    )
+
+    response = client.post(UPSERT_URL, data=json.dumps(payload), headers=admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.get_json()["data"]
+    assert data["id"] == str(_NEW)
+    assert data["name"] == "ZZTest Subs Upserted"
+    assert data["className"] == "ZZTest Class A"
+    assert data["maxdoseAdult"] == 250
+    assert data["divisionRange"] == 0.5
+    assert data["handling"] == {"chemo": "S"}
+
+    row = get_substance_row(_NEW)
+    assert row is not None
+    assert row.nome == "ZZTest Subs Upserted"
+    assert row.idclasse == _CLASS_A
+    assert row.divisor_faixa == 0.5
+
+
+def test_upsert_updates_an_existing_substance(
+    client, admin_headers, substance_to_update
+):
+    """Upsert: a known id overwrites the stored attributes"""
+    payload = _upsert_payload(
+        id=substance_to_update,
+        name="ZZTest Subs Renamed",
+        active=False,
+        idClass=_CLASS_B,
+        defaultMeasureUnit="ml",
+        maxdoseAdult=42,
+    )
+
+    response = client.post(UPSERT_URL, data=json.dumps(payload), headers=admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.get_json()["data"]
+    assert data["name"] == "ZZTest Subs Renamed"
+    assert data["active"] is False
+    assert data["className"] == "ZZTest Class B"
+
+    row = get_substance_row(substance_to_update)
+    assert row.nome == "ZZTest Subs Renamed"
+    assert row.ativo is False
+    assert row.unidadepadrao == "ml"
+    assert row.dosemax_adulto == 42
+
+
+def test_upsert_stamps_the_requesting_user_as_responsible(
+    client, admin_headers, substance_to_update
+):
+    """Upsert: the substance records who last changed it"""
+    payload = _upsert_payload(
+        id=substance_to_update,
+        name="ZZTest Subs Existing",
+        defaultMeasureUnit="mg",
+        maxdoseAdult=10,
+    )
+
+    response = client.post(UPSERT_URL, data=json.dumps(payload), headers=admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["responsible"] == "User Admin"
+    assert get_substance_row(substance_to_update).update_by == 2
+
+
+def test_upsert_clears_empty_handling(
+    client, admin_headers, cleanup_new_substance
+):
+    """Upsert: an empty handling object is stored as null instead of {}"""
+    payload = _upsert_payload(handling={})
+
+    response = client.post(UPSERT_URL, data=json.dumps(payload), headers=admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["handling"] is None
+    assert get_substance_row(_NEW).manejo is None
+
+
+@pytest.mark.parametrize(
+    "dose_field",
+    [
+        "maxdoseAdult",
+        "maxdoseAdultWeight",
+        "maxdosePediatric",
+        "maxdosePediatricWeight",
+    ],
+)
+def test_upsert_rejects_max_dose_without_default_measure_unit(
+    client, admin_headers, cleanup_new_substance, dose_field
+):
+    """Upsert: any max dose requires a default measure unit"""
+    payload = _upsert_payload(**{dose_field: 10})
+
+    response = client.post(UPSERT_URL, data=json.dumps(payload), headers=admin_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+    # the rejected insert must not leak into the table
+    assert get_substance_row(_NEW) is None
+
+
+def test_upsert_rejects_payload_without_required_fields(client, admin_headers):
+    """Upsert: a payload missing name fails pydantic validation"""
+    response = client.post(
+        UPSERT_URL, data=json.dumps({"id": _NEW, "active": True}), headers=admin_headers
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["message"] == "Parâmetros inválidos"
+
+
+def test_list_requires_the_admin_substances_permission(client, analyst_headers):
+    """List: a role without ADMIN_SUBSTANCES is rejected"""
+    response = _list(client, analyst_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_get_requires_the_admin_substances_permission(client, analyst_headers):
+    """Get: a role without ADMIN_SUBSTANCES is rejected"""
+    response = client.get(f"{GET_URL}/{_ALPHA}", headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_upsert_requires_the_admin_substances_permission(client, analyst_headers):
+    """Upsert: a role without ADMIN_SUBSTANCES is rejected"""
+    response = client.post(
+        UPSERT_URL, data=json.dumps(_upsert_payload()), headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert get_substance_row(_NEW) is None
+
+
+def test_curator_can_manage_substances(client, curator_headers):
+    """List: the curator role also holds ADMIN_SUBSTANCES"""
+    response = _list(client, curator_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _ids(response) == [str(_ALPHA), str(_BETA), str(_GAMMA)]

--- a/tests/utils/utils_test_admin_exam.py
+++ b/tests/utils/utils_test_admin_exam.py
@@ -1,0 +1,172 @@
+"""Helpers to create admin-exam test fixtures in the DB.
+
+demo.segmentoexame carries no seed data, so this module owns every row it
+creates. Exam types are prefixed with ``zzt`` and segments use the 991x range
+so nothing collides with the seed segments (1, 2) or with the 9901/9902
+segments reserved by test_admin_protocol.py.
+"""
+
+from sqlalchemy import text
+
+from tests.conftest import session, session_commit
+
+
+def create_test_segment(id_segment: int, name: str, tp_segment: int = 1) -> None:
+    """Insert a segment into demo.segmento (idempotent)."""
+    session.execute(
+        text(
+            "INSERT INTO demo.segmento (idsegmento, nome, status, tp_segmento, cpoe) "
+            "VALUES (:id, :name, 1, :tp_segment, false) "
+            "ON CONFLICT (idsegmento) DO NOTHING"
+        ),
+        {"id": id_segment, "name": name, "tp_segment": tp_segment},
+    )
+    session_commit()
+
+
+def create_test_segment_exam(
+    id_segment: int,
+    type_exam: str,
+    name: str = "ZZTest Exam",
+    initials: str = "ZZ",
+    min: float = 1,
+    max: float = 10,
+    ref: str = "ref",
+    order: int = 1,
+    active: bool = True,
+    tp_exam_ref: str | None = None,
+) -> None:
+    """Insert a segment exam into demo.segmentoexame (idempotent)."""
+    session.execute(
+        text(
+            "INSERT INTO demo.segmentoexame "
+            "  (idsegmento, tpexame, tpexame_ref, abrev, nome, min, max, referencia, "
+            "   posicao, ativo, update_at, update_by) "
+            "VALUES "
+            "  (:id_segment, :type_exam, :tp_exam_ref, :initials, :name, :min, :max, "
+            "   :ref, :order, :active, now(), 1) "
+            "ON CONFLICT (idsegmento, tpexame) DO NOTHING"
+        ),
+        {
+            "id_segment": id_segment,
+            "type_exam": type_exam,
+            "tp_exam_ref": tp_exam_ref,
+            "initials": initials,
+            "name": name,
+            "min": min,
+            "max": max,
+            "ref": ref,
+            "order": order,
+            "active": active,
+        },
+    )
+    session_commit()
+
+
+def create_test_global_exam(
+    tp_exam: str,
+    name: str,
+    initials: str = "ZZ",
+    measureunit: str = "mg/dL",
+    active: bool = True,
+    min_adult: float = 1,
+    max_adult: float = 2,
+    ref_adult: str = "adult ref",
+    min_pediatric: float = 3,
+    max_pediatric: float = 4,
+    ref_pediatric: str = "pediatric ref",
+) -> None:
+    """Insert a global exam into public.exame (idempotent)."""
+    session.execute(
+        text(
+            "INSERT INTO public.exame "
+            "  (tpexame, nome, abrev, unidade, ativo, min_adulto, max_adulto, "
+            "   referencia_adulto, min_pediatrico, max_pediatrico, referencia_pediatrico, "
+            "   created_at, created_by) "
+            "VALUES "
+            "  (:tp_exam, :name, :initials, :measureunit, :active, :min_adult, :max_adult, "
+            "   :ref_adult, :min_pediatric, :max_pediatric, :ref_pediatric, now(), 1) "
+            "ON CONFLICT (tpexame) DO NOTHING"
+        ),
+        {
+            "tp_exam": tp_exam,
+            "name": name,
+            "initials": initials,
+            "measureunit": measureunit,
+            "active": active,
+            "min_adult": min_adult,
+            "max_adult": max_adult,
+            "ref_adult": ref_adult,
+            "min_pediatric": min_pediatric,
+            "max_pediatric": max_pediatric,
+            "ref_pediatric": ref_pediatric,
+        },
+    )
+    session_commit()
+
+
+def get_segment_exam_row(id_segment: int, type_exam: str):
+    """Read a segment exam straight from the DB, bypassing the service layer."""
+    return session.execute(
+        text(
+            "SELECT idsegmento, tpexame, tpexame_ref, abrev, nome, min, max, "
+            "       referencia, posicao, ativo, update_by "
+            "FROM demo.segmentoexame "
+            "WHERE idsegmento = :id_segment AND tpexame = :type_exam"
+        ),
+        {"id_segment": id_segment, "type_exam": type_exam},
+    ).first()
+
+
+def get_segment_exam_types(id_segment: int) -> list[str]:
+    """Exam types configured for a segment, ordered by name."""
+    return [
+        row[0]
+        for row in session.execute(
+            text(
+                "SELECT tpexame FROM demo.segmentoexame "
+                "WHERE idsegmento = :id_segment ORDER BY nome"
+            ),
+            {"id_segment": id_segment},
+        ).all()
+    ]
+
+
+def delete_segment_exams(id_segments) -> None:
+    """Remove every segment exam of the given segments."""
+    session.execute(
+        text("DELETE FROM demo.segmentoexame WHERE idsegmento IN :ids").bindparams(
+            ids=tuple(id_segments)
+        )
+    )
+    session_commit()
+
+
+def delete_segment_exams_by_type(type_exams) -> None:
+    """Remove segment exams of the given types across every segment."""
+    session.execute(
+        text("DELETE FROM demo.segmentoexame WHERE tpexame IN :types").bindparams(
+            types=tuple(type_exams)
+        )
+    )
+    session_commit()
+
+
+def delete_segments(id_segments) -> None:
+    """Remove the given test segments."""
+    session.execute(
+        text("DELETE FROM demo.segmento WHERE idsegmento IN :ids").bindparams(
+            ids=tuple(id_segments)
+        )
+    )
+    session_commit()
+
+
+def delete_global_exams(tp_exams) -> None:
+    """Remove the given global exams."""
+    session.execute(
+        text("DELETE FROM public.exame WHERE tpexame IN :types").bindparams(
+            types=tuple(tp_exams)
+        )
+    )
+    session_commit()

--- a/tests/utils/utils_test_admin_substance.py
+++ b/tests/utils/utils_test_admin_substance.py
@@ -1,0 +1,89 @@
+"""Helpers to create admin-substance test fixtures in the DB.
+
+Rows live in the shared ``public.substancia`` / ``public.classe`` tables.
+Substance ids in the 95000+ range are reserved for this module: they sit inside
+the ``sctid >= 90000`` window wiped by ``tests/conftest.py::_cleanup`` while
+staying clear of the 90001-90006 ids used by the unit-conversion tests.
+"""
+
+from sqlalchemy import text
+
+from tests.conftest import session, session_commit
+
+
+def create_test_substance_class(id_class: str, name: str) -> None:
+    """Insert a substance class into public.classe (idempotent)."""
+    session.execute(
+        text(
+            "INSERT INTO public.classe (idclasse, idclassemae, nome) "
+            "VALUES (:id, :id, :name) ON CONFLICT (idclasse) DO NOTHING"
+        ),
+        {"id": id_class, "name": name},
+    )
+    session_commit()
+
+
+def create_test_substance(
+    id: int,
+    name: str,
+    id_class: str | None = None,
+    active: bool = True,
+    admin_text: str | None = None,
+    default_measureunit: str | None = None,
+    maxdose_adult: float | None = None,
+    maxdose_adult_weight: float | None = None,
+    maxdose_pediatric: float | None = None,
+    maxdose_pediatric_weight: float | None = None,
+    tags: list[str] | None = None,
+    updated_by: int = 1,
+) -> None:
+    """Insert a substance row into public.substancia (idempotent)."""
+    session.execute(
+        text(
+            "INSERT INTO public.substancia "
+            "  (sctid, nome, link, idclasse, ativo, curadoria, unidadepadrao, "
+            "   dosemax_adulto, dosemax_peso_adulto, dosemax_pediatrico, "
+            "   dosemax_peso_pediatrico, tags, update_at, update_by) "
+            "VALUES "
+            "  (:id, :name, '', :id_class, :active, :admin_text, :default_measureunit, "
+            "   :maxdose_adult, :maxdose_adult_weight, :maxdose_pediatric, "
+            "   :maxdose_pediatric_weight, :tags, now(), :updated_by) "
+            "ON CONFLICT (sctid) DO NOTHING"
+        ),
+        {
+            "id": id,
+            "name": name,
+            "id_class": id_class,
+            "active": active,
+            "admin_text": admin_text,
+            "default_measureunit": default_measureunit,
+            "maxdose_adult": maxdose_adult,
+            "maxdose_adult_weight": maxdose_adult_weight,
+            "maxdose_pediatric": maxdose_pediatric,
+            "maxdose_pediatric_weight": maxdose_pediatric_weight,
+            "tags": tags,
+            "updated_by": updated_by,
+        },
+    )
+    session_commit()
+
+
+def set_substance_handling(id: int, handling: str) -> None:
+    """Set the ``manejo`` jsonb column of a substance (raw json string)."""
+    session.execute(
+        text("UPDATE public.substancia SET manejo = CAST(:handling AS jsonb) WHERE sctid = :id"),
+        {"id": id, "handling": handling},
+    )
+    session_commit()
+
+
+def get_substance_row(id: int):
+    """Read a substance straight from the DB, bypassing the service layer."""
+    return session.execute(
+        text(
+            "SELECT sctid, nome, idclasse, ativo, unidadepadrao, dosemax_adulto, "
+            "       manejo, curadoria, tags, update_by, divisor_faixa "
+            "FROM public.substancia WHERE sctid = :id"
+        ),
+        {"id": id},
+    ).first()


### PR DESCRIPTION
## Why

Two features had no test coverage at all — every endpoint of each was untested:

| Service | Before | After |
|---|---|---|
| `services/admin/admin_substance_service.py` | 16.0% | 96.2% |
| `services/admin/admin_exam_service.py` | 27.1% | 99.2% |

Suite total goes from **63.4% → 65.1%**; 67 new tests (1270 → 1337 passing).

## What

### `tests/integration/test_admin_substance.py`

Covers `/admin/substance/list`, `/admin/substance/<id>` and the `/admin/substance` upsert:

- every listing filter — name, class list, class name, `hasClass`, `hasAdminText`, each of the four max-dose columns, `active`, tags overlap and `tpSubstanceTagList=notin`, `handlingOption` filled/empty
- pagination: `count` comes from the window function and ignores `limit`/`offset`
- single lookup returns the full DTO with `className`/`responsible`, and 404s on an unknown id
- upsert insert and update paths, and that it stamps the requesting user as responsible
- the business rule that **any** max dose requires a default measure unit (parametrized over all four dose fields), asserting the rejected insert leaves no row behind
- empty `handling` is normalized to `null` rather than `{}`
- the `ADMIN_SUBSTANCES` permission gate, plus that `CURATOR` also holds it

### `tests/integration/test_admin_exam.py`

Covers `/admin/exam/list`, `/get`, `/upsert`, `/order`, `/copy`, `/types`, `/list-global`, `/most-frequent` and `/most-frequent/add`:

- segment exam listing ordered by name, and the single lookup matching the exam type case-insensitively
- upsert rules: type lowercased, html escaped in the free-text fields, reference capped at 250 chars (250 accepted / 251 rejected), refusing to recreate an already-active exam, reusing and reactivating an inactive one, omitted fields keeping their stored value, and the insert path leaving `posicao` unset
- `set_exams_order` assigning positions in payload order and pushing unlisted exams to 99
- `copy_exams` applying the **adult** vs **pediatric** range of the global catalog based on the destination's `tp_segmento`, copying unreferenced exams verbatim, and skipping exams the destination already has (`on conflict do nothing`)
- the global catalog exposing both age ranges and omitting inactive entries
- `add_most_frequent` registering only the missing types, disabled and last
- permission gates for `READ_CONFIG_EXAMS` / `WRITE_CONFIG_EXAMS` / `ADMIN_EXAMS__COPY` / `ADMIN_EXAMS__MOST_FREQUENT`, and the segment-authorization check (asserting `errors.businessRules` rather than `error.authorizationError`, so the test can't pass for the wrong reason)

### Test data

Two helper modules, `tests/utils/utils_test_admin_substance.py` and `tests/utils/utils_test_admin_exam.py`, follow the existing `tests/utils/` pattern. Every row asserted on is created by the tests themselves and torn down by module-scoped fixtures — `demo.segmentoexame` and `public.exame` carry no seed data, so nothing is assumed about the fixture DB.

Reserved id ranges avoid collisions with seed data and with other modules:

- substances: `sctid >= 95000` — inside the `>= 90000` window the session cleanup already wipes, clear of the 90001-90006 ids used by `test_admin_unit_conversion.py`
- segments: `991x` — clear of the seed segments (1, 2) and of the 9901/9902 reserved by `test_admin_protocol.py`
- exam types and names: `zzt` / `ZZTest` prefix

## Verification

- Full suite green against a Postgres loaded from `noharm-ai/database` with the same SQL files CI uses: **1337 passed**
- Both new modules re-run cleanly back to back and leave no rows behind in `public.substancia`, `public.classe`, `demo.segmentoexame`, `demo.segmento` or `public.exame`
- Mutation-checked the two central business rules — relaxing the 250-char reference cap and dropping the max-dose/measure-unit rule each make the corresponding tests fail

No production code changed; this PR is tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wvNaFB2XpkYntCJnWf6WX

---
_Generated by [Claude Code](https://claude.ai/code/session_013wvNaFB2XpkYntCJnWf6WX)_