### PR TITLE
test: cover admin schema memory and admin custom reports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,9 +102,11 @@ def _cleanup():
         text("UPDATE demo.prescricao set status = '0' WHERE fkprescricao in (9199, 20)")
     )
 
+    # every kind inserted by _setup_test_data, so a re-run does not stack duplicates
     session.execute(
         text(
-            "DELETE FROM demo.memoria WHERE tipo IN ('map-origin-solution', 'map-origin-diet')"
+            "DELETE FROM demo.memoria WHERE tipo IN "
+            "('map-origin-solution', 'map-origin-diet', 'map-origin-procedure')"
         )
     )
 
@@ -114,6 +116,14 @@ def _cleanup():
 
     # Admin global-memory test records (reserved kind prefix, includes _bkp rows)
     session.execute(text("DELETE FROM public.memoria WHERE tipo LIKE 'zztest-gm%'"))
+
+    # Admin schema-memory test records (reserved kind prefix, includes _bkp rows)
+    session.execute(text("DELETE FROM demo.memoria WHERE tipo LIKE 'zztest-am%'"))
+
+    # Admin custom-report test records (reserved uppercase name prefix)
+    session.execute(
+        text("DELETE FROM demo.relatorio WHERE nome LIKE 'ZZTEST!_RPT%' ESCAPE '!'")
+    )
 
     # Admin tag test records (reserved uppercase name prefixes)
     session.execute(

--- a/tests/integration/test_admin_memory.py
+++ b/tests/integration/test_admin_memory.py
@@ -1,0 +1,569 @@
+"""Integration tests for the /admin/memory endpoints.
+
+Covers admin_memory_service: the kind-filtered listing (including the
+placeholder rows returned for kinds that have no record yet and the
+"map-schedules" values derived from recent prescriptions) and the update
+routine that keeps a "<kind>_bkp" snapshot and guards the protected feature
+flags.
+
+Records live in the schema-local demo.memoria table. Every row created here
+uses a kind starting with the reserved prefix below, except the tests that
+must target the real "features" kind — those snapshot the seed value and
+restore it afterwards.
+"""
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import FeatureEnum, MemoryEnum
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_prescription import (
+    create_prescription,
+    create_prescription_drug,
+    test_counters,
+)
+from utils import status
+
+LIST_URL = "/admin/memory/list"
+UPDATE_URL = "/admin/memory"
+
+# every kind written by this module starts with this prefix, so a single
+# LIKE clause isolates the rows (including the "_bkp" snapshots)
+_PREFIX = "zztest-am"
+
+_ALPHA_KIND = f"{_PREFIX}-alpha"
+_BETA_KIND = f"{_PREFIX}-beta"
+
+_ALPHA_VALUE = {"label": "alpha", "enabled": True}
+_BETA_VALUE = ["one", "two"]
+
+_FEATURES_KIND = MemoryEnum.FEATURES.value
+_SCHEDULES_KIND = MemoryEnum.MAP_SCHEDULES.value
+
+# public.usuario id of the users behind the admin_headers/curator_headers fixtures
+_ADMIN_USER_ID = 2
+_CURATOR_USER_ID = 3
+
+# id of the user that owns the seeded rows created by this module
+_SEED_USER_ID = 1
+
+
+def _insert(kind: str, value) -> int:
+    """Insert a schema memory row and return its generated key."""
+    result = session.execute(
+        text(
+            "INSERT INTO demo.memoria (tipo, valor, update_at, update_by) "
+            "VALUES (:kind, CAST(:value AS json), now(), :user) RETURNING idmemoria"
+        ),
+        {"kind": kind, "value": json.dumps(value), "user": _SEED_USER_ID},
+    )
+    return result.scalar()
+
+
+def _rows(kind: str):
+    """Return (key, value, update_by) for every row of a given kind."""
+    result = session.execute(
+        text(
+            "SELECT idmemoria, valor, update_by FROM demo.memoria WHERE tipo = :kind "
+            "ORDER BY idmemoria"
+        ),
+        {"kind": kind},
+    )
+    return result.all()
+
+
+def _cleanup():
+    """Remove every reserved row this module may have created."""
+    session.execute(
+        text("DELETE FROM demo.memoria WHERE tipo LIKE :prefix"),
+        {"prefix": f"{_PREFIX}%"},
+    )
+    session_commit()
+
+
+@pytest.fixture(autouse=True)
+def seed_memory():
+    """Recreate the reserved rows before each test and drop them afterwards."""
+    _cleanup()
+
+    keys = {
+        _ALPHA_KIND: _insert(_ALPHA_KIND, _ALPHA_VALUE),
+        _BETA_KIND: _insert(_BETA_KIND, _BETA_VALUE),
+    }
+    session_commit()
+
+    yield keys
+
+    _cleanup()
+
+
+@pytest.fixture
+def features_row():
+    """Snapshot the seeded "features" row and restore it after the test.
+
+    The features kind is shared seed data consumed by other suites, and
+    updating it also leaves a "features_bkp" snapshot behind, so both are
+    reverted here.
+    """
+    original = _rows(_FEATURES_KIND)
+    assert len(original) == 1, "the demo schema is expected to seed one features row"
+    key, value, user = original[0]
+
+    yield {"key": key, "value": value, "user": user}
+
+    session.execute(
+        text(
+            "UPDATE demo.memoria SET valor = CAST(:value AS json), update_by = :user "
+            "WHERE idmemoria = :key AND tipo = :kind"
+        ),
+        {
+            "value": json.dumps(value),
+            "user": user,
+            "key": key,
+            "kind": _FEATURES_KIND,
+        },
+    )
+    session.execute(
+        text("DELETE FROM demo.memoria WHERE tipo = :kind"),
+        {"kind": f"{_FEATURES_KIND}_bkp"},
+    )
+    session_commit()
+
+
+def _list(client, headers, kinds):
+    """Call the listing endpoint with the given kinds."""
+    return client.post(LIST_URL, data=json.dumps({"kinds": kinds}), headers=headers)
+
+
+def _update(client, headers, key, kind, value, unique=None):
+    """Call the update endpoint."""
+    payload = {"key": key, "kind": kind, "value": value}
+    if unique is not None:
+        payload["unique"] = unique
+
+    return client.put(UPDATE_URL, data=json.dumps(payload), headers=headers)
+
+
+def _by_kind(items):
+    """Index a listing response by kind."""
+    return {item["kind"]: item for item in items}
+
+
+# ---------------------------------------------------------------------------
+# listing
+# ---------------------------------------------------------------------------
+
+
+def test_list_requires_an_admin_permission(client, analyst_headers):
+    """Listing schema memory without INTEGRATION_UTILS or ADMIN_ROUTES is refused [401 UNAUTHORIZED]."""
+    response = _list(client, analyst_headers, [_ALPHA_KIND])
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_list_is_allowed_for_admin(client, admin_headers, seed_memory):
+    """ADMIN holds INTEGRATION_UTILS and may list schema memory."""
+    response = _list(client, admin_headers, [_ALPHA_KIND])
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"][0]["key"] == seed_memory[_ALPHA_KIND]
+
+
+def test_list_is_allowed_for_curator_through_admin_routes(client, curator_headers):
+    """CURATOR lacks INTEGRATION_UTILS but ADMIN_ROUTES alone grants the listing."""
+    response = _list(client, curator_headers, [_ALPHA_KIND])
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_list_returns_key_kind_and_value(client, admin_headers, seed_memory):
+    """A listed entry carries its key, its kind and the stored json value."""
+    response = _list(client, admin_headers, [_ALPHA_KIND])
+
+    assert response.status_code == status.HTTP_200_OK
+    items = response.get_json()["data"]
+    assert len(items) == 1
+    assert items[0] == {
+        "key": seed_memory[_ALPHA_KIND],
+        "kind": _ALPHA_KIND,
+        "value": _ALPHA_VALUE,
+    }
+
+
+def test_list_returns_only_the_requested_kinds(client, admin_headers):
+    """The kinds filter narrows the stored rows to the requested kinds."""
+    response = _list(client, admin_headers, [_ALPHA_KIND])
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _BETA_KIND not in _by_kind(response.get_json()["data"])
+
+
+def test_list_returns_a_placeholder_for_a_kind_without_a_record(client, admin_headers):
+    """A requested kind that has no row still comes back, with an empty value."""
+    missing = f"{_PREFIX}-does-not-exist"
+
+    response = _list(client, admin_headers, [missing])
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == [{"key": None, "kind": missing, "value": []}]
+
+
+def test_list_mixes_stored_rows_and_placeholders(client, admin_headers, seed_memory):
+    """Stored kinds keep their value while missing kinds are padded with placeholders."""
+    missing = f"{_PREFIX}-missing"
+
+    response = _list(client, admin_headers, [_ALPHA_KIND, missing, _BETA_KIND])
+
+    assert response.status_code == status.HTTP_200_OK
+    items = _by_kind(response.get_json()["data"])
+    assert set(items) == {_ALPHA_KIND, missing, _BETA_KIND}
+    assert items[_ALPHA_KIND]["value"] == _ALPHA_VALUE
+    assert items[_BETA_KIND]["value"] == _BETA_VALUE
+    assert items[missing] == {"key": None, "kind": missing, "value": []}
+
+
+def test_list_without_kinds_returns_empty(client, admin_headers):
+    """Omitting the kinds attribute lists nothing rather than everything."""
+    response = client.post(LIST_URL, data=json.dumps({}), headers=admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == []
+
+
+def test_list_escapes_the_kind_of_a_placeholder(client, admin_headers):
+    """A placeholder kind is html-escaped before being echoed back."""
+    response = _list(client, admin_headers, [f"{_PREFIX}-<script>"])
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"][0]["kind"] == f"{_PREFIX}-&lt;script&gt;"
+
+
+# ---------------------------------------------------------------------------
+# listing: the map-schedules special case
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def recent_intervals():
+    """Create a recent prescription carrying distinctive drug intervals.
+
+    Returns the intervals that must show up in a derived map-schedules list.
+    The prescription and its drugs use reserved test ids, so the session-wide
+    clean_test_artifacts fixture removes them.
+    """
+    id_prescription = test_counters["id_prescription"]
+    test_counters["id_prescription"] += 1
+    admission_number = test_counters["admission_number"]
+    test_counters["admission_number"] += 1
+
+    create_prescription(
+        id=id_prescription,
+        admissionNumber=admission_number,
+        idPatient=1,
+        date=datetime.now() - timedelta(hours=1),
+    )
+
+    id_prescription_drug = int(f"{id_prescription}001")
+    intervals = ["ZZTEST 06:00", "ZZTEST 18:00"]
+
+    for offset, interval in enumerate(intervals):
+        create_prescription_drug(
+            id=id_prescription_drug + offset,
+            idPrescription=id_prescription,
+            idDrug=3,
+            interval=interval,
+        )
+
+    # a drug without an interval must not reach the derived list
+    create_prescription_drug(
+        id=id_prescription_drug + len(intervals),
+        idPrescription=id_prescription,
+        idDrug=4,
+        interval=None,
+    )
+    # ...and neither must an empty one
+    create_prescription_drug(
+        id=id_prescription_drug + len(intervals) + 1,
+        idPrescription=id_prescription,
+        idDrug=4,
+        interval="",
+    )
+
+    return intervals
+
+
+def test_list_derives_map_schedules_from_recent_prescriptions(
+    client, admin_headers, recent_intervals
+):
+    """With no stored row, map-schedules is built from recent prescription intervals."""
+    response = _list(client, admin_headers, [_SCHEDULES_KIND])
+
+    assert response.status_code == status.HTTP_200_OK
+    item = response.get_json()["data"][0]
+    assert item["key"] is None
+    assert item["kind"] == _SCHEDULES_KIND
+
+    derived = item["value"]
+    for interval in recent_intervals:
+        assert {"id": interval, "value": interval} in derived
+
+
+def test_list_omits_blank_intervals_from_map_schedules(
+    client, admin_headers, recent_intervals
+):
+    """Null and empty intervals are skipped when deriving map-schedules."""
+    response = _list(client, admin_headers, [_SCHEDULES_KIND])
+
+    assert response.status_code == status.HTTP_200_OK
+    values = {entry["value"] for entry in response.get_json()["data"][0]["value"]}
+    assert None not in values
+    assert "" not in values
+
+
+def test_list_does_not_derive_map_schedules_when_a_row_exists(
+    client, admin_headers, recent_intervals
+):
+    """A stored map-schedules row is returned as-is, without touching prescriptions."""
+    stored = [{"id": "ZZTEST stored", "value": "ZZTEST stored"}]
+    key = _insert(_SCHEDULES_KIND, stored)
+    session_commit()
+
+    try:
+        response = _list(client, admin_headers, [_SCHEDULES_KIND])
+
+        assert response.status_code == status.HTTP_200_OK
+        item = response.get_json()["data"][0]
+        assert item["key"] == key
+        assert item["value"] == stored
+    finally:
+        session.execute(
+            text("DELETE FROM demo.memoria WHERE idmemoria = :key AND tipo = :kind"),
+            {"key": key, "kind": _SCHEDULES_KIND},
+        )
+        session_commit()
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+def test_update_requires_the_app_features_permission(
+    client, analyst_headers, seed_memory
+):
+    """Updating schema memory without ADMIN_APP_FEATURES is refused [401 UNAUTHORIZED]."""
+    key = seed_memory[_ALPHA_KIND]
+
+    response = _update(client, analyst_headers, key, _ALPHA_KIND, {"label": "x"})
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    session_commit()
+    assert _rows(_ALPHA_KIND)[0][1] == _ALPHA_VALUE
+
+
+def test_update_replaces_the_value(client, admin_headers, seed_memory):
+    """Updating stores the new value and echoes the key back."""
+    key = seed_memory[_ALPHA_KIND]
+    new_value = {"label": "alpha updated", "enabled": False}
+
+    response = _update(client, admin_headers, key, _ALPHA_KIND, new_value)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == str(key)
+
+    session_commit()
+    rows = _rows(_ALPHA_KIND)
+    assert len(rows) == 1
+    assert rows[0][1] == new_value
+
+
+def test_update_keeps_a_backup_of_the_previous_value(
+    client, admin_headers, seed_memory
+):
+    """The previous value is preserved in a row whose kind ends with _bkp."""
+    key = seed_memory[_BETA_KIND]
+
+    response = _update(client, admin_headers, key, _BETA_KIND, ["three"])
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    backup = _rows(f"{_BETA_KIND}_bkp")
+    assert len(backup) == 1
+    assert backup[0][1] == _BETA_VALUE
+    # the snapshot keeps the authorship of the value it holds
+    assert backup[0][2] == _SEED_USER_ID
+
+
+def test_update_stamps_the_current_user(client, admin_headers, seed_memory):
+    """The updated row records the user who performed the change."""
+    key = seed_memory[_ALPHA_KIND]
+
+    response = _update(client, admin_headers, key, _ALPHA_KIND, {"label": "v2"})
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    assert _rows(_ALPHA_KIND)[0][2] == _ADMIN_USER_ID
+
+
+def test_update_creates_a_row_when_the_kind_has_none(client, admin_headers):
+    """A kind without a record is inserted instead of updated, and leaves no backup."""
+    kind = f"{_PREFIX}-created"
+
+    response = _update(client, admin_headers, None, kind, {"label": "brand new"})
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    rows = _rows(kind)
+    assert len(rows) == 1
+    assert rows[0][1] == {"label": "brand new"}
+    assert rows[0][2] == _ADMIN_USER_ID
+    assert _rows(f"{kind}_bkp") == []
+
+
+def test_update_matches_by_key_and_kind(client, admin_headers, seed_memory):
+    """Without the unique flag the row is looked up by key and kind together."""
+    # the beta key with the alpha kind matches nothing, so a new row appears
+    response = _update(
+        client, admin_headers, seed_memory[_BETA_KIND], _ALPHA_KIND, {"label": "new"}
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    rows = _rows(_ALPHA_KIND)
+    assert len(rows) == 2
+    # the original row is untouched
+    assert {row[1]["label"] for row in rows} == {"alpha", "new"}
+
+
+def test_update_with_unique_ignores_the_key(client, admin_headers, seed_memory):
+    """The unique flag resolves the row by kind alone, whatever key is sent."""
+    response = _update(
+        client,
+        admin_headers,
+        seed_memory[_BETA_KIND],
+        _ALPHA_KIND,
+        {"label": "unique"},
+        unique=True,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    rows = _rows(_ALPHA_KIND)
+    assert len(rows) == 1
+    assert rows[0][0] == seed_memory[_ALPHA_KIND]
+    assert rows[0][1] == {"label": "unique"}
+
+
+# ---------------------------------------------------------------------------
+# update: the protected feature flags
+# ---------------------------------------------------------------------------
+
+
+def test_update_features_accepts_a_protected_flag_for_admin(
+    client, admin_headers, features_row
+):
+    """ADMIN holds INTEGRATION_UTILS and may toggle a protected feature."""
+    new_value = list(features_row["value"]) + [FeatureEnum.PRIMARY_CARE.value]
+
+    response = _update(
+        client, admin_headers, features_row["key"], _FEATURES_KIND, new_value
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    assert FeatureEnum.PRIMARY_CARE.value in _rows(_FEATURES_KIND)[0][1]
+
+
+def test_update_features_refuses_a_protected_flag_for_curator(
+    client, curator_headers, features_row
+):
+    """CURATOR has ADMIN_APP_FEATURES but adding OAUTH needs INTEGRATION_UTILS [403 FORBIDDEN]."""
+    new_value = list(features_row["value"]) + [FeatureEnum.OAUTH.value]
+
+    response = _update(
+        client, curator_headers, features_row["key"], _FEATURES_KIND, new_value
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.get_json()["code"] == "errors.unauthorized"
+    assert FeatureEnum.OAUTH.value in response.get_json()["message"]
+
+    session_commit()
+    assert _rows(_FEATURES_KIND)[0][1] == features_row["value"]
+
+
+def test_update_features_refuses_removing_a_protected_flag_for_curator(
+    client, curator_headers, features_row
+):
+    """Dropping a protected feature is guarded just like adding one [403 FORBIDDEN]."""
+    protected = FeatureEnum.PATIENT_DAY_OUTPATIENT_FLOW.value
+    session.execute(
+        text(
+            "UPDATE demo.memoria SET valor = CAST(:value AS json) "
+            "WHERE idmemoria = :key AND tipo = :kind"
+        ),
+        {
+            "value": json.dumps(list(features_row["value"]) + [protected]),
+            "key": features_row["key"],
+            "kind": _FEATURES_KIND,
+        },
+    )
+    session_commit()
+
+    response = _update(
+        client,
+        curator_headers,
+        features_row["key"],
+        _FEATURES_KIND,
+        list(features_row["value"]),
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.get_json()["code"] == "errors.unauthorized"
+
+    session_commit()
+    assert protected in _rows(_FEATURES_KIND)[0][1]
+
+
+def test_update_features_accepts_an_unprotected_flag_for_curator(
+    client, curator_headers, features_row
+):
+    """A feature outside the protected set is editable with ADMIN_APP_FEATURES alone."""
+    new_value = list(features_row["value"]) + [FeatureEnum.DISABLE_SOLUTION_TAB.value]
+
+    response = _update(
+        client, curator_headers, features_row["key"], _FEATURES_KIND, new_value
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    stored = _rows(_FEATURES_KIND)[0]
+    assert FeatureEnum.DISABLE_SOLUTION_TAB.value in stored[1]
+    assert stored[2] == _CURATOR_USER_ID
+
+
+def test_update_features_refusal_leaves_no_backup(
+    client, curator_headers, features_row
+):
+    """A refused features update must not create a _bkp snapshot."""
+    new_value = list(features_row["value"]) + [FeatureEnum.PRIMARY_CARE.value]
+
+    response = _update(
+        client, curator_headers, features_row["key"], _FEATURES_KIND, new_value
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    session_commit()
+    assert _rows(f"{_FEATURES_KIND}_bkp") == []

--- a/tests/integration/test_admin_report.py
+++ b/tests/integration/test_admin_report.py
@@ -1,0 +1,608 @@
+"""Integration tests for the /admin/report endpoints.
+
+Covers admin_report_service: the create/update branches of the upsert
+routine, the graphs-only patch, and the SQL guards that keep a custom report
+restricted to read-only statements over the caller's own schema.
+
+Custom reports live in the schema-local demo.relatorio table. Every row
+created here is named with the reserved prefix below, so a single LIKE clause
+isolates them.
+
+The /admin/report/list endpoint is not covered: it reads public.vanna_report,
+a table the test database (noharm-ai/database) does not create.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import ReportStatusEnum, ReportTypeEnum
+from tests.conftest import session, session_commit
+from utils import status
+
+UPSERT_URL = "/admin/report"
+GRAPHS_URL = "/admin/report/{id_report}/graphs"
+
+# every report written by this module is named with this prefix
+_PREFIX = "ZZTEST_RPT"
+
+# a query that satisfies both SQL guards, used whenever the SQL is incidental
+_VALID_SQL = "select fkprescricao from demo.prescricao"
+
+# public.usuario id of the users behind the admin_headers/curator_headers fixtures
+_ADMIN_USER_ID = 2
+_CURATOR_USER_ID = 3
+
+# id of the user that owns the rows seeded by this module
+_SEED_USER_ID = 1
+
+
+def _insert_report(
+    name: str,
+    sql: str = _VALID_SQL,
+    active: bool = True,
+    report_status: int = ReportStatusEnum.PROCESSED.value,
+    error: str = "previous failure",
+    graphs=None,
+) -> int:
+    """Insert a custom report already in a processed state and return its id.
+
+    Starting from a processed row with an error message makes it observable
+    whether an update resets the processing state.
+    """
+    result = session.execute(
+        text(
+            "INSERT INTO demo.relatorio "
+            "(nome, descricao, tp_relatorio, sql, ativo, tp_status, erro, graficos, "
+            " processed_at, processed_by, created_at, created_by) "
+            "VALUES (:name, :description, :report_type, :sql, :active, :status, :error, "
+            " CAST(:graphs AS json), now(), :user, now(), :user) "
+            "RETURNING idrelatorio"
+        ),
+        {
+            "name": name,
+            "description": "seeded by test_admin_report",
+            "report_type": ReportTypeEnum.CUSTOM.value,
+            "sql": sql,
+            "active": active,
+            "status": report_status,
+            "error": error,
+            "graphs": json.dumps(graphs) if graphs is not None else None,
+            "user": _SEED_USER_ID,
+        },
+    )
+    return result.scalar()
+
+
+def _row(id_report: int):
+    """Return the stored columns of a single report as a mapping."""
+    result = session.execute(
+        text(
+            "SELECT idrelatorio, nome, descricao, tp_relatorio, sql, ativo, tp_status, "
+            "       erro, graficos, processed_at, updated_by "
+            "FROM demo.relatorio WHERE idrelatorio = :id"
+        ),
+        {"id": id_report},
+    )
+    return result.mappings().first()
+
+
+def _rows_named(name: str):
+    """Return every report stored under a given name."""
+    result = session.execute(
+        text("SELECT idrelatorio FROM demo.relatorio WHERE nome = :name"),
+        {"name": name},
+    )
+    return result.all()
+
+
+def _cleanup():
+    """Remove every reserved report this module may have created."""
+    session.execute(
+        text("DELETE FROM demo.relatorio WHERE nome LIKE :prefix"),
+        {"prefix": f"{_PREFIX}%"},
+    )
+    session_commit()
+
+
+@pytest.fixture(autouse=True)
+def clean_reports():
+    """Drop the reserved reports before and after each test."""
+    _cleanup()
+    yield
+    _cleanup()
+
+
+@pytest.fixture
+def stored_report():
+    """A processed custom report available for update."""
+    id_report = _insert_report(name=f"{_PREFIX} stored")
+    session_commit()
+    return id_report
+
+
+def _upsert(client, headers, **overrides):
+    """Call the upsert endpoint, defaulting every required attribute."""
+    payload = {
+        "name": f"{_PREFIX} created",
+        "description": "created by test_admin_report",
+        "sql": _VALID_SQL,
+        "active": True,
+    }
+    payload.update(overrides)
+    payload = {k: v for k, v in payload.items() if v is not _OMIT}
+
+    return client.post(UPSERT_URL, data=json.dumps(payload), headers=headers)
+
+
+def _patch_graphs(client, headers, id_report, graphs):
+    """Call the graphs-only patch endpoint."""
+    return client.patch(
+        GRAPHS_URL.format(id_report=id_report),
+        data=json.dumps({"graphs": graphs}),
+        headers=headers,
+    )
+
+
+class _Omit:
+    """Sentinel telling _upsert to leave an attribute out of the payload."""
+
+
+_OMIT = _Omit()
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+def test_create_requires_the_write_reports_permission(client, analyst_headers):
+    """Creating a report without WRITE_CUSTOM_REPORTS is refused [401 UNAUTHORIZED]."""
+    response = _upsert(client, analyst_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    session_commit()
+    assert _rows_named(f"{_PREFIX} created") == []
+
+
+def test_create_is_refused_for_curator(client, curator_headers):
+    """CURATOR may edit graphs but not the report itself [401 UNAUTHORIZED]."""
+    response = _upsert(client, curator_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    session_commit()
+    assert _rows_named(f"{_PREFIX} created") == []
+
+
+def test_create_returns_the_new_report(client, admin_headers):
+    """Creating returns the stored identity and the initial processing status."""
+    response = _upsert(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.get_json()["data"]
+    assert data["id"] is not None
+    assert data["name"] == f"{_PREFIX} created"
+    assert data["description"] == "created by test_admin_report"
+    assert data["active"] is True
+    assert data["status"] == ReportStatusEnum.NOT_PROCESSED.value
+
+
+def test_create_persists_the_custom_report_defaults(client, admin_headers):
+    """A created report is typed CUSTOM, left unprocessed and stamped with the author."""
+    response = _upsert(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    row = _row(response.get_json()["data"]["id"])
+    assert row["nome"] == f"{_PREFIX} created"
+    assert row["sql"] == _VALID_SQL
+    assert row["tp_relatorio"] == ReportTypeEnum.CUSTOM.value
+    assert row["tp_status"] == ReportStatusEnum.NOT_PROCESSED.value
+    assert row["ativo"] is True
+    assert row["erro"] is None
+    assert row["processed_at"] is None
+
+
+def test_create_honours_the_active_flag(client, admin_headers):
+    """A report may be created inactive."""
+    response = _upsert(client, admin_headers, active=False)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["active"] is False
+
+    session_commit()
+    assert _row(response.get_json()["data"]["id"])["ativo"] is False
+
+
+def test_create_defaults_to_active(client, admin_headers):
+    """Omitting the active attribute creates an active report."""
+    response = _upsert(client, admin_headers, active=_OMIT)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["active"] is True
+
+
+@pytest.mark.parametrize("missing", ["name", "description", "sql"])
+def test_create_rejects_a_missing_attribute(client, admin_headers, missing):
+    """Name, description and sql are all mandatory [400 BAD REQUEST]."""
+    response = _upsert(client, admin_headers, **{missing: _OMIT})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_create_rejects_a_name_over_the_column_length(client, admin_headers):
+    """The name is capped at 150 characters [400 BAD REQUEST]."""
+    response = _upsert(client, admin_headers, name=_PREFIX + "x" * 150)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# create: the sql guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "delete from demo.prescricao",
+        "insert into demo.marcador (nome) values ('x')",
+        "drop table demo.prescricao",
+        "truncate demo.prescricao",
+        "select fkprescricao from demo.prescricao where 1 = 1 alter",
+    ],
+)
+def test_create_rejects_a_destructive_statement(client, admin_headers, sql):
+    """Only read-only statements may be stored [400 BAD REQUEST]."""
+    response = _upsert(client, admin_headers, sql=sql)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidSQL"
+
+
+def test_create_rejects_a_statement_that_does_not_select(client, admin_headers):
+    """A query has to start with SELECT or WITH [400 BAD REQUEST]."""
+    response = _upsert(client, admin_headers, sql=f"explain {_VALID_SQL}")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidSQL"
+
+
+def test_create_rejects_multiple_statements(client, admin_headers):
+    """Chaining statements with a semicolon is refused [400 BAD REQUEST]."""
+    response = _upsert(
+        client, admin_headers, sql=f"{_VALID_SQL}; select 1 from demo.prescricao"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidSQL"
+
+
+def test_create_rejects_a_blank_statement(client, admin_headers):
+    """Whitespace is not a query [400 BAD REQUEST]."""
+    response = _upsert(client, admin_headers, sql="   ")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidSQL"
+
+
+def test_create_accepts_a_trailing_semicolon(client, admin_headers):
+    """A single statement may end with a semicolon."""
+    response = _upsert(client, admin_headers, sql=f"{_VALID_SQL};")
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_create_accepts_a_common_table_expression(client, admin_headers):
+    """A query may start with WITH."""
+    sql = f"with base as ({_VALID_SQL}) select fkprescricao from base"
+
+    response = _upsert(client, admin_headers, sql=sql)
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_create_accepts_a_forbidden_word_inside_a_string_literal(client, admin_headers):
+    """A keyword quoted as data is not an operation [200 OK]."""
+    response = _upsert(
+        client, admin_headers, sql="select 'update' as acao from demo.prescricao"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_create_accepts_a_forbidden_word_inside_a_quoted_identifier(
+    client, admin_headers
+):
+    """A keyword used as a column alias is not an operation [200 OK]."""
+    response = _upsert(
+        client,
+        admin_headers,
+        sql='select leito as "Data Update" from demo.prescricao',
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_create_accepts_a_column_name_containing_a_forbidden_word(
+    client, admin_headers
+):
+    """update_at is a column, not an UPDATE statement [200 OK]."""
+    response = _upsert(
+        client, admin_headers, sql="select update_at from demo.prescricao"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_create_ignores_a_forbidden_word_inside_a_comment(client, admin_headers):
+    """Comments are stripped before the keyword check [200 OK]."""
+    response = _upsert(client, admin_headers, sql=f"{_VALID_SQL} -- delete everything")
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+# ---------------------------------------------------------------------------
+# create: the schema guard
+# ---------------------------------------------------------------------------
+
+
+def test_create_rejects_another_schema(client, admin_headers):
+    """A report may not read a schema other than the caller's [400 BAD REQUEST]."""
+    response = _upsert(
+        client, admin_headers, sql="select fkprescricao from hospital_zz.prescricao"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.unauthorizedSchemaAccess"
+
+
+def test_create_rejects_a_public_table_outside_the_whitelist(client, admin_headers):
+    """Only a few public tables are readable [400 BAD REQUEST]."""
+    response = _upsert(client, admin_headers, sql="select tipo from public.memoria")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.unauthorizedSchemaAccess"
+
+
+def test_create_accepts_a_whitelisted_public_table(client, admin_headers):
+    """public.substancia is explicitly allowed."""
+    response = _upsert(client, admin_headers, sql="select sctid from public.substancia")
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_create_accepts_a_join_inside_the_own_schema(client, admin_headers):
+    """Joining two tables of the caller's schema is allowed."""
+    sql = (
+        "select p.fkprescricao from demo.prescricao p "
+        "inner join demo.presmed pm on pm.fkprescricao = p.fkprescricao"
+    )
+
+    response = _upsert(client, admin_headers, sql=sql)
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_create_rejects_a_reference_to_the_catalog(client, admin_headers):
+    """information_schema is off limits anywhere in the query [400 BAD REQUEST]."""
+    response = _upsert(
+        client,
+        admin_headers,
+        sql=f"{_VALID_SQL} where prescritor = 'information_schema'",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.unauthorizedSchemaAccess"
+
+
+def test_create_rejects_a_suspicious_unqualified_table(client, admin_headers):
+    """An unqualified table that could resolve elsewhere is refused [400 BAD REQUEST]."""
+    response = _upsert(client, admin_headers, sql="select nome from users")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.suspiciousTableAccess"
+
+
+def test_create_accepts_extract_from_a_qualified_column(client, admin_headers):
+    """The FROM inside EXTRACT is not a table reference [200 OK]."""
+    sql = "select extract(epoch from p.dtprescricao) from demo.prescricao p"
+
+    response = _upsert(client, admin_headers, sql=sql)
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+def test_update_replaces_the_editable_fields(client, admin_headers, stored_report):
+    """Sending an id updates the existing report instead of creating one."""
+    new_sql = "select leito from demo.prescricao"
+
+    response = _upsert(
+        client,
+        admin_headers,
+        id=stored_report,
+        name=f"{_PREFIX} renamed",
+        description="renamed by test",
+        sql=new_sql,
+        active=False,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["id"] == stored_report
+
+    session_commit()
+    row = _row(stored_report)
+    assert row["nome"] == f"{_PREFIX} renamed"
+    assert row["descricao"] == "renamed by test"
+    assert row["sql"] == new_sql
+    assert row["ativo"] is False
+
+
+def test_update_does_not_create_a_second_row(client, admin_headers, stored_report):
+    """An update leaves exactly one report behind."""
+    response = _upsert(client, admin_headers, id=stored_report, name=f"{_PREFIX} once")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    assert len(_rows_named(f"{_PREFIX} once")) == 1
+
+
+def test_update_resets_the_processing_state(client, admin_headers, stored_report):
+    """Editing a report queues it for reprocessing and clears the previous error."""
+    response = _upsert(client, admin_headers, id=stored_report)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["status"] == ReportStatusEnum.NOT_PROCESSED.value
+
+    session_commit()
+    row = _row(stored_report)
+    assert row["tp_status"] == ReportStatusEnum.NOT_PROCESSED.value
+    assert row["processed_at"] is None
+    assert row["erro"] is None
+
+
+def test_update_stamps_the_current_user(client, admin_headers, stored_report):
+    """The updated report records who changed it."""
+    response = _upsert(client, admin_headers, id=stored_report)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    assert _row(stored_report)["updated_by"] == _ADMIN_USER_ID
+
+
+def test_update_keeps_the_custom_report_type(client, admin_headers, stored_report):
+    """An updated report stays typed CUSTOM."""
+    response = _upsert(client, admin_headers, id=stored_report)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    assert _row(stored_report)["tp_relatorio"] == ReportTypeEnum.CUSTOM.value
+
+
+def test_update_of_an_unknown_report_is_refused(client, admin_headers):
+    """Updating a report that does not exist is a business error [400 BAD REQUEST]."""
+    response = _upsert(client, admin_headers, id=99999999)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRecord"
+
+
+def test_update_validates_the_sql_before_looking_up_the_report(
+    client, admin_headers, stored_report
+):
+    """A rejected query leaves the stored report untouched [400 BAD REQUEST]."""
+    response = _upsert(
+        client, admin_headers, id=stored_report, sql="delete from demo.prescricao"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidSQL"
+
+    session_commit()
+    row = _row(stored_report)
+    assert row["sql"] == _VALID_SQL
+    assert row["tp_status"] == ReportStatusEnum.PROCESSED.value
+
+
+# ---------------------------------------------------------------------------
+# graphs
+# ---------------------------------------------------------------------------
+
+
+def test_graphs_requires_the_graphs_permission(client, analyst_headers, stored_report):
+    """Patching graphs without WRITE_CUSTOM_REPORTS_GRAPHS is refused [401 UNAUTHORIZED]."""
+    response = _patch_graphs(client, analyst_headers, stored_report, [{"type": "bar"}])
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    session_commit()
+    assert _row(stored_report)["graficos"] is None
+
+
+def test_graphs_is_allowed_for_admin(client, admin_headers, stored_report):
+    """ADMIN may configure the graphs of a report."""
+    graphs = [{"type": "bar", "x": "leito"}]
+
+    response = _patch_graphs(client, admin_headers, stored_report, graphs)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == {"id": stored_report, "graphs": graphs}
+
+    session_commit()
+    assert _row(stored_report)["graficos"] == graphs
+
+
+def test_graphs_is_allowed_for_curator(client, curator_headers, stored_report):
+    """CURATOR holds WRITE_CUSTOM_REPORTS_GRAPHS even without WRITE_CUSTOM_REPORTS."""
+    graphs = [{"type": "line"}]
+
+    response = _patch_graphs(client, curator_headers, stored_report, graphs)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    row = _row(stored_report)
+    assert row["graficos"] == graphs
+    assert row["updated_by"] == _CURATOR_USER_ID
+
+
+def test_graphs_does_not_touch_the_processing_state(
+    client, admin_headers, stored_report
+):
+    """Graphs are presentation only, so the report is not queued for reprocessing."""
+    response = _patch_graphs(client, admin_headers, stored_report, [{"type": "pie"}])
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    row = _row(stored_report)
+    assert row["tp_status"] == ReportStatusEnum.PROCESSED.value
+    assert row["processed_at"] is not None
+    assert row["erro"] == "previous failure"
+
+
+def test_graphs_replaces_the_previous_configuration(client, admin_headers):
+    """Patching overwrites the stored graphs rather than merging them."""
+    id_report = _insert_report(name=f"{_PREFIX} with graphs", graphs=[{"type": "bar"}])
+    session_commit()
+
+    response = _patch_graphs(client, admin_headers, id_report, [{"type": "area"}])
+
+    assert response.status_code == status.HTTP_200_OK
+
+    session_commit()
+    assert _row(id_report)["graficos"] == [{"type": "area"}]
+
+
+def test_graphs_clears_the_configuration_when_null(client, admin_headers):
+    """Sending a null graphs configuration removes the stored one."""
+    id_report = _insert_report(name=f"{_PREFIX} clear", graphs=[{"type": "bar"}])
+    session_commit()
+
+    response = _patch_graphs(client, admin_headers, id_report, None)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["graphs"] is None
+
+    session_commit()
+    assert _row(id_report)["graficos"] is None
+
+
+def test_graphs_of_an_unknown_report_is_refused(client, admin_headers):
+    """Patching a report that does not exist is a business error [400 BAD REQUEST]."""
+    response = _patch_graphs(client, admin_headers, 99999999, [{"type": "bar"}])
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRecord"

--- a/tests/integration/test_admin_report.py
+++ b/tests/integration/test_admin_report.py
@@ -122,6 +122,13 @@ def stored_report():
     return id_report
 
 
+class _Omit:
+    """Sentinel telling _upsert to leave an attribute out of the payload."""
+
+
+_OMIT = _Omit()
+
+
 def _upsert(client, headers, **overrides):
     """Call the upsert endpoint, defaulting every required attribute."""
     payload = {
@@ -143,13 +150,6 @@ def _patch_graphs(client, headers, id_report, graphs):
         data=json.dumps({"graphs": graphs}),
         headers=headers,
     )
-
-
-class _Omit:
-    """Sentinel telling _upsert to leave an attribute out of the payload."""
-
-
-_OMIT = _Omit()
 
 
 # ---------------------------------------------------------------------------
@@ -253,7 +253,12 @@ def test_create_rejects_a_name_over_the_column_length(client, admin_headers):
         "insert into demo.marcador (nome) values ('x')",
         "drop table demo.prescricao",
         "truncate demo.prescricao",
-        "select fkprescricao from demo.prescricao where 1 = 1 alter",
+        "alter table demo.prescricao add column zztest int",
+        "grant all on demo.prescricao to public",
+        # postgres can write a query result straight to the filesystem
+        "copy (select fkprescricao from demo.prescricao) to '/tmp/out.csv'",
+        # ...and the mysql spelling of the same exfiltration
+        "select fkprescricao from demo.prescricao into outfile '/tmp/out.csv'",
     ],
 )
 def test_create_rejects_a_destructive_statement(client, admin_headers, sql):
@@ -388,8 +393,18 @@ def test_create_accepts_a_join_inside_the_own_schema(client, admin_headers):
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_create_rejects_a_reference_to_the_catalog(client, admin_headers):
-    """information_schema is off limits anywhere in the query [400 BAD REQUEST]."""
+def test_create_rejects_the_catalog_schema(client, admin_headers):
+    """Enumerating the database through information_schema is refused [400 BAD REQUEST]."""
+    response = _upsert(
+        client, admin_headers, sql="select table_name from information_schema.tables"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.unauthorizedSchemaAccess"
+
+
+def test_create_rejects_a_catalog_name_anywhere_in_the_query(client, admin_headers):
+    """The catalog check is a substring match, so even a quoted mention trips it."""
     response = _upsert(
         client,
         admin_headers,


### PR DESCRIPTION
Two features had no tests at all. This adds integration coverage for both.

| module | before | after |
| --- | --- | --- |
| `services/admin/admin_memory_service.py` | 30% | **100%** |
| `services/admin/admin_report_service.py` | 27% | **91%** |
| `utils/sqlutils.py` | 100% (unit) | 100% (now also at the API boundary) |

Suite goes from 1366 to 1439 tests.

## `tests/integration/test_admin_memory.py` (24 tests)

`/admin/memory/list` and `/admin/memory`:

- **Listing** — kind filtering; the placeholder rows padded in for kinds that have no record yet, including the html escaping applied to them; the `map-schedules` values derived from the intervals of recent prescriptions when no row is stored (blank intervals skipped, derivation skipped once a row exists).
- **Permission gate** — `INTEGRATION_UTILS` *or* `ADMIN_ROUTES`, so CURATOR passes through `ADMIN_ROUTES` alone while an analyst is refused. This pins down the OR semantics of `@has_permission`.
- **Update** — insert vs update, the `"<kind>_bkp"` snapshot (and that a refused update leaves none), the `unique` flag resolving the row by kind alone whatever key is sent, and user stamping.
- **Protected feature flags** — `PRIMARYCARE`, `OAUTH` and `PATIENT_DAY_OUTPATIENT_FLOW` need `INTEGRATION_UTILS` to be added *or removed*, so CURATOR gets a 403 while ADMIN succeeds; an unprotected flag stays editable with `ADMIN_APP_FEATURES` alone.

## `tests/integration/test_admin_report.py` (49 tests)

`/admin/report` and `/admin/report/<id>/graphs`:

- **Upsert** — the create and update branches, the CUSTOM type and unprocessed status applied on create, the processing state (`status`/`processed_at`/`error`) reset on edit, and the unknown-report business error.
- **SQL guard at the API boundary** — `DELETE`/`INSERT`/`DROP`/`TRUNCATE`/`ALTER`/`GRANT`, the postgres `COPY … TO` filesystem write and the mysql `INTO OUTFILE` spelling of the same exfiltration are all refused, as are non-SELECT queries, chained statements and blank input. Keywords appearing in string literals, quoted identifiers, column names (`update_at`) and comments are *not* false positives; CTEs and a trailing semicolon are accepted.
- **Schema guard** — cross-schema reads, non-whitelisted public tables and `information_schema` are refused; the caller's own schema, `public.substancia` and the `FROM` inside `EXTRACT(...)` are allowed.
- **Split permissions** — creating a report needs `WRITE_CUSTOM_REPORTS` (CURATOR refused), while patching graphs needs `WRITE_CUSTOM_REPORTS_GRAPHS` (CURATOR allowed). Graphs are presentation-only, so patching them does not queue the report for reprocessing.

## Notes

- **`/admin/report/list` is deliberately uncovered.** It reads `public.vanna_report`, a table `noharm-ai/database` does not create, so the endpoint currently returns 500 against the CI database. That accounts for the remaining 9% of `admin_report_service`. Worth a follow-up in the database repo.
- Both modules reserve their own name space (`zztest-am*` kinds, `ZZTEST_RPT*` report names) and clean up after themselves. The tests that must touch the shared `features` row snapshot and restore it, backup row included.
- `tests/conftest.py` gets the matching session-wide safety net, and also drops `map-origin-procedure` — which `_setup_test_data` inserted but `_cleanup` never removed, so repeated runs were stacking a duplicate row each time.

## Verification

Full suite run repeatedly against a fresh PostgreSQL load of `noharm-ai/database`: **1439 passed**, with no leaked rows and the `features` seed value intact afterwards.

Each new test was checked against a mutated service to confirm it fails when the behaviour it describes is removed — the protected-features guard, the `_bkp` snapshot, the `unique` flag, the `map-schedules` derivation, both SQL validators, the status reset, and the graphs not-found guard.