### PR TITLE
test: cover primary-care patient listing and navigation copy

### DIFF
--- a/tests/integration/test_navigation_copy.py
+++ b/tests/integration/test_navigation_copy.py
@@ -1,0 +1,494 @@
+"""Integration tests for the navigation "copy patient" endpoint.
+
+Covers ``navigation_service.copy_patient`` (POST /navigation/copy), which had
+no coverage at all. The endpoint gathers the drugs of a patient's newest
+aggregated prescription, encrypts the identifying data (name, phone and
+clinical notes) and hands the whole payload to a backend Lambda that performs
+the copy in the destination schema.
+
+Only the Lambda call is mocked — the drug selection, the encryption and the
+error handling all run for real against the test database. The payload the
+service would have sent is captured from the mock and decrypted, so the tests
+assert on what actually crosses the boundary.
+"""
+
+import base64
+import io
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import text
+
+from config import Config
+from security.role import Role
+from tests.conftest import get_access, make_headers, session, session_commit
+
+URL = "/navigation/copy"
+
+# Non-CPOE cohort (department 1 -> segment 1).
+ADMISSION_STANDARD = 991001
+# CPOE cohort (department 3 -> segment 2).
+ADMISSION_CPOE = 991002
+# Patient without any aggregated prescription.
+ADMISSION_WITHOUT_AGG = 991003
+
+_ADMISSIONS = (ADMISSION_STANDARD, ADMISSION_CPOE, ADMISSION_WITHOUT_AGG)
+
+DEPARTMENT_STANDARD = 1
+DEPARTMENT_CPOE = 3
+
+AGG_DATE = datetime(2026, 1, 10, 12, 0)
+
+# Prescription ids, and the prescription-drug ids they carry.
+PRESC_AGG_STANDARD = 991100
+PRESC_OLD_GROUP = 991101
+PRESC_NEW_GROUP = 991102
+PRESC_AGG_CPOE = 991200
+PRESC_CPOE_A = 991201
+PRESC_CPOE_B = 991202
+
+DRUG_OLD_GROUP = 991101001
+DRUG_NEW_GROUP = 991102001
+DRUG_CPOE_A = 991201001
+DRUG_CPOE_B = 991202001
+
+BED = "301"
+INSURANCE = "zztest-insurance"
+
+PATIENT_NAME = "Zztest Paciente Navegação"
+PATIENT_PHONE = "+55 51 90000-0000"
+
+
+def _insert_patient(admission_number):
+    """Insert a ``pessoa`` row keyed by the given admission number."""
+    session.execute(
+        text(
+            "INSERT INTO demo.pessoa "
+            "(fkhospital, fkpessoa, nratendimento, dtnascimento, dtinternacao) "
+            "VALUES (1, :admission, :admission, :birthdate, :admitted)"
+        ),
+        {
+            "admission": admission_number,
+            "birthdate": datetime(1975, 5, 5),
+            "admitted": datetime(2026, 1, 1),
+        },
+    )
+
+
+def _insert_prescription(
+    id_prescription, admission_number, id_department, date, expire, agg=None
+):
+    """Insert a ``prescricao`` row.
+
+    ``idsegmento`` is left to the insert trigger, which derives it from the
+    department through ``demo.segmentosetor``.
+    """
+    session.execute(
+        text(
+            "INSERT INTO demo.prescricao "
+            "(fkhospital, fksetor, fkprescricao, fkpessoa, nratendimento, "
+            "dtprescricao, dtvigencia, agregada, status, leito, convenio) "
+            "VALUES (1, :department, :id, :admission, :admission, :date, "
+            ":expire, :agg, '0', :bed, :insurance)"
+        ),
+        {
+            "id": id_prescription,
+            "admission": admission_number,
+            "department": id_department,
+            "date": date,
+            "expire": expire,
+            "agg": agg,
+            "bed": BED,
+            "insurance": INSURANCE,
+        },
+    )
+
+
+def _insert_prescription_drug(id_prescription_drug, id_prescription, id_drug):
+    """Insert a ``presmed`` row attached to the given prescription."""
+    session.execute(
+        text(
+            "INSERT INTO demo.presmed "
+            "(fkpresmed, fkprescricao, fkmedicamento, fkunidademedida, "
+            "fkfrequencia, dose, frequenciadia, via, origem, status) "
+            "VALUES (:id, :prescription, :drug, 'mg', '1x', 100, 1, 'VO', "
+            "'Medicamentos', '0')"
+        ),
+        {
+            "id": id_prescription_drug,
+            "prescription": id_prescription,
+            "drug": id_drug,
+        },
+    )
+
+
+def _delete_cohort():
+    """Remove every row the cohort fixture creates."""
+    admissions = tuple(_ADMISSIONS)
+    session.execute(
+        text(
+            "DELETE FROM demo.presmed WHERE fkprescricao IN "
+            "(SELECT fkprescricao FROM demo.prescricao WHERE nratendimento IN "
+            ":admissions)"
+        ),
+        {"admissions": admissions},
+    )
+    session.execute(
+        text("DELETE FROM demo.prescricao WHERE nratendimento IN :admissions"),
+        {"admissions": admissions},
+    )
+    session.execute(
+        text("DELETE FROM demo.pessoa WHERE nratendimento IN :admissions"),
+        {"admissions": admissions},
+    )
+    session_commit()
+
+
+@pytest.fixture
+def cohort():
+    """Build the three admissions the copy tests operate on.
+
+    ``ADMISSION_STANDARD`` carries two open prescriptions with *different*
+    expiry dates, so the non-CPOE branch — which keeps only the drugs of the
+    latest expiry group — has something to discard.
+
+    ``ADMISSION_CPOE`` carries two open prescriptions in a CPOE segment, where
+    every drug is copied regardless of expiry.
+
+    ``ADMISSION_WITHOUT_AGG`` has no aggregated prescription at all.
+    """
+    _delete_cohort()
+
+    for admission in _ADMISSIONS:
+        _insert_patient(admission)
+
+    # --- non-CPOE admission
+    _insert_prescription(
+        id_prescription=PRESC_AGG_STANDARD,
+        admission_number=ADMISSION_STANDARD,
+        id_department=DEPARTMENT_STANDARD,
+        date=AGG_DATE,
+        expire=datetime(2026, 1, 11),
+        agg=True,
+    )
+    _insert_prescription(
+        id_prescription=PRESC_OLD_GROUP,
+        admission_number=ADMISSION_STANDARD,
+        id_department=DEPARTMENT_STANDARD,
+        date=datetime(2026, 1, 8),
+        expire=datetime(2026, 1, 10),
+        agg=None,
+    )
+    _insert_prescription(
+        id_prescription=PRESC_NEW_GROUP,
+        admission_number=ADMISSION_STANDARD,
+        id_department=DEPARTMENT_STANDARD,
+        date=datetime(2026, 1, 9),
+        expire=datetime(2026, 1, 12),
+        agg=None,
+    )
+    _insert_prescription_drug(DRUG_OLD_GROUP, PRESC_OLD_GROUP, id_drug=3)
+    _insert_prescription_drug(DRUG_NEW_GROUP, PRESC_NEW_GROUP, id_drug=4)
+
+    # --- CPOE admission
+    _insert_prescription(
+        id_prescription=PRESC_AGG_CPOE,
+        admission_number=ADMISSION_CPOE,
+        id_department=DEPARTMENT_CPOE,
+        date=AGG_DATE,
+        expire=datetime(2026, 1, 11),
+        agg=True,
+    )
+    _insert_prescription(
+        id_prescription=PRESC_CPOE_A,
+        admission_number=ADMISSION_CPOE,
+        id_department=DEPARTMENT_CPOE,
+        date=datetime(2026, 1, 8),
+        expire=datetime(2026, 1, 10),
+        agg=None,
+    )
+    _insert_prescription(
+        id_prescription=PRESC_CPOE_B,
+        admission_number=ADMISSION_CPOE,
+        id_department=DEPARTMENT_CPOE,
+        date=datetime(2026, 1, 9),
+        expire=datetime(2026, 1, 12),
+        agg=None,
+    )
+    _insert_prescription_drug(DRUG_CPOE_A, PRESC_CPOE_A, id_drug=3)
+    _insert_prescription_drug(DRUG_CPOE_B, PRESC_CPOE_B, id_drug=4)
+
+    # --- admission with no aggregated prescription
+    _insert_prescription(
+        id_prescription=991301,
+        admission_number=ADMISSION_WITHOUT_AGG,
+        id_department=DEPARTMENT_STANDARD,
+        date=datetime(2026, 1, 9),
+        expire=datetime(2026, 1, 12),
+        agg=None,
+    )
+
+    session_commit()
+
+    yield
+
+    _delete_cohort()
+
+
+@pytest.fixture
+def fernet(monkeypatch):
+    """Install a throwaway ENCRYPTION_KEY and return the matching Fernet."""
+    key = Fernet.generate_key()
+    monkeypatch.setattr(Config, "ENCRYPTION_KEY", key.decode("utf-8"))
+    return Fernet(key)
+
+
+@pytest.fixture
+def lambda_client():
+    """Patch the boto3 Lambda client and return the MagicMock standing in for it.
+
+    ``utils.aws.get_client`` is memoised, so the module attribute is patched
+    rather than the boto3 factory underneath it. The default response is a
+    successful copy; tests override ``invoke.return_value`` when they need a
+    different one.
+    """
+    client = MagicMock()
+    client.invoke.return_value = _lambda_response({"status": "success"})
+
+    with patch("services.navigation_service.aws.get_client", return_value=client):
+        yield client
+
+
+def _lambda_response(payload):
+    """Wrap a dict the way boto3 returns a Lambda RequestResponse invocation."""
+    return {"Payload": io.BytesIO(json.dumps(payload).encode("utf-8"))}
+
+
+def _body(admission_number, name=PATIENT_NAME, phone=PATIENT_PHONE, notes=None):
+    """Build a valid request body for the copy endpoint."""
+    return {
+        "admission_number": admission_number,
+        "name": name,
+        "phone": phone,
+        "clinical_notes": {"admission": "zztest note"} if notes is None else notes,
+    }
+
+
+def _sent_payload(lambda_client):
+    """Decode the JSON payload handed to the Lambda invocation."""
+    assert lambda_client.invoke.call_count == 1
+    return json.loads(lambda_client.invoke.call_args.kwargs["Payload"])
+
+
+def _decrypt(fernet, value):
+    """Reverse ``cryptutils.encrypt_data`` for an encrypted payload field."""
+    return fernet.decrypt(base64.b64decode(value)).decode("utf-8")
+
+
+# --- guards ----------------------------------------------------------------
+
+
+def test_copy_requires_the_nav_permission(client, cohort):
+    """An analyst has no NAV_COPY_PATIENT permission, so the copy is refused."""
+    headers = make_headers(get_access(client, roles=[Role.PRESCRIPTION_ANALYST.value]))
+
+    response = client.post(URL, json=_body(ADMISSION_STANDARD), headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_copy_rejects_an_incomplete_body(client, navigator_headers, cohort):
+    """Every NavCopyPatientRequest field is required [400]."""
+    response = client.post(
+        URL,
+        json={"admission_number": ADMISSION_STANDARD},
+        headers=navigator_headers,
+    )
+
+    assert response.status_code == 400
+
+
+def test_copy_rejects_an_admission_without_an_aggregated_prescription(
+    client, navigator_headers, cohort, lambda_client
+):
+    """Without an aggregated prescription there is nothing to copy [400]."""
+    response = client.post(
+        URL, json=_body(ADMISSION_WITHOUT_AGG), headers=navigator_headers
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Não há prescrição para este atendimento"
+    lambda_client.invoke.assert_not_called()
+
+
+# --- happy path ------------------------------------------------------------
+
+
+def test_copy_returns_the_lambda_response(
+    client, navigator_headers, cohort, fernet, lambda_client
+):
+    """The Lambda payload is returned to the caller untouched."""
+    lambda_client.invoke.return_value = _lambda_response(
+        {"status": "success", "admission_number": 4242}
+    )
+
+    response = client.post(
+        URL, json=_body(ADMISSION_STANDARD), headers=navigator_headers
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == {
+        "status": "success",
+        "admission_number": 4242,
+    }
+
+
+def test_copy_sends_the_admission_context_to_the_lambda(
+    client, navigator_headers, cohort, fernet, lambda_client
+):
+    """The payload names the command, both schemas and the admission context."""
+    client.post(URL, json=_body(ADMISSION_STANDARD), headers=navigator_headers)
+
+    payload = _sent_payload(lambda_client)
+
+    assert payload["command"] == "lambda_navigation.copy_patient_prescription"
+    assert payload["from_schema"] == "demo"
+    assert payload["to_schema"] == "demo"
+    assert payload["from_admission_number"] == ADMISSION_STANDARD
+    assert payload["id_department"] == DEPARTMENT_STANDARD
+    assert payload["bed"] == BED
+    assert payload["insurance"] == INSURANCE
+    assert payload["encrypted"] is True
+
+
+def test_copy_keeps_only_the_latest_expiry_group_outside_cpoe(
+    client, navigator_headers, cohort, fernet, lambda_client
+):
+    """Outside CPOE only the drugs of the latest expiry date are copied."""
+    client.post(URL, json=_body(ADMISSION_STANDARD), headers=navigator_headers)
+
+    assert _sent_payload(lambda_client)["drug_list"] == [DRUG_NEW_GROUP]
+
+
+def test_copy_keeps_every_drug_in_cpoe(
+    client, navigator_headers, cohort, fernet, lambda_client
+):
+    """In a CPOE segment the expiry grouping is skipped and all drugs go."""
+    client.post(URL, json=_body(ADMISSION_CPOE), headers=navigator_headers)
+
+    assert sorted(_sent_payload(lambda_client)["drug_list"]) == [
+        DRUG_CPOE_A,
+        DRUG_CPOE_B,
+    ]
+
+
+# --- encryption ------------------------------------------------------------
+
+
+def test_copy_encrypts_the_patient_identity(
+    client, navigator_headers, cohort, fernet, lambda_client
+):
+    """Name and phone travel encrypted, never in clear text."""
+    client.post(URL, json=_body(ADMISSION_STANDARD), headers=navigator_headers)
+
+    payload = _sent_payload(lambda_client)
+
+    assert payload["patient_name"] != PATIENT_NAME
+    assert payload["patient_phone"] != PATIENT_PHONE
+    assert _decrypt(fernet, payload["patient_name"]) == PATIENT_NAME
+    assert _decrypt(fernet, payload["patient_phone"]) == PATIENT_PHONE
+
+
+def test_copy_encrypts_every_clinical_note(
+    client, navigator_headers, cohort, fernet, lambda_client
+):
+    """Each clinical note value is encrypted under its own key."""
+    notes = {"admission": "zztest admission note", "evolution": "zztest evolution"}
+
+    client.post(
+        URL,
+        json=_body(ADMISSION_STANDARD, notes=notes),
+        headers=navigator_headers,
+    )
+
+    encrypted = _sent_payload(lambda_client)["clinical_notes"]
+
+    assert set(encrypted.keys()) == set(notes.keys())
+    for key, value in notes.items():
+        assert encrypted[key] != value
+        assert _decrypt(fernet, encrypted[key]) == value
+
+
+def test_copy_truncates_a_long_clinical_note(
+    client, navigator_headers, cohort, fernet, lambda_client
+):
+    """Notes are capped at 5000 characters and marked as truncated."""
+    long_note = "palavra " * 1000  # 8000 characters
+
+    client.post(
+        URL,
+        json=_body(ADMISSION_STANDARD, notes={"admission": long_note}),
+        headers=navigator_headers,
+    )
+
+    stored = _decrypt(
+        fernet, _sent_payload(lambda_client)["clinical_notes"]["admission"]
+    )
+
+    assert len(stored) <= 5000
+    assert stored.endswith("... [truncado]")
+
+
+def test_copy_nulls_out_non_string_clinical_notes(
+    client, navigator_headers, cohort, fernet, lambda_client
+):
+    """Empty or non-string note values are sent as None instead of ciphertext."""
+    client.post(
+        URL,
+        json=_body(
+            ADMISSION_STANDARD,
+            notes={"admission": "", "evolution": 42, "exam": None},
+        ),
+        headers=navigator_headers,
+    )
+
+    assert _sent_payload(lambda_client)["clinical_notes"] == {
+        "admission": None,
+        "evolution": None,
+        "exam": None,
+    }
+
+
+def test_copy_sends_no_clinical_notes_when_the_dict_is_empty(
+    client, navigator_headers, cohort, fernet, lambda_client
+):
+    """An empty clinical_notes dict stays empty in the payload."""
+    client.post(
+        URL,
+        json=_body(ADMISSION_STANDARD, notes={}),
+        headers=navigator_headers,
+    )
+
+    assert _sent_payload(lambda_client)["clinical_notes"] == {}
+
+
+# --- lambda failure --------------------------------------------------------
+
+
+def test_copy_reports_a_lambda_error_as_a_server_error(
+    client, navigator_headers, cohort, fernet, lambda_client
+):
+    """An "error" key in the Lambda response surfaces as a 500 to the caller."""
+    lambda_client.invoke.return_value = _lambda_response(
+        {"error": True, "message": "zztest lambda failure"}
+    )
+
+    response = client.post(
+        URL, json=_body(ADMISSION_STANDARD), headers=navigator_headers
+    )
+
+    assert response.status_code == 500
+    assert "Ocorreu um erro ao copiar" in response.get_json()["message"]

--- a/tests/integration/test_patient_list.py
+++ b/tests/integration/test_patient_list.py
@@ -1,0 +1,492 @@
+"""Integration tests for the primary-care patient listing endpoints.
+
+Covers ``patient_service.get_patients`` through both routes that reach it —
+``GET /patient`` (legacy query-string form) and ``POST /patient/list`` (JSON
+body form) — which had no coverage at all.
+
+The listing joins each ``pessoa`` row to its newest aggregated prescription
+and decorates it with the most recent "Agendamento" clinical note (the
+appointment date, exposed as ``refDate``). Every filter in
+``PatientListRequest`` narrows that query, so the fixtures below build a
+small, self-contained cohort and each test asserts which of those patients
+survive a given filter.
+
+All rows use the 99xxxx id range so they never collide with seed data nor
+with the 1000xx range that ``tests/utils/utils_test_prescription.py`` hands
+out, and they are removed again in the fixture teardown.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import FeatureEnum
+from models.main import User
+from security.role import Role
+from tests.conftest import get_access, make_headers, session, session_commit
+
+# One admission per patient; ids are reused across the three tables.
+ADMISSION_SCHEDULED = 990001
+ADMISSION_NOT_SCHEDULED = 990002
+ADMISSION_OTHER_SEGMENT = 990003
+ADMISSION_DISCHARGED = 990004
+
+_ADMISSIONS = (
+    ADMISSION_SCHEDULED,
+    ADMISSION_NOT_SCHEDULED,
+    ADMISSION_OTHER_SEGMENT,
+    ADMISSION_DISCHARGED,
+)
+
+# Departments: the cohort is split so idDepartment filtering is observable.
+# The prescricao insert trigger derives idsegmento from the department through
+# demo.segmentosetor, so the pairs below have to match that seed mapping.
+DEPARTMENT_A = 1  # -> segment 1
+SEGMENT_A = 1
+DEPARTMENT_B = 3  # -> segment 2
+SEGMENT_B = 2
+
+# Users referenced by the clinical notes, so scheduledBy/attendedBy differ.
+SCHEDULER_USER = 1
+ATTENDANT_USER = 2
+
+APPOINTMENT_DATE = datetime(2026, 3, 10, 8, 30)
+DISCHARGE_DATE = datetime(2026, 2, 1, 12, 0)
+
+TAG_INCLUDED = "ZZTEST_PMC_INCLUDED"
+TAG_EXCLUDED = "ZZTEST_PMC_EXCLUDED"
+
+_NOTE_ID_BASE = 990000
+
+
+def _insert_patient(admission_number, discharge_date=None, tags=None):
+    """Insert a ``pessoa`` row keyed by the given admission number."""
+    session.execute(
+        text(
+            "INSERT INTO demo.pessoa "
+            "(fkhospital, fkpessoa, nratendimento, dtnascimento, dtinternacao, "
+            "dtalta, marcadores, anotacao) "
+            "VALUES (1, :admission, :admission, :birthdate, :admitted, "
+            ":discharged, :tags, :observation)"
+        ),
+        {
+            "admission": admission_number,
+            "birthdate": datetime(1980, 1, 1),
+            "admitted": datetime(2026, 1, 1),
+            "discharged": discharge_date,
+            "tags": tags,
+            "observation": f"observation {admission_number}",
+        },
+    )
+
+
+def _insert_prescription(id_prescription, admission_number, id_department):
+    """Insert an aggregated ``prescricao`` row for the given admission.
+
+    ``idsegmento`` is left to the insert trigger, which resolves it from the
+    department through ``demo.segmentosetor``.
+    """
+    session.execute(
+        text(
+            "INSERT INTO demo.prescricao "
+            "(fkhospital, fksetor, fkprescricao, fkpessoa, nratendimento, "
+            "dtprescricao, agregada, status) "
+            "VALUES (1, :department, :id, :admission, :admission, "
+            ":date, true, '0')"
+        ),
+        {
+            "id": id_prescription,
+            "admission": admission_number,
+            "department": id_department,
+            "date": datetime(2026, 1, 2),
+        },
+    )
+
+
+def _insert_note(id_note, admission_number, position, date, user):
+    """Insert an ``evolucao`` row used as an appointment/attendance marker."""
+    session.execute(
+        text(
+            "INSERT INTO demo.evolucao "
+            "(fkevolucao, nratendimento, dtevolucao, texto, cargo, exame, update_by) "
+            "VALUES (:id, :admission, :date, 'zztest note', :position, false, :user)"
+        ),
+        {
+            "id": id_note,
+            "admission": admission_number,
+            "date": date,
+            "position": position,
+            "user": user,
+        },
+    )
+
+
+def _delete_cohort():
+    """Remove every row the cohort fixture creates."""
+    admissions = tuple(_ADMISSIONS)
+    session.execute(
+        text("DELETE FROM demo.evolucao WHERE nratendimento IN :admissions"),
+        {"admissions": admissions},
+    )
+    session.execute(
+        text("DELETE FROM demo.prescricao WHERE nratendimento IN :admissions"),
+        {"admissions": admissions},
+    )
+    session.execute(
+        text("DELETE FROM demo.pessoa WHERE nratendimento IN :admissions"),
+        {"admissions": admissions},
+    )
+    session_commit()
+
+
+@pytest.fixture
+def cohort():
+    """Build the patient cohort the listing tests filter over.
+
+    - ``ADMISSION_SCHEDULED``: department A, has an "Agendamento" note (so it
+      carries a ``refDate``) plus an attendance note.
+    - ``ADMISSION_NOT_SCHEDULED``: department A, no notes.
+    - ``ADMISSION_OTHER_SEGMENT``: department B (a different segment), no notes.
+    - ``ADMISSION_DISCHARGED``: department A, discharged, tagged.
+
+    ``ADMISSION_SCHEDULED`` gets two aggregated prescriptions so the "newest
+    aggregated prescription wins" join is exercised too.
+    """
+    _delete_cohort()
+
+    _insert_patient(ADMISSION_SCHEDULED)
+    _insert_patient(ADMISSION_NOT_SCHEDULED)
+    _insert_patient(ADMISSION_OTHER_SEGMENT)
+    _insert_patient(
+        ADMISSION_DISCHARGED,
+        discharge_date=DISCHARGE_DATE,
+        tags=[TAG_INCLUDED],
+    )
+
+    # older aggregated prescription — must lose to the newer one below
+    _insert_prescription(
+        id_prescription=ADMISSION_SCHEDULED,
+        admission_number=ADMISSION_SCHEDULED,
+        id_department=DEPARTMENT_A,
+    )
+    _insert_prescription(
+        id_prescription=ADMISSION_SCHEDULED + 500,
+        admission_number=ADMISSION_SCHEDULED,
+        id_department=DEPARTMENT_A,
+    )
+    _insert_prescription(
+        id_prescription=ADMISSION_NOT_SCHEDULED,
+        admission_number=ADMISSION_NOT_SCHEDULED,
+        id_department=DEPARTMENT_A,
+    )
+    _insert_prescription(
+        id_prescription=ADMISSION_OTHER_SEGMENT,
+        admission_number=ADMISSION_OTHER_SEGMENT,
+        id_department=DEPARTMENT_B,
+    )
+    _insert_prescription(
+        id_prescription=ADMISSION_DISCHARGED,
+        admission_number=ADMISSION_DISCHARGED,
+        id_department=DEPARTMENT_A,
+    )
+
+    _insert_note(
+        id_note=_NOTE_ID_BASE + 1,
+        admission_number=ADMISSION_SCHEDULED,
+        position="Agendamento",
+        date=APPOINTMENT_DATE,
+        user=SCHEDULER_USER,
+    )
+    _insert_note(
+        id_note=_NOTE_ID_BASE + 2,
+        admission_number=ADMISSION_SCHEDULED,
+        position="Enfermagem",
+        date=datetime(2026, 3, 1, 9, 0),
+        user=ATTENDANT_USER,
+    )
+
+    session_commit()
+
+    yield
+
+    _delete_cohort()
+
+
+@pytest.fixture
+def primary_care_headers(client):
+    """Headers for an analyst whose user config enables the PRIMARYCARE flag.
+
+    ``memory_service.has_feature`` accepts a per-user override, so the flag is
+    switched on through the demo user's config instead of mutating the shared
+    ``features`` memory row. The config is baked into the JWT claims at login,
+    so it has to be in place *before* authenticating.
+    """
+    user = session.query(User).filter_by(email="demo").first()
+    original_config = user.config
+
+    user.config = {
+        "roles": [Role.PRESCRIPTION_ANALYST.value],
+        "features": [
+            FeatureEnum.STAGING_ACCESS.value,
+            FeatureEnum.PRIMARY_CARE.value,
+        ],
+    }
+    session_commit()
+
+    response = client.post(
+        "/authenticate",
+        json={"email": "demo", "password": "demo"},
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    assert response.status_code == 200, "demo user must be able to authenticate"
+
+    yield make_headers(response.get_json()["access_token"])
+
+    user.config = original_config
+    session_commit()
+
+
+def _list(client, headers, **filters):
+    """POST /patient/list and return the response."""
+    return client.post("/patient/list", json=filters, headers=headers)
+
+
+def _admissions(response):
+    """Extract the cohort admission numbers from a successful response."""
+    return {
+        item["admissionNumber"]
+        for item in response.get_json()["data"]
+        if item["admissionNumber"] in _ADMISSIONS
+    }
+
+
+def _by_admission(response, admission_number):
+    """Return the single listing entry for the given admission number."""
+    matches = [
+        item
+        for item in response.get_json()["data"]
+        if item["admissionNumber"] == admission_number
+    ]
+    assert len(matches) == 1, f"expected exactly one entry for {admission_number}"
+    return matches[0]
+
+
+# --- guards ----------------------------------------------------------------
+
+
+def test_list_requires_read_prescription(client, cohort):
+    """A dispensing manager has no READ_PRESCRIPTION permission [401]."""
+    headers = make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+
+    response = _list(client, headers)
+
+    assert response.status_code == 401
+
+
+def test_list_requires_the_primary_care_feature(client, analyst_headers, cohort):
+    """Without the PRIMARYCARE flag the service rejects the request [400]."""
+    response = _list(client, analyst_headers)
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Funcionalidade não está habilitada"
+
+
+# --- unfiltered listing ----------------------------------------------------
+
+
+def test_list_returns_patients_with_an_aggregated_prescription(
+    client, primary_care_headers, cohort
+):
+    """Every cohort patient has an aggregated prescription, so all are listed."""
+    response = _list(client, primary_care_headers)
+
+    assert response.status_code == 200
+    assert _admissions(response) == set(_ADMISSIONS)
+
+
+def test_list_serializes_the_patient_payload(client, primary_care_headers, cohort):
+    """Each entry carries the patient identity, its observation and its tags."""
+    response = _list(client, primary_care_headers)
+
+    entry = _by_admission(response, ADMISSION_DISCHARGED)
+
+    assert entry["idPatient"] == ADMISSION_DISCHARGED
+    assert entry["birthdate"] == "1980-01-01"
+    assert entry["admissionDate"] == "2026-01-01T00:00:00"
+    assert entry["observation"] == f"observation {ADMISSION_DISCHARGED}"
+    assert entry["tags"] == [TAG_INCLUDED]
+
+
+def test_list_picks_the_newest_aggregated_prescription(
+    client, primary_care_headers, cohort
+):
+    """When a patient has several aggregated prescriptions the highest id wins."""
+    response = _list(client, primary_care_headers)
+
+    entry = _by_admission(response, ADMISSION_SCHEDULED)
+
+    assert entry["idPrescription"] == ADMISSION_SCHEDULED + 500
+
+
+def test_list_exposes_the_appointment_date_as_ref_date(
+    client, primary_care_headers, cohort
+):
+    """refDate is the latest "Agendamento" note date, and None without one."""
+    response = _list(client, primary_care_headers)
+
+    assert (
+        _by_admission(response, ADMISSION_SCHEDULED)["refDate"]
+        == APPOINTMENT_DATE.date().isoformat()
+    )
+    assert _by_admission(response, ADMISSION_NOT_SCHEDULED)["refDate"] is None
+
+
+# --- filters ---------------------------------------------------------------
+
+
+def test_list_filters_by_segment(client, primary_care_headers, cohort):
+    """idSegment keeps only the patients prescribed in that segment."""
+    response = _list(client, primary_care_headers, idSegment=SEGMENT_B)
+
+    assert response.status_code == 200
+    assert _admissions(response) == {ADMISSION_OTHER_SEGMENT}
+
+
+def test_list_filters_by_department(client, primary_care_headers, cohort):
+    """idDepartment accepts a list and matches the prescription department."""
+    response = _list(client, primary_care_headers, idDepartment=[DEPARTMENT_B])
+
+    assert response.status_code == 200
+    assert _admissions(response) == {ADMISSION_OTHER_SEGMENT}
+
+
+def test_list_filters_scheduled_patients(client, primary_care_headers, cohort):
+    """appointment=scheduled keeps only patients holding an appointment."""
+    response = _list(client, primary_care_headers, appointment="scheduled")
+
+    assert response.status_code == 200
+    assert _admissions(response) == {ADMISSION_SCHEDULED}
+
+
+def test_list_filters_not_scheduled_patients(client, primary_care_headers, cohort):
+    """appointment=not-scheduled is the complement of the scheduled filter."""
+    response = _list(client, primary_care_headers, appointment="not-scheduled")
+
+    assert response.status_code == 200
+    assert _admissions(response) == set(_ADMISSIONS) - {ADMISSION_SCHEDULED}
+
+
+def test_list_filters_by_appointment_window(client, primary_care_headers, cohort):
+    """A window around the appointment keeps the scheduled patient..."""
+    response = _list(
+        client,
+        primary_care_headers,
+        nextAppointmentStartDate="2026-03-01T00:00:00",
+        nextAppointmentEndDate="2026-03-31T00:00:00",
+    )
+
+    assert response.status_code == 200
+    assert _admissions(response) == {ADMISSION_SCHEDULED}
+
+
+def test_list_appointment_window_excludes_dates_outside_it(
+    client, primary_care_headers, cohort
+):
+    """...and a window that ends before it drops every cohort patient."""
+    response = _list(
+        client,
+        primary_care_headers,
+        nextAppointmentStartDate="2026-01-01T00:00:00",
+        nextAppointmentEndDate="2026-01-31T00:00:00",
+    )
+
+    assert response.status_code == 200
+    assert _admissions(response) == set()
+
+
+def test_list_filters_by_scheduled_by(client, primary_care_headers, cohort):
+    """scheduledBy matches the author of the "Agendamento" note only."""
+    scheduled = _list(client, primary_care_headers, scheduledBy=[SCHEDULER_USER])
+    other = _list(client, primary_care_headers, scheduledBy=[ATTENDANT_USER])
+
+    assert _admissions(scheduled) == {ADMISSION_SCHEDULED}
+    assert _admissions(other) == set()
+
+
+def test_list_filters_by_attended_by(client, primary_care_headers, cohort):
+    """attendedBy matches the author of any non-"Agendamento" note."""
+    attended = _list(client, primary_care_headers, attendedBy=[ATTENDANT_USER])
+    other = _list(client, primary_care_headers, attendedBy=[SCHEDULER_USER])
+
+    assert _admissions(attended) == {ADMISSION_SCHEDULED}
+    assert _admissions(other) == set()
+
+
+def test_list_filters_by_discharge_date_range(client, primary_care_headers, cohort):
+    """A discharge range keeps only the discharged patient."""
+    response = _list(
+        client,
+        primary_care_headers,
+        dischargeDateStart="2026-01-15T00:00:00",
+        dischargeDateEnd="2026-02-15T00:00:00",
+    )
+
+    assert response.status_code == 200
+    assert _admissions(response) == {ADMISSION_DISCHARGED}
+
+
+def test_list_filters_by_tags(client, primary_care_headers, cohort):
+    """tags overlaps the patient tag array; an unused tag matches nobody."""
+    tagged = _list(client, primary_care_headers, tags=[TAG_INCLUDED])
+    untagged = _list(client, primary_care_headers, tags=[TAG_EXCLUDED])
+
+    assert _admissions(tagged) == {ADMISSION_DISCHARGED}
+    assert _admissions(untagged) == set()
+
+
+def test_list_combines_filters(client, primary_care_headers, cohort):
+    """Filters are additive: the first segment plus scheduled leaves one patient."""
+    response = _list(
+        client,
+        primary_care_headers,
+        idSegment=SEGMENT_A,
+        appointment="scheduled",
+    )
+
+    assert response.status_code == 200
+    assert _admissions(response) == {ADMISSION_SCHEDULED}
+
+
+def test_list_rejects_an_unparsable_filter(client, primary_care_headers, cohort):
+    """A non-date value for a date filter fails Pydantic validation [400]."""
+    response = _list(client, primary_care_headers, dischargeDateStart="not-a-date")
+
+    assert response.status_code == 400
+
+
+# --- legacy GET route ------------------------------------------------------
+
+
+def test_legacy_get_route_lists_the_same_patients(client, primary_care_headers, cohort):
+    """GET /patient reaches the same service and honours the same filters."""
+    response = client.get(
+        f"/patient?idSegment={SEGMENT_B}&appointment=not-scheduled",
+        headers=primary_care_headers,
+    )
+
+    assert response.status_code == 200
+    assert _admissions(response) == {ADMISSION_OTHER_SEGMENT}
+
+
+def test_legacy_get_route_reads_repeated_department_params(
+    client, primary_care_headers, cohort
+):
+    """The legacy route collects repeated idDepartment[] params into a list."""
+    response = client.get(
+        f"/patient?idDepartment[]={DEPARTMENT_B}&idDepartment[]={DEPARTMENT_A}",
+        headers=primary_care_headers,
+    )
+
+    assert response.status_code == 200
+    assert _admissions(response) == set(_ADMISSIONS)


### PR DESCRIPTION
Adds integration coverage for two features that had none.

## 1. Primary-care patient listing

`patient_service.get_patients`, reached by both `GET /patient` (legacy query-string form) and `POST /patient/list` (JSON body form). Nothing in the suite touched it.

`tests/integration/test_patient_list.py` builds a small cohort of patients with aggregated prescriptions and clinical notes, then asserts:

- the `READ_PRESCRIPTION` permission guard and the `PRIMARYCARE` feature guard;
- the serialized payload (identity, observation, tags);
- the "newest aggregated prescription wins" join, using a patient with two of them;
- `refDate` resolving to the latest `Agendamento` note, and `None` without one;
- every filter in `PatientListRequest` — `idSegment`, `idDepartment`, `appointment` (scheduled / not-scheduled), the appointment date window, `scheduledBy`, `attendedBy`, the discharge-date range, `tags`, filters combined, and an unparsable date;
- the legacy `GET` route, including its repeated `idDepartment[]` params.

The cohort leaves `idsegmento` to the `prescricao` insert trigger, which derives it from the department through `demo.segmentosetor`.

## 2. Navigation copy patient

`navigation_service.copy_patient` (`POST /navigation/copy`). Also untested.

`tests/integration/test_navigation_copy.py` mocks only the Lambda boundary — the drug selection, the encryption and the error handling all run for real against the test database. The payload the service hands to the Lambda is captured and decrypted, so the assertions are on what actually crosses the boundary:

- the `NAV_COPY_PATIENT` guard and request-body validation;
- a 400 when the admission has no aggregated prescription, with no Lambda call;
- the command, both schemas and the admission context in the payload;
- the drug selection: outside CPOE only the latest expiry group is copied, inside CPOE every drug is;
- name, phone and each clinical note encrypted (never in clear text), notes truncated at 5000 chars with the `... [truncado]` marker, non-string note values nulled out, an empty notes dict left empty;
- an `error` key in the Lambda response surfacing as a 500.

## Coverage

| | before | after |
|---|---|---|
| `services/navigation_service.py` | 37% | 97% |
| `routes/navigation.py` | 89% | 100% |
| `services/patient_service.py` | 38% | 55% |
| `routes/patient.py` | 86% | 95% |

Overall (`services` + `repository` + `utils` + `routes`): 69% → 70%.

## Testing

Full suite run locally against a PostgreSQL instance loaded from `noharm-ai/database` (the same SQL files CI uses): **1416 passed** (1383 before, +33). Both new files are re-runnable — each fixture deletes its rows on setup as well as teardown — and all new rows use the 99xxxx id range, clear of both the seed data and the 1000xx range `tests/utils/utils_test_prescription.py` hands out.

No production code was changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mpmq1a1aTEaoTMZRdPaWBL)_