### PR TITLE
test: cover conciliation flows and admin max-dose reference

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,9 @@ def _cleanup():
 
     session.execute(text("DELETE FROM demo.checkedindex"))
 
+    # patients created for conciliation flows (seed admissions stay below 100000)
+    session.execute(text("DELETE FROM demo.pessoa WHERE nratendimento >= 100000"))
+
     session.execute(text("DELETE FROM demo.usuario WHERE email LIKE 'test%@noharm.ai'"))
 
     session.execute(

--- a/tests/integration/test_conciliation_flows.py
+++ b/tests/integration/test_conciliation_flows.py
@@ -1,0 +1,525 @@
+"""Tests: medication conciliation flows (services.conciliation_service).
+
+Covers the three /conciliation endpoints, none of which had coverage before:
+
+* ``POST /conciliation/create`` — opens the daily conciliation prescription for
+  an admission (one per admission per day) and flips the patient conciliation
+  status from PENDING to CREATED.
+* ``GET /conciliation/list-available`` — lists the five most recent
+  conciliations of an admission.
+* ``POST /conciliation/copy`` — refills a conciliation with the items of the
+  patient's previous conciliation, skipping suspended items.
+
+All three are gated by schema features (``CONCILIATION`` /
+``CONCILIATION_EDIT``). Features are resolved from the JWT claims first and
+then from the schema ``features`` memory, so the tests toggle the memory row
+(the claims are frozen at authentication time).
+"""
+
+import json
+from datetime import date, datetime, timedelta
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import PatientConciliationStatusEnum
+from models.prescription import Patient, Prescription, PrescriptionDrug
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_prescription import (
+    create_basic_prescription,
+    create_prescription,
+    create_prescription_drug,
+    test_counters,
+)
+from utils import prescriptionutils
+
+CONCILIATION = "CONCILIATION"
+CONCILIATION_EDIT = "CONCILIATION_EDIT"
+
+# presmed ids for hand-built conciliation items. Above the cleanup threshold
+# (100000001) used by tests/conftest.py and far from the `<prescription id>NNN`
+# ids minted by utils_test_prescription, which stay below 10^9.
+_item_id = {"next": 10**12}
+
+
+def _next_item_id():
+    """Reserve a unique presmed id for a hand-built conciliation item."""
+    _item_id["next"] += 1
+    return _item_id["next"]
+
+
+def _next_admission():
+    """Reserve an admission number not used by any other test."""
+    admission = test_counters["admission_number"]
+    test_counters["admission_number"] += 1
+    return admission
+
+
+def _read_features():
+    """Return the feature list currently stored in the demo schema."""
+    row = session.execute(
+        text("SELECT valor FROM demo.memoria WHERE tipo = 'features'")
+    ).first()
+    return list(row[0]) if row else []
+
+
+def _write_features(features):
+    """Overwrite the demo schema feature list."""
+    session.execute(
+        text(
+            "UPDATE demo.memoria SET valor = CAST(:value AS json) WHERE tipo = 'features'"
+        ),
+        {"value": json.dumps(features)},
+    )
+    session_commit()
+
+
+@pytest.fixture
+def conciliation_features():
+    """Enable both conciliation features for the demo schema."""
+    original = _read_features()
+    _write_features(original + [CONCILIATION, CONCILIATION_EDIT])
+    yield
+    _write_features(original)
+
+
+def _conciliation_id(admission_number, pdate, id_segment=1):
+    """Reproduce the id conciliation_service mints for a given day."""
+    return 90000000000000000 + prescriptionutils.gen_agg_id(
+        admission_number=admission_number, id_segment=id_segment, pdate=pdate
+    )
+
+
+def _create_conciliation_prescription(admission_number, pdate, id_patient, status=None):
+    """Insert a conciliation prescription (concilia = 's') directly.
+
+    The ``complete_prescricao`` insert trigger does not carry ``status``, so a
+    non-default status is applied with a follow-up update.
+    """
+    prescription = create_prescription(
+        id=_conciliation_id(admission_number=admission_number, pdate=pdate),
+        admissionNumber=admission_number,
+        idPatient=id_patient,
+        date=pdate,
+        expire=pdate,
+        concilia="s",
+    )
+
+    if status is not None:
+        session.execute(
+            text(
+                "UPDATE demo.prescricao SET status = :status WHERE fkprescricao = :id"
+            ),
+            {"status": status, "id": prescription.id},
+        )
+        session_commit()
+
+    return prescription
+
+
+def _create(client, headers, admission_number):
+    return client.post(
+        "/conciliation/create",
+        json={"admissionNumber": admission_number},
+        headers=headers,
+    )
+
+
+def _list_available(client, headers, admission_number):
+    return client.get(
+        f"/conciliation/list-available?admissionNumber={admission_number}",
+        headers=headers,
+    )
+
+
+def _copy(client, headers, id_prescription):
+    return client.post(
+        "/conciliation/copy",
+        json={"idPrescription": id_prescription},
+        headers=headers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /conciliation/create
+# ---------------------------------------------------------------------------
+
+
+def test_create_is_blocked_when_feature_is_disabled(client, analyst_headers):
+    """POST /conciliation/create answers 401 while CONCILIATION_EDIT is off."""
+    prescription = create_basic_prescription()
+
+    response = _create(client, analyst_headers, prescription.admissionNumber)
+
+    assert response.status_code == 401
+    assert response.get_json()["code"] == "errors.unauthorizedFeature"
+
+
+def test_create_rejects_an_admission_without_prescriptions(
+    client, analyst_headers, conciliation_features
+):
+    """An admission with no regular prescription cannot be conciliated."""
+    response = _create(client, analyst_headers, _next_admission())
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["code"] == "errors.businessRules"
+    assert "Atendimento inválido" in body["message"]
+
+
+def test_create_opens_todays_conciliation(
+    client, analyst_headers, conciliation_features
+):
+    """The new prescription reuses the reference's admission data and is flagged."""
+    reference = create_basic_prescription()
+    session.expire_all()
+    reference = session.get(Prescription, reference.id)
+    expected_id = _conciliation_id(
+        admission_number=reference.admissionNumber,
+        pdate=date.today(),
+        id_segment=reference.idSegment,
+    )
+
+    response = _create(client, analyst_headers, reference.admissionNumber)
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == str(expected_id)
+
+    session.expire_all()
+    created = session.get(Prescription, expected_id)
+    assert created is not None
+    assert created.concilia == "s"
+    assert created.agg is None
+    assert created.admissionNumber == reference.admissionNumber
+    assert created.idPatient == reference.idPatient
+    assert created.idDepartment == reference.idDepartment
+    assert created.date.date() == date.today()
+
+
+def test_create_allows_only_one_conciliation_per_day(
+    client, analyst_headers, conciliation_features
+):
+    """A second call on the same day is refused instead of overwriting."""
+    reference = create_basic_prescription()
+
+    first = _create(client, analyst_headers, reference.admissionNumber)
+    assert first.status_code == 200
+
+    second = _create(client, analyst_headers, reference.admissionNumber)
+
+    assert second.status_code == 400
+    body = second.get_json()
+    assert body["code"] == "errors.businessRules"
+    assert "Somente uma conciliação por dia" in body["message"]
+
+
+def test_create_moves_the_patient_to_the_created_status(
+    client, analyst_headers, conciliation_features
+):
+    """A patient waiting for conciliation is marked as CREATED."""
+    reference = create_basic_prescription()
+
+    patient = Patient()
+    patient.admissionNumber = reference.admissionNumber
+    patient.idPatient = reference.idPatient
+    patient.idHospital = 1
+    patient.admissionDate = datetime.now()
+    patient.st_conciliation = PatientConciliationStatusEnum.PENDING.value
+    session.add(patient)
+    session_commit()
+
+    response = _create(client, analyst_headers, reference.admissionNumber)
+
+    assert response.status_code == 200
+
+    session.expire_all()
+    updated = session.get(Patient, reference.admissionNumber)
+    assert updated.st_conciliation == PatientConciliationStatusEnum.CREATED.value
+
+
+def test_create_keeps_a_patient_status_that_is_not_pending(
+    client, analyst_headers, conciliation_features
+):
+    """Only the PENDING status is advanced; anything else is left untouched."""
+    reference = create_basic_prescription()
+
+    patient = Patient()
+    patient.admissionNumber = reference.admissionNumber
+    patient.idPatient = reference.idPatient
+    patient.idHospital = 1
+    patient.admissionDate = datetime.now()
+    patient.st_conciliation = PatientConciliationStatusEnum.CREATED.value
+    session.add(patient)
+    session_commit()
+
+    assert (
+        _create(client, analyst_headers, reference.admissionNumber).status_code == 200
+    )
+
+    session.expire_all()
+    updated = session.get(Patient, reference.admissionNumber)
+    assert updated.st_conciliation == PatientConciliationStatusEnum.CREATED.value
+
+
+# ---------------------------------------------------------------------------
+# GET /conciliation/list-available
+# ---------------------------------------------------------------------------
+
+
+def test_list_available_is_blocked_when_feature_is_disabled(client, analyst_headers):
+    """The listing is gated by CONCILIATION, not by CONCILIATION_EDIT."""
+    response = _list_available(client, analyst_headers, _next_admission())
+
+    assert response.status_code == 401
+    assert response.get_json()["code"] == "errors.unauthorizedFeature"
+
+
+def test_list_available_returns_conciliations_newest_first(
+    client, analyst_headers, conciliation_features
+):
+    """Conciliations come back ordered by date descending, ids as strings."""
+    admission = _next_admission()
+    id_patient = 990001
+
+    older = _create_conciliation_prescription(
+        admission_number=admission,
+        pdate=datetime.now() - timedelta(days=3),
+        id_patient=id_patient,
+    )
+    newer = _create_conciliation_prescription(
+        admission_number=admission,
+        pdate=datetime.now() - timedelta(days=1),
+        id_patient=id_patient,
+        status="s",
+    )
+
+    response = _list_available(client, analyst_headers, admission)
+
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert [item["id"] for item in data] == [str(newer.id), str(older.id)]
+    assert data[0]["status"] == "s"
+    assert data[0]["date"] == newer.date.isoformat()
+
+
+def test_list_available_ignores_regular_prescriptions(
+    client, analyst_headers, conciliation_features
+):
+    """Prescriptions without the concilia flag are not listed."""
+    admission = _next_admission()
+    id_patient = 990002
+
+    create_prescription(
+        id=test_counters["id_prescription"],
+        admissionNumber=admission,
+        idPatient=id_patient,
+    )
+    test_counters["id_prescription"] += 1
+    conciliation = _create_conciliation_prescription(
+        admission_number=admission,
+        pdate=datetime.now() - timedelta(days=1),
+        id_patient=id_patient,
+    )
+
+    response = _list_available(client, analyst_headers, admission)
+
+    data = response.get_json()["data"]
+    assert [item["id"] for item in data] == [str(conciliation.id)]
+
+
+def test_list_available_is_capped_at_five_records(
+    client, analyst_headers, conciliation_features
+):
+    """Older conciliations beyond the fifth are dropped."""
+    admission = _next_admission()
+    id_patient = 990003
+
+    created = [
+        _create_conciliation_prescription(
+            admission_number=admission,
+            pdate=datetime.now() - timedelta(days=offset),
+            id_patient=id_patient,
+        )
+        for offset in range(1, 8)
+    ]
+
+    response = _list_available(client, analyst_headers, admission)
+
+    data = response.get_json()["data"]
+    assert len(data) == 5
+    # the five most recent ones, i.e. the smallest day offsets
+    assert [item["id"] for item in data] == [str(p.id) for p in created[:5]]
+
+
+# ---------------------------------------------------------------------------
+# POST /conciliation/copy
+# ---------------------------------------------------------------------------
+
+
+def test_copy_is_blocked_when_feature_is_disabled(client, analyst_headers):
+    """POST /conciliation/copy answers 401 while CONCILIATION_EDIT is off."""
+    admission = _next_admission()
+    conciliation = _create_conciliation_prescription(
+        admission_number=admission,
+        pdate=datetime.now(),
+        id_patient=990004,
+    )
+
+    response = _copy(client, analyst_headers, conciliation.id)
+
+    assert response.status_code == 401
+    assert response.get_json()["code"] == "errors.unauthorizedFeature"
+
+
+def test_copy_rejects_an_unknown_prescription(
+    client, analyst_headers, conciliation_features
+):
+    """A prescription id that does not exist is reported as invalid."""
+    response = _copy(client, analyst_headers, 90000000000000001)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["code"] == "errors.invalidRecord"
+    assert "Conciliação inexistente" in body["message"]
+
+
+def test_copy_rejects_a_regular_prescription(
+    client, analyst_headers, conciliation_features
+):
+    """Only prescriptions flagged as conciliation can be refilled."""
+    prescription = create_basic_prescription()
+
+    response = _copy(client, analyst_headers, prescription.id)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["code"] == "errors.businessRules"
+    assert "Conciliação inválida" in body["message"]
+
+
+def test_copy_requires_a_previous_conciliation(
+    client, analyst_headers, conciliation_features
+):
+    """The first conciliation of a patient has nothing to copy from."""
+    admission = _next_admission()
+    conciliation = _create_conciliation_prescription(
+        admission_number=admission,
+        pdate=datetime.now(),
+        id_patient=990005,
+    )
+
+    response = _copy(client, analyst_headers, conciliation.id)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["code"] == "errors.businessRules"
+    assert "Não foi encontrada conciliação anterior" in body["message"]
+
+
+def test_copy_duplicates_the_previous_items_and_skips_suspended_ones(
+    client, analyst_headers, conciliation_features
+):
+    """Active items are recreated on the new conciliation; suspended ones are not."""
+    admission = _next_admission()
+    id_patient = 990006
+
+    previous = _create_conciliation_prescription(
+        admission_number=admission,
+        pdate=datetime.now() - timedelta(days=2),
+        id_patient=id_patient,
+    )
+    create_prescription_drug(
+        id=_next_item_id(),
+        idPrescription=previous.id,
+        idDrug=3,
+        idMeasureUnit="1",
+        idFrequency="1",
+        dose=42.0,
+        route="VO",
+        interval="8h",
+        notes="manter em jejum",
+        source="Medicamentos",
+    )
+    create_prescription_drug(
+        id=_next_item_id(),
+        idPrescription=previous.id,
+        idDrug=4,
+        suspendedDate=datetime.now() - timedelta(days=1),
+    )
+
+    current = _create_conciliation_prescription(
+        admission_number=admission,
+        pdate=datetime.now(),
+        id_patient=id_patient,
+    )
+
+    response = _copy(client, analyst_headers, current.id)
+
+    assert response.status_code == 200
+
+    session.expire_all()
+    copied = (
+        session.query(PrescriptionDrug)
+        .filter(PrescriptionDrug.idPrescription == current.id)
+        .all()
+    )
+
+    assert len(copied) == 1
+    item = copied[0]
+    assert item.idDrug == 3
+    assert item.dose == 42.0
+    assert item.idMeasureUnit == "1"
+    assert item.idFrequency == "1"
+    assert item.interval == "8h"
+    assert item.route == "VO"
+    assert item.notes == "manter em jejum"
+    assert item.source == "Medicamentos"
+
+
+def test_copy_reaches_conciliations_of_a_previous_admission(
+    client, analyst_headers, conciliation_features
+):
+    """The source conciliation may belong to an earlier stay of the same patient."""
+    previous_admission = _next_admission()
+    current_admission = _next_admission()
+    id_patient = 990007
+
+    for admission in (previous_admission, current_admission):
+        patient = Patient()
+        patient.admissionNumber = admission
+        patient.idPatient = id_patient
+        patient.idHospital = 1
+        patient.admissionDate = datetime.now() - timedelta(days=30)
+        session.add(patient)
+    session_commit()
+
+    previous = _create_conciliation_prescription(
+        admission_number=previous_admission,
+        pdate=datetime.now() - timedelta(days=20),
+        id_patient=id_patient,
+    )
+    create_prescription_drug(
+        id=_next_item_id(),
+        idPrescription=previous.id,
+        idDrug=3,
+        dose=15.0,
+    )
+
+    current = _create_conciliation_prescription(
+        admission_number=current_admission,
+        pdate=datetime.now(),
+        id_patient=id_patient,
+    )
+
+    response = _copy(client, analyst_headers, current.id)
+
+    assert response.status_code == 200
+
+    session.expire_all()
+    copied = (
+        session.query(PrescriptionDrug)
+        .filter(PrescriptionDrug.idPrescription == current.id)
+        .all()
+    )
+
+    assert [(item.idDrug, item.dose) for item in copied] == [(3, 15.0)]

--- a/tests/unit/test_admin_drug_dosemax.py
+++ b/tests/unit/test_admin_drug_dosemax.py
@@ -1,0 +1,413 @@
+"""Unit tests for the admin max-dose reference calculation (services.admin.admin_drug_service).
+
+``get_max_dose_ref`` turns a substance's reference max dose — always expressed in
+the substance's own default measure unit — into a max dose expressed in the
+unit the drug is prescribed in. It needs a measure-unit conversion factor for
+that drug/segment pair; without one the reference cannot be applied and the
+record is reported as ``not_converted``. Which reference is read (adult or
+pediatric) depends on the segment type.
+
+``calculate_dosemax_uniq`` applies that result to a single ``medatributos``
+record and ``calculate_dosemax_bulk`` does it for the whole table, so both are
+covered here through their repository boundaries.
+
+The functions are reached through ``__wrapped__`` to bypass the
+``@has_permission`` gate — no request context or database is involved.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from exception.validation_error import ValidationError
+from models.enums import SegmentTypeEnum
+from models.main import Drug, DrugAttributes, Substance
+from models.segment import Segment
+from services.admin import admin_drug_service
+
+# The undecorated business logic (skips the permission gate).
+_max_dose_ref = admin_drug_service.get_max_dose_ref.__wrapped__
+_dosemax_uniq = admin_drug_service.calculate_dosemax_uniq.__wrapped__
+_dosemax_bulk = admin_drug_service.calculate_dosemax_bulk.__wrapped__
+
+
+def _segment(id=1, type=SegmentTypeEnum.ADULT.value):
+    segment = Segment()
+    segment.id = id
+    segment.description = "Adulto"
+    segment.type = type
+    return segment
+
+
+def _drug(id=100):
+    drug = Drug()
+    drug.id = id
+    drug.name = "Dipirona 500mg comprimido"
+    drug.sctid = 26472009
+    return drug
+
+
+def _attributes(id_drug=100, id_segment=1, use_weight=False):
+    attributes = DrugAttributes()
+    attributes.idDrug = id_drug
+    attributes.idSegment = id_segment
+    attributes.useWeight = use_weight
+    return attributes
+
+
+def _substance(
+    *,
+    maxdose_adult=None,
+    maxdose_adult_weight=None,
+    maxdose_pediatric=None,
+    maxdose_pediatric_weight=None,
+    default_measureunit="mg",
+):
+    substance = Substance()
+    substance.id = 26472009
+    substance.name = "dipirona"
+    substance.maxdose_adult = maxdose_adult
+    substance.maxdose_adult_weight = maxdose_adult_weight
+    substance.maxdose_pediatric = maxdose_pediatric
+    substance.maxdose_pediatric_weight = maxdose_pediatric_weight
+    substance.default_measureunit = default_measureunit
+    return substance
+
+
+def _conversion(*, id_drug=100, id_segment=1, measureunit_nh="mg", factor=1):
+    """Build a conversion row as returned by drugs_repository.get_conversions."""
+    return SimpleNamespace(
+        MeasureUnitConvert=SimpleNamespace(
+            idDrug=id_drug, idSegment=id_segment, factor=factor
+        ),
+        MeasureUnit=SimpleNamespace(measureunit_nh=measureunit_nh),
+    )
+
+
+def _run_max_dose_ref(
+    *, substance, segment=None, conversions=None, attributes=None, drug=None
+):
+    return _max_dose_ref(
+        attributes=attributes or _attributes(),
+        drug=drug or _drug(),
+        segment=segment or _segment(),
+        substance=substance,
+        conversions=conversions if conversions is not None else [_conversion()],
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_max_dose_ref
+# ---------------------------------------------------------------------------
+
+
+def test_segment_without_type_is_rejected():
+    """An unconfigured segment type cannot pick between adult and pediatric doses."""
+    with pytest.raises(ValidationError) as excinfo:
+        _run_max_dose_ref(
+            substance=_substance(maxdose_adult=4000),
+            segment=_segment(type=None),
+        )
+
+    assert excinfo.value.code == "errors.businessRules"
+
+
+def test_substance_without_reference_dose_reports_no_reference():
+    """A substance with no max dose configured yields no reference at all."""
+    result = _run_max_dose_ref(substance=_substance())
+
+    assert result["type"] == "no_reference"
+    assert "dosemax" not in result
+    assert "dosemaxWeight" not in result
+
+
+def test_result_always_identifies_the_medatributos_record():
+    """The drug/segment pair is echoed back so the bulk update can target the row."""
+    result = _run_max_dose_ref(
+        substance=_substance(),
+        attributes=_attributes(id_drug=321, id_segment=7),
+        drug=_drug(id=321),
+        segment=_segment(id=7),
+    )
+
+    assert result["idDrug"] == 321
+    assert result["idSegment"] == 7
+
+
+def test_reference_without_a_conversion_factor_is_not_converted():
+    """Without a factor for the drug's unit the reference cannot be applied."""
+    result = _run_max_dose_ref(substance=_substance(maxdose_adult=4000), conversions=[])
+
+    assert result["type"] == "not_converted"
+    assert "dosemax" not in result
+
+
+def test_adult_segment_uses_the_adult_reference():
+    """An adult segment reads maxdose_adult / maxdose_adult_weight."""
+    result = _run_max_dose_ref(
+        substance=_substance(
+            maxdose_adult=4000,
+            maxdose_adult_weight=60,
+            maxdose_pediatric=1000,
+            maxdose_pediatric_weight=15,
+        ),
+        segment=_segment(type=SegmentTypeEnum.ADULT.value),
+    )
+
+    assert result["type"] == "converted"
+    assert result["dosemax"] == 4000
+    assert result["dosemaxWeight"] == 60
+
+
+def test_pediatric_segment_uses_the_pediatric_reference():
+    """A pediatric segment reads maxdose_pediatric / maxdose_pediatric_weight."""
+    result = _run_max_dose_ref(
+        substance=_substance(
+            maxdose_adult=4000,
+            maxdose_adult_weight=60,
+            maxdose_pediatric=1000,
+            maxdose_pediatric_weight=15,
+        ),
+        segment=_segment(type=SegmentTypeEnum.PEDIATRIC.value),
+    )
+
+    assert result["type"] == "converted"
+    assert result["dosemax"] == 1000
+    assert result["dosemaxWeight"] == 15
+
+
+def test_reference_dose_is_multiplied_by_the_conversion_factor():
+    """The reference is expressed in the drug's own measure unit."""
+    result = _run_max_dose_ref(
+        substance=_substance(maxdose_adult=4000, maxdose_adult_weight=60),
+        conversions=[_conversion(factor=0.002)],
+    )
+
+    assert result["type"] == "converted"
+    assert result["dosemax"] == 8
+    assert result["dosemaxWeight"] == 0.12
+
+
+def test_converted_doses_are_rounded_to_three_decimals():
+    """Converted values keep at most three decimals."""
+    result = _run_max_dose_ref(
+        substance=_substance(maxdose_adult=1, maxdose_adult_weight=2),
+        conversions=[_conversion(factor=1 / 3)],
+    )
+
+    assert result["dosemax"] == 0.333
+    assert result["dosemaxWeight"] == 0.667
+
+
+def test_only_the_configured_reference_is_converted():
+    """A weight-only reference does not produce an absolute max dose, and vice versa."""
+    weight_only = _run_max_dose_ref(
+        substance=_substance(maxdose_adult_weight=60),
+        conversions=[_conversion(factor=2)],
+    )
+    assert weight_only["type"] == "converted"
+    assert weight_only["dosemaxWeight"] == 120
+    assert "dosemax" not in weight_only
+
+    absolute_only = _run_max_dose_ref(
+        substance=_substance(maxdose_adult=4000),
+        conversions=[_conversion(factor=2)],
+    )
+    assert absolute_only["type"] == "converted"
+    assert absolute_only["dosemax"] == 8000
+    assert "dosemaxWeight" not in absolute_only
+
+
+@pytest.mark.parametrize(
+    "conversion",
+    [
+        pytest.param(_conversion(id_drug=999), id="other-drug"),
+        pytest.param(_conversion(id_segment=99), id="other-segment"),
+        pytest.param(_conversion(measureunit_nh="ml"), id="other-measure-unit"),
+    ],
+)
+def test_conversion_lookup_matches_drug_segment_and_unit(conversion):
+    """A factor belonging to another drug, segment or unit is not reused."""
+    result = _run_max_dose_ref(
+        substance=_substance(maxdose_adult=4000, default_measureunit="mg"),
+        conversions=[conversion],
+    )
+
+    assert result["type"] == "not_converted"
+
+
+def test_conversion_lookup_picks_the_matching_row_from_a_list():
+    """The right factor is selected among conversions of several drugs."""
+    result = _run_max_dose_ref(
+        substance=_substance(maxdose_adult=10),
+        conversions=[
+            _conversion(id_drug=999, factor=100),
+            _conversion(measureunit_nh="ml", factor=50),
+            _conversion(factor=3),
+        ],
+    )
+
+    assert result["dosemax"] == 30
+
+
+# ---------------------------------------------------------------------------
+# calculate_dosemax_uniq
+# ---------------------------------------------------------------------------
+
+
+def _attributes_row(attributes, segment):
+    """Build a row as returned by drugs_repository.get_drug_attributes."""
+    return SimpleNamespace(
+        DrugAttributes=attributes,
+        Drug=_drug(),
+        Substance=_substance(),
+        Segment=segment,
+    )
+
+
+def _run_dosemax_uniq(rows, max_dose_ref):
+    with (
+        patch.object(
+            admin_drug_service.drugs_repository,
+            "get_drug_attributes",
+            return_value=rows,
+        ),
+        patch.object(
+            admin_drug_service.drugs_repository, "get_conversions", return_value=[]
+        ),
+        patch.object(admin_drug_service, "get_max_dose_ref", return_value=max_dose_ref),
+        patch.object(admin_drug_service, "db"),
+    ):
+        return _dosemax_uniq(id_drug=100, id_segment=1)
+
+
+def test_dosemax_uniq_returns_none_for_an_unknown_record():
+    """A drug without medatributos for the segment has nothing to calculate."""
+    assert _run_dosemax_uniq(rows=[], max_dose_ref={"type": "no_reference"}) is None
+
+
+def test_dosemax_uniq_applies_the_converted_reference():
+    """A converted reference is stored and promoted to the effective max dose."""
+    attributes = _attributes(use_weight=False)
+
+    result = _run_dosemax_uniq(
+        rows=[_attributes_row(attributes, _segment())],
+        max_dose_ref={"type": "converted", "dosemax": 8, "dosemaxWeight": 0.12},
+    )
+
+    assert result is attributes
+    assert attributes.ref_maxdose == 8
+    assert attributes.ref_maxdose_weight == 0.12
+    assert attributes.maxDose == 8
+
+
+def test_dosemax_uniq_uses_the_weight_reference_for_weight_based_drugs():
+    """Drugs prescribed per kg take the weight reference as effective max dose."""
+    attributes = _attributes(use_weight=True)
+
+    _run_dosemax_uniq(
+        rows=[_attributes_row(attributes, _segment())],
+        max_dose_ref={"type": "converted", "dosemax": 8, "dosemaxWeight": 0.12},
+    )
+
+    assert attributes.maxDose == 0.12
+
+
+def test_dosemax_uniq_clears_the_max_dose_when_the_reference_cannot_be_converted():
+    """An unconvertible reference must not leave a stale max dose behind."""
+    attributes = _attributes()
+    attributes.maxDose = 999
+
+    _run_dosemax_uniq(
+        rows=[_attributes_row(attributes, _segment())],
+        max_dose_ref={"type": "not_converted"},
+    )
+
+    assert attributes.maxDose is None
+    assert attributes.ref_maxdose is None
+    assert attributes.ref_maxdose_weight is None
+
+
+# ---------------------------------------------------------------------------
+# calculate_dosemax_bulk
+# ---------------------------------------------------------------------------
+
+
+def _run_dosemax_bulk(refs):
+    """Run the bulk calculation over one row per entry of ``refs``."""
+    rows = [_attributes_row(_attributes(), _segment()) for _ in refs]
+    user_context = SimpleNamespace(id=1, schema="demo")
+
+    with (
+        patch.object(
+            admin_drug_service.drugs_repository,
+            "get_drug_attributes",
+            return_value=rows,
+        ),
+        patch.object(
+            admin_drug_service.drugs_repository, "get_conversions", return_value=[]
+        ),
+        patch.object(admin_drug_service, "get_max_dose_ref", side_effect=list(refs)),
+        patch.object(
+            admin_drug_service, "drug_attributes_repository"
+        ) as attributes_repository,
+    ):
+        attributes_repository.copy_dose_max_from_ref.return_value = MagicMock(
+            rowcount=len([r for r in refs if r["type"] == "converted"])
+        )
+        result = _dosemax_bulk(user_context=user_context)
+
+    return result, attributes_repository
+
+
+def test_dosemax_bulk_counts_every_outcome():
+    """Each record is tallied under the outcome its reference produced."""
+    result, _ = _run_dosemax_bulk(
+        [
+            {"type": "converted", "idDrug": 1, "idSegment": 1, "dosemax": 10},
+            {"type": "converted", "idDrug": 2, "idSegment": 1, "dosemax": 20},
+            {"type": "not_converted", "idDrug": 3, "idSegment": 1},
+            {"type": "no_reference", "idDrug": 4, "idSegment": 1},
+        ]
+    )
+
+    assert result["converted"] == 2
+    assert result["notConverted"] == 1
+    assert result["noReference"] == 1
+    assert result["updated"] == 2
+
+
+def test_dosemax_bulk_only_persists_converted_records():
+    """Records without a usable reference are not sent to the update statement."""
+    converted = {"type": "converted", "idDrug": 1, "idSegment": 1, "dosemax": 10}
+
+    _, attributes_repository = _run_dosemax_bulk(
+        [converted, {"type": "not_converted", "idDrug": 2, "idSegment": 1}]
+    )
+
+    attributes_repository.update_dose_max.assert_called_once_with(
+        update_list=[converted], schema="demo"
+    )
+    attributes_repository.copy_dose_max_from_ref.assert_called_once_with(
+        schema="demo", update_by=1
+    )
+
+
+def test_dosemax_bulk_skips_the_update_when_nothing_converted():
+    """No conversion means no write and nothing reported as updated."""
+    result, attributes_repository = _run_dosemax_bulk(
+        [
+            {"type": "not_converted", "idDrug": 1, "idSegment": 1},
+            {"type": "no_reference", "idDrug": 2, "idSegment": 1},
+        ]
+    )
+
+    assert result == {
+        "converted": 0,
+        "notConverted": 1,
+        "noReference": 1,
+        "updated": 0,
+    }
+    attributes_repository.update_dose_max.assert_not_called()
+    attributes_repository.copy_dose_max_from_ref.assert_not_called()


### PR DESCRIPTION
## Summary

Adds tests for two features that had essentially no coverage. No production code is touched — this PR is tests plus one cleanup line in `tests/conftest.py`.

Suite goes from 1464 to 1500 passing tests; overall coverage 83% → 84%.

## 1. Conciliation — integration tests

`tests/integration/test_conciliation_flows.py` (16 tests)

The three `/conciliation` endpoints had no tests of their own; the existing `test_conciliation.py` only reads a seed prescription through `/prescriptions`. The new file drives the endpoints:

- **`POST /conciliation/create`** — feature gate (401 when `CONCILIATION_EDIT` is off), invalid admission, the id minted for the day, the one-conciliation-per-admission-per-day rule, and the patient `st_conciliation` PENDING → CREATED transition (including that a non-PENDING status is left alone).
- **`GET /conciliation/list-available`** — feature gate (`CONCILIATION`), newest-first ordering, regular prescriptions excluded, and the five-record cap.
- **`POST /conciliation/copy`** — feature gate, unknown prescription, non-conciliation prescription, missing previous conciliation, item duplication with suspended items skipped, and copying from a conciliation that belongs to a previous admission of the same patient.

`services/conciliation_service.py` 23% → 100%, `routes/conciliation.py` 67% → 100%.

Two notes on how the tests are built:

- Features are read from the JWT claims first and then from the schema `features` memory. The claims are frozen at authentication time, so the fixture toggles the memory row and restores it on teardown.
- The `complete_prescricao` insert trigger does not carry `status` through its upsert, so a conciliation that needs a non-default status gets it via a follow-up update.

## 2. Admin max-dose reference — unit tests

`tests/unit/test_admin_drug_dosemax.py` (20 tests)

`get_max_dose_ref`, `calculate_dosemax_uniq` and `calculate_dosemax_bulk` in `services/admin/admin_drug_service.py` had no tests. They turn a substance's reference max dose into a max dose expressed in the unit the drug is actually prescribed in, so the conversion and the adult/pediatric split are worth pinning down.

Covered: rejection of a segment with no type, `no_reference` / `not_converted` / `converted` outcomes, adult vs pediatric reference selection, the conversion lookup being scoped to drug + segment + measure unit, three-decimal rounding, the absolute-only and weight-only cases, the `useWeight` branch that picks the effective max dose, clearing a stale max dose when the reference cannot be converted, and the bulk tallies plus the repository calls being skipped when nothing converted.

Reached through `__wrapped__` to bypass `@has_permission`, following the pattern already used in `tests/unit/test_unit_conversion_service.py`. No database or request context involved.

`services/admin/admin_drug_service.py` 51% → 79%.

## Test hygiene

`tests/conftest.py` now also deletes test-generated `demo.pessoa` rows (the conciliation tests create patients). Seed admission numbers top out at 9999, so the existing `>= 100000` threshold is safe. Both new files are re-runnable: the full suite was run twice back to back with no manual cleanup.

## Incidental finding (not fixed here)

`create_conciliation` sets `prescription.prescriber = user_context.name`, but `User.find` builds its user from JWT claims and never populates `name`, so the column always ends up `NULL`. The tests do not assert on `prescriber` either way — flagging it as a separate fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_013q66tEpQwEj7raMi8SjoJ2)_