### PR TITLE
test: cover admin global memory and admin tag management

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,18 @@ def _cleanup():
         text("DELETE FROM demo.prescricao_evolucao WHERE fkprescricao = 20")
     )
 
+    # Admin global-memory test records (reserved kind prefix, includes _bkp rows)
+    session.execute(text("DELETE FROM public.memoria WHERE tipo LIKE 'zztest-gm%'"))
+
+    # Admin tag test records (reserved uppercase name prefixes)
+    session.execute(
+        text(
+            "DELETE FROM demo.marcador "
+            "WHERE nome LIKE 'ZZTEST!_ADMIN%' ESCAPE '!' "
+            "OR nome LIKE 'NAVEGACAO!_ZZTEST%' ESCAPE '!'"
+        )
+    )
+
     # Unit-conversion test records (IDs >= 90000)
     session.execute(text("DELETE FROM demo.medatributos WHERE fkmedicamento >= 90000"))
     session.execute(

--- a/tests/integration/test_admin_global_memory.py
+++ b/tests/integration/test_admin_global_memory.py
@@ -1,0 +1,238 @@
+"""Integration tests for the /admin/global-memory endpoints.
+
+Covers admin_global_memory_service: the kind-filtered listing and the update
+routine that keeps a "<kind>_bkp" snapshot of the previous value. Records live
+in the shared public.memoria table, so every row created here uses a kind
+starting with the reserved prefix below.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import session, session_commit
+from utils import status
+
+LIST_URL = "/admin/global-memory/list"
+UPDATE_URL = "/admin/global-memory/update"
+
+# every kind written by this module starts with this prefix, so a single
+# LIKE clause isolates the rows (including the "_bkp" snapshots)
+_PREFIX = "zztest-gm"
+
+_ALPHA_KIND = f"{_PREFIX}-alpha"
+_BETA_KIND = f"{_PREFIX}-beta"
+_GAMMA_KIND = f"{_PREFIX}-gamma"
+
+_ALPHA_VALUE = {"label": "alpha", "enabled": True}
+_BETA_VALUE = {"label": "beta", "items": [1, 2, 3]}
+_GAMMA_VALUE = {"label": "gamma"}
+
+# public.usuario id of the user behind the admin_headers fixture
+_ADMIN_USER_ID = 2
+
+
+def _insert(kind: str, value: dict) -> int:
+    """Insert a global memory row and return its generated key."""
+    result = session.execute(
+        text(
+            "INSERT INTO public.memoria (tipo, valor, update_at, update_by) "
+            "VALUES (:kind, CAST(:value AS json), now(), 1) RETURNING idmemoria"
+        ),
+        {"kind": kind, "value": json.dumps(value)},
+    )
+    return result.scalar()
+
+
+def _rows(kind: str):
+    """Return (value, update_by) for every row of a given kind."""
+    result = session.execute(
+        text(
+            "SELECT valor, update_by FROM public.memoria WHERE tipo = :kind "
+            "ORDER BY idmemoria"
+        ),
+        {"kind": kind},
+    )
+    return result.all()
+
+
+def _cleanup():
+    """Remove every row this module may have created."""
+    session.execute(
+        text("DELETE FROM public.memoria WHERE tipo LIKE :prefix"),
+        {"prefix": f"{_PREFIX}%"},
+    )
+    session_commit()
+
+
+@pytest.fixture(autouse=True)
+def seed_global_memory():
+    """Recreate the reserved rows before each test and drop them afterwards."""
+    _cleanup()
+
+    keys = {
+        _ALPHA_KIND: _insert(_ALPHA_KIND, _ALPHA_VALUE),
+        _BETA_KIND: _insert(_BETA_KIND, _BETA_VALUE),
+        _GAMMA_KIND: _insert(_GAMMA_KIND, _GAMMA_VALUE),
+    }
+    session_commit()
+
+    yield keys
+
+    _cleanup()
+
+
+def _list(client, headers, kinds):
+    """Call the listing endpoint with the given kinds."""
+    return client.post(LIST_URL, data=json.dumps({"kinds": kinds}), headers=headers)
+
+
+def _update(client, headers, key, kind, value):
+    """Call the update endpoint."""
+    return client.post(
+        UPDATE_URL,
+        data=json.dumps({"key": key, "kind": kind, "value": value}),
+        headers=headers,
+    )
+
+
+def test_list_requires_admin_permission(client, analyst_headers):
+    """Listing global memory without ADMIN_NZERO is refused [401 UNAUTHORIZED]."""
+    response = _list(client, analyst_headers, [_ALPHA_KIND])
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_list_is_refused_for_curator(client, curator_headers):
+    """CURATOR is a privileged role but still lacks ADMIN_NZERO [401 UNAUTHORIZED]."""
+    response = _list(client, curator_headers, [_ALPHA_KIND])
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_list_returns_key_kind_and_value(client, admin_headers, seed_global_memory):
+    """A listed entry carries its key, its kind and the stored json value."""
+    response = _list(client, admin_headers, [_ALPHA_KIND])
+
+    assert response.status_code == status.HTTP_200_OK
+    items = response.get_json()["data"]
+    assert len(items) == 1
+    assert items[0]["key"] == seed_global_memory[_ALPHA_KIND]
+    assert items[0]["kind"] == _ALPHA_KIND
+    assert items[0]["value"] == _ALPHA_VALUE
+
+
+def test_list_returns_only_the_requested_kinds(client, admin_headers):
+    """The kinds filter narrows the result to the requested kinds."""
+    response = _list(client, admin_headers, [_ALPHA_KIND, _BETA_KIND])
+
+    assert response.status_code == status.HTTP_200_OK
+    kinds = {item["kind"] for item in response.get_json()["data"]}
+    assert kinds == {_ALPHA_KIND, _BETA_KIND}
+
+
+def test_list_unknown_kind_returns_empty(client, admin_headers):
+    """Asking for a kind that does not exist returns an empty list."""
+    response = _list(client, admin_headers, [f"{_PREFIX}-does-not-exist"])
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == []
+
+
+def test_list_rejects_missing_kinds(client, admin_headers):
+    """The kinds attribute is mandatory [400 BAD REQUEST]."""
+    response = client.post(LIST_URL, data=json.dumps({}), headers=admin_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_update_replaces_the_value(client, admin_headers, seed_global_memory):
+    """Updating stores the new value and returns the updated key."""
+    key = seed_global_memory[_ALPHA_KIND]
+    new_value = {"label": "alpha updated", "enabled": False}
+
+    response = _update(client, admin_headers, key, _ALPHA_KIND, new_value)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == str(key)
+
+    session_commit()
+    rows = _rows(_ALPHA_KIND)
+    assert len(rows) == 1
+    assert rows[0][0] == new_value
+
+
+def test_update_stamps_the_current_user(client, admin_headers, seed_global_memory):
+    """The updated row records the user who performed the change."""
+    key = seed_global_memory[_BETA_KIND]
+
+    response = _update(client, admin_headers, key, _BETA_KIND, {"label": "beta v2"})
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    rows = _rows(_BETA_KIND)
+    assert rows[0][1] == _ADMIN_USER_ID
+
+
+def test_update_keeps_a_backup_of_the_previous_value(
+    client, admin_headers, seed_global_memory
+):
+    """The previous value is preserved in a row whose kind ends with _bkp."""
+    key = seed_global_memory[_GAMMA_KIND]
+
+    response = _update(client, admin_headers, key, _GAMMA_KIND, {"label": "gamma v2"})
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    backup = _rows(f"{_GAMMA_KIND}_bkp")
+    assert len(backup) == 1
+    assert backup[0][0] == _GAMMA_VALUE
+    # the snapshot keeps the authorship of the value it holds
+    assert backup[0][1] == 1
+
+
+def test_update_backup_is_not_returned_by_the_listing(
+    client, admin_headers, seed_global_memory
+):
+    """The _bkp snapshot is a separate kind and is not listed with the original."""
+    key = seed_global_memory[_ALPHA_KIND]
+    _update(client, admin_headers, key, _ALPHA_KIND, {"label": "alpha v2"})
+
+    response = _list(client, admin_headers, [_ALPHA_KIND])
+
+    assert response.status_code == status.HTTP_200_OK
+    items = response.get_json()["data"]
+    assert len(items) == 1
+    assert items[0]["value"] == {"label": "alpha v2"}
+
+
+def test_update_unknown_key_is_refused(client, admin_headers):
+    """Updating a key that does not exist is a business error [400 BAD REQUEST]."""
+    response = _update(client, admin_headers, 99999999, _ALPHA_KIND, {"label": "x"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_update_requires_admin_permission(client, analyst_headers, seed_global_memory):
+    """Updating global memory without ADMIN_NZERO is refused [401 UNAUTHORIZED]."""
+    key = seed_global_memory[_ALPHA_KIND]
+
+    response = _update(client, analyst_headers, key, _ALPHA_KIND, {"label": "x"})
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    session_commit()
+    assert _rows(_ALPHA_KIND)[0][0] == _ALPHA_VALUE
+
+
+def test_update_rejects_a_non_object_value(client, admin_headers, seed_global_memory):
+    """The value must be a json object [400 BAD REQUEST]."""
+    key = seed_global_memory[_ALPHA_KIND]
+
+    response = _update(client, admin_headers, key, _ALPHA_KIND, "not-an-object")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/integration/test_admin_tag.py
+++ b/tests/integration/test_admin_tag.py
@@ -1,0 +1,275 @@
+"""Integration tests for the /admin/tag endpoints (admin_tag_service).
+
+Covers the permission-aware listing and the upsert rules: name normalisation,
+duplicate detection and the restricted path taken by users that only hold
+WRITE_PATIENT_TAGS (navigation markers must be prefixed with "NAVEGACAO_").
+Rows live in demo.marcador; every name written here starts with a reserved
+uppercase prefix so the cleanup never touches seed data.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import TagTypeEnum
+from tests.conftest import session, session_commit
+from utils import status
+
+LIST_URL = "/admin/tag/list"
+UPSERT_URL = "/admin/tag/upsert"
+
+PATIENT = TagTypeEnum.PATIENT.value  # 1
+PATIENT_NAV = TagTypeEnum.PATIENT_NAVIGATION.value  # 2
+
+# reserved (uppercase) name space for this module — test_tag.py uses lowercase
+# names, and LIKE is case sensitive in PostgreSQL, so the two never collide
+_SEEDED_PATIENT = "ZZTEST_ADMIN_PATIENT"
+_SEEDED_NAV = "ZZTEST_ADMIN_NAV"
+
+_NEW_PATIENT = "ZZTEST_ADMIN_NEW"
+_NEW_NAV = "NAVEGACAO_ZZTEST_ADMIN"
+
+# public.usuario id of the user behind the admin_headers fixture
+_ADMIN_USER_ID = 2
+
+
+def _insert(name: str, tag_type: int, active: bool = True):
+    """Insert a marcador row directly, bypassing the endpoint."""
+    session.execute(
+        text(
+            "INSERT INTO demo.marcador "
+            "(nome, tp_marcador, ativo, created_at, created_by, updated_at, updated_by) "
+            "VALUES (:name, :tp, :active, now(), 1, now(), 1)"
+        ),
+        {"name": name, "tp": tag_type, "active": active},
+    )
+
+
+def _row(name: str, tag_type: int):
+    """Return (ativo, created_by, updated_by) for a marcador row, or None."""
+    result = session.execute(
+        text(
+            "SELECT ativo, created_by, updated_by FROM demo.marcador "
+            "WHERE nome = :name AND tp_marcador = :tp"
+        ),
+        {"name": name, "tp": tag_type},
+    )
+    return result.first()
+
+
+def _cleanup():
+    """Remove every row this module may have created."""
+    session.execute(
+        text(
+            "DELETE FROM demo.marcador "
+            "WHERE nome LIKE 'ZZTEST!_ADMIN%' ESCAPE '!' "
+            "OR nome LIKE 'NAVEGACAO!_ZZTEST%' ESCAPE '!'"
+        )
+    )
+    session_commit()
+
+
+@pytest.fixture(autouse=True)
+def seed_tags():
+    """Recreate the reserved marcador rows before each test and drop them after."""
+    _cleanup()
+
+    _insert(_SEEDED_PATIENT, PATIENT)
+    _insert(_SEEDED_NAV, PATIENT_NAV)
+    session_commit()
+
+    yield
+
+    _cleanup()
+
+
+def _list(client, headers, **filters):
+    """Call the admin listing endpoint."""
+    return client.post(LIST_URL, data=json.dumps(filters), headers=headers)
+
+
+def _upsert(client, headers, name, tag_type, active=True, new=False):
+    """Call the admin upsert endpoint."""
+    payload = {"name": name, "tagType": tag_type, "active": active, "new": new}
+    return client.post(UPSERT_URL, data=json.dumps(payload), headers=headers)
+
+
+def _names(response):
+    """Extract the set of tag names from a successful response envelope."""
+    return {item["name"] for item in response.get_json()["data"]}
+
+
+def test_list_requires_a_tag_permission(client, navigator_headers):
+    """NAVIGATOR may write patient tags but cannot list them here [401 UNAUTHORIZED]."""
+    response = _list(client, navigator_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_list_returns_expected_shape(client, admin_headers):
+    """A listed tag carries name, tagType, active and both timestamps."""
+    response = _list(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    items = response.get_json()["data"]
+    match = next((item for item in items if item["name"] == _SEEDED_PATIENT), None)
+    assert match is not None, f"Tag {_SEEDED_PATIENT} not found in response"
+    assert match["tagType"] == PATIENT
+    assert match["active"] is True
+    assert match["createdAt"] is not None
+    assert match["updatedAt"] is not None
+
+
+def test_list_includes_navigation_tags_with_read_nav(client, admin_headers):
+    """With READ_NAV the listing spans patient and navigation markers."""
+    response = _list(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    names = _names(response)
+    assert _SEEDED_PATIENT in names
+    assert _SEEDED_NAV in names
+
+
+def test_list_excludes_navigation_tags_without_read_nav(
+    client, config_manager_headers
+):
+    """Without READ_NAV the listing is restricted to patient markers."""
+    response = _list(client, config_manager_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    names = _names(response)
+    assert _SEEDED_PATIENT in names
+    assert _SEEDED_NAV not in names
+
+
+def test_list_active_filter(client, admin_headers):
+    """The active filter narrows the listing to active markers."""
+    _insert("ZZTEST_ADMIN_OFF", PATIENT, active=False)
+    session_commit()
+
+    response = _list(client, admin_headers, active=True)
+
+    assert response.status_code == status.HTTP_200_OK
+    names = _names(response)
+    assert _SEEDED_PATIENT in names
+    assert "ZZTEST_ADMIN_OFF" not in names
+
+
+def test_upsert_requires_a_write_permission(client, viewer_headers):
+    """VIEWER holds neither write permission [401 UNAUTHORIZED]."""
+    response = _upsert(client, viewer_headers, _NEW_PATIENT, PATIENT)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_upsert_creates_a_tag(client, admin_headers):
+    """A new marker is created and returned with its stored attributes."""
+    response = _upsert(client, admin_headers, _NEW_PATIENT, PATIENT, new=True)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.get_json()["data"]
+    assert data["name"] == _NEW_PATIENT
+    assert data["tagType"] == PATIENT
+    assert data["active"] is True
+
+    session_commit()
+    row = _row(_NEW_PATIENT, PATIENT)
+    assert row is not None
+    assert row[0] is True
+    assert row[1] == _ADMIN_USER_ID
+
+
+def test_upsert_uppercases_the_name(client, admin_headers):
+    """Names are normalised to uppercase before being stored."""
+    response = _upsert(client, admin_headers, _NEW_PATIENT.lower(), PATIENT, new=True)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["name"] == _NEW_PATIENT
+
+    session_commit()
+    assert _row(_NEW_PATIENT, PATIENT) is not None
+
+
+def test_upsert_updates_an_existing_tag(client, admin_headers):
+    """Upserting an existing marker updates it instead of duplicating it."""
+    response = _upsert(client, admin_headers, _SEEDED_PATIENT, PATIENT, active=False)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["active"] is False
+
+    session_commit()
+    row = _row(_SEEDED_PATIENT, PATIENT)
+    assert row[0] is False
+    # created_by is preserved, updated_by moves to the acting user
+    assert row[1] == 1
+    assert row[2] == _ADMIN_USER_ID
+
+
+def test_upsert_rejects_a_duplicate_when_flagged_as_new(client, admin_headers):
+    """Creating a marker whose name already exists is refused [400 BAD REQUEST]."""
+    response = _upsert(client, admin_headers, _SEEDED_PATIENT, PATIENT, new=True)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_upsert_same_name_on_another_type_creates_a_new_tag(client, admin_headers):
+    """The name/type pair is the identity, so the same name may exist per type."""
+    response = _upsert(client, admin_headers, _SEEDED_PATIENT, PATIENT_NAV, new=True)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    assert _row(_SEEDED_PATIENT, PATIENT) is not None
+    assert _row(_SEEDED_PATIENT, PATIENT_NAV) is not None
+
+
+def test_upsert_rejects_a_name_over_the_limit(client, admin_headers):
+    """Names longer than 40 characters are refused [400 BAD REQUEST]."""
+    response = _upsert(client, admin_headers, "ZZTEST_ADMIN_" + ("X" * 40), PATIENT)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_patient_tag_writer_cannot_create_a_patient_tag(client, analyst_headers):
+    """WRITE_PATIENT_TAGS alone does not allow writing plain patient markers [403]."""
+    response = _upsert(client, analyst_headers, _NEW_PATIENT, PATIENT, new=True)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.get_json()["code"] == "errors.businessRules"
+
+    session_commit()
+    assert _row(_NEW_PATIENT, PATIENT) is None
+
+
+def test_patient_tag_writer_needs_the_navigation_prefix(client, analyst_headers):
+    """A navigation marker created by such a user must start with NAVEGACAO_ [400]."""
+    response = _upsert(client, analyst_headers, _NEW_PATIENT, PATIENT_NAV, new=True)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+
+    session_commit()
+    assert _row(_NEW_PATIENT, PATIENT_NAV) is None
+
+
+def test_patient_tag_writer_creates_a_prefixed_navigation_tag(client, analyst_headers):
+    """With the NAVEGACAO_ prefix the restricted user may create the marker."""
+    response = _upsert(client, analyst_headers, _NEW_NAV, PATIENT_NAV, new=True)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["name"] == _NEW_NAV
+
+    session_commit()
+    assert _row(_NEW_NAV, PATIENT_NAV) is not None
+
+
+def test_navigation_prefix_check_is_case_insensitive(client, analyst_headers):
+    """The prefix is compared on the uppercased name, so lowercase input passes."""
+    response = _upsert(client, analyst_headers, _NEW_NAV.lower(), PATIENT_NAV, new=True)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    assert _row(_NEW_NAV, PATIENT_NAV) is not None


### PR DESCRIPTION
Adds integration coverage for two features that previously had no tests at all (`services/admin/admin_global_memory_service.py` and `services/admin/admin_tag_service.py`).

## `tests/integration/test_admin_global_memory.py` (13 tests)

Covers `/admin/global-memory/list` and `/admin/global-memory/update`:

- the `ADMIN_NZERO` gate — both endpoints refuse `PRESCRIPTION_ANALYST`, and the listing also refuses `CURATOR` (a privileged role that still lacks the permission)
- the `kinds` filter: shape of a returned entry (`key` / `kind` / `value`), multi-kind filtering, unknown kind returning an empty list, missing `kinds` rejected by Pydantic
- update: value replacement, the returned key, `update_by` stamped with the acting user, the unknown-key business error, and rejection of a non-object `value`
- the `<kind>_bkp` snapshot: it holds the previous value along with the authorship of that value, and — since it is a distinct kind — it does not leak into a later listing of the original kind

## `tests/integration/test_admin_tag.py` (16 tests)

Covers `/admin/tag/list` and `/admin/tag/upsert`:

- listing: refused for `NAVIGATOR` (which may write patient tags but holds none of the read permissions), returned DTO shape, and the `READ_NAV`-dependent tag-type filtering — `ADMIN` sees navigation markers, `CONFIG_MANAGER` does not — plus the `active` filter
- upsert as a full `WRITE_TAGS` holder: refused for `VIEWER`, create, name uppercasing, update-in-place (preserving `created_by` while moving `updated_by`), duplicate rejection when `new=true`, the same name allowed on a different tag type, and the 40-character name limit
- upsert on the restricted `WRITE_PATIENT_TAGS`-only path: plain patient markers refused with 403, navigation markers refused without the `NAVEGACAO_` prefix, accepted with it, and the prefix check passing on lowercase input since it runs on the uppercased name

## Notes

Both modules reserve their own name space in the shared tables (`zztest-gm*` kinds in `public.memoria`, `ZZTEST_ADMIN*` / `NAVEGACAO_ZZTEST*` names in `demo.marcador`) and clean up before and after each test. The reserved prefixes were also added to the session-wide `_cleanup` in `tests/conftest.py` as a safety net for interrupted runs. The uppercase tag prefix cannot collide with the lowercase names used by `tests/integration/test_tag.py`, since `LIKE` is case sensitive in PostgreSQL.

Full suite locally: 1366 passed (1337 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdmNvUfamyZCcdCEtTAPEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdmNvUfamyZCcdCEtTAPEP)_