### PR TITLE
Add multi-prompt SOAP config support with variant selection

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -207,7 +207,7 @@ Set `idPrescriptionDrugList` (array of ints) to save the same intervention on mu
 | `GET` | `/notes/<admissionNumber>/v2` | Get clinical notes for a patient (`?date=`). |
 | `GET` | `/notes/single/<idClinicalNotes>` | Get a single clinical note. |
 | `POST` | `/notes` | Create a clinical note. |
-| `POST` | `/notes/soap` | Generate a SOAP evolution from a clinical note via LLM. |
+| `POST` | `/notes/soap` | Generate a SOAP evolution from a clinical note via LLM (optional `prompt_key` selects a prompt version). |
 | `POST` | `/notes/<idNote>` | Update a clinical note. |
 | `POST` | `/notes/remove-annotation` | Remove an annotation from a note. |
 | `GET` | `/notes/get-user-last` | Get the current user's last notes (`?admissionNumber=`). |

--- a/models/enums.py
+++ b/models/enums.py
@@ -36,6 +36,7 @@ class GlobalMemoryEnum(Enum):
     N0_AGENT = "n0-agent"
     USER_KB = "user-kb"
     NAV_SOAP_CONFIG = "nav-soap-config"
+    NAV_SOAP_CONFIG_V2 = "nav-soap-config-v2"
 
 
 class NoHarmENV(Enum):

--- a/models/main.py
+++ b/models/main.py
@@ -17,6 +17,10 @@ def redis_cert_reqs(env: str):
     """
     return None if env == NoHarmENV.DEVELOPMENT.value else "required"
 
+def redis_timeout(env: str):
+    """redis timeout based on env"""
+    return 0 if env == NoHarmENV.DEVELOPMENT.value else 2
+
 
 redis_client = redis.StrictRedis(
     host=Config.REDIS_HOST,
@@ -25,8 +29,8 @@ redis_client = redis.StrictRedis(
     decode_responses=True,
     ssl=True,
     ssl_cert_reqs=redis_cert_reqs(Config.ENV),
-    socket_timeout=2,
-    socket_connect_timeout=2,
+    socket_timeout=redis_timeout(Config.ENV),
+    socket_connect_timeout=redis_timeout(Config.ENV),
 )
 
 

--- a/models/requests/clinical_notes_request.py
+++ b/models/requests/clinical_notes_request.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 
@@ -5,3 +7,4 @@ class GenerateSoapRequest(BaseModel):
     """Request model for LLM-based SOAP evolution generation from a clinical note"""
 
     id: int
+    prompt_key: Optional[str] = None

--- a/services/soap_service.py
+++ b/services/soap_service.py
@@ -21,7 +21,14 @@ SOAP_INPUT_MAX_CHARS = 60000
 def generate_soap(request_data: GenerateSoapRequest, user_context: User):
     """Generate a SOAP-format pharmaceutical evolution from a clinical note via LLM."""
 
-    config = _get_config()
+    prompts_config = _get_prompts_config()
+
+    if prompts_config:
+        config, prompt_key, prompt_options = _resolve_prompt_variant(
+            config=prompts_config, prompt_key=request_data.prompt_key
+        )
+    else:
+        config, prompt_key, prompt_options = _get_config(), None, []
 
     note = (
         db.session.query(ClinicalNotes)
@@ -48,7 +55,11 @@ def generate_soap(request_data: GenerateSoapRequest, user_context: User):
         messages=messages, system=config.get("prompt"), config=config
     )
 
-    return {"text": generated_text}
+    return {
+        "text": generated_text,
+        "prompt_key": prompt_key,
+        "prompt_options": prompt_options,
+    }
 
 
 def _get_config() -> dict:
@@ -73,6 +84,76 @@ def _get_config() -> dict:
         )
 
     return config.value
+
+
+def _get_prompts_config() -> dict | None:
+    """Load the multi-prompt SOAP config from global memory, if it exists."""
+
+    config = (
+        db.session.query(GlobalMemory)
+        .filter(GlobalMemory.kind == GlobalMemoryEnum.NAV_SOAP_CONFIG_V2.value)
+        .first()
+    )
+
+    if not config:
+        return None
+
+    prompts = (config.value or {}).get("prompts")
+
+    if not prompts or not isinstance(prompts, list):
+        raise ValidationError(
+            "Configuração da evolução SOAP não encontrada.",
+            "errors.businessRules",
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+    return config.value
+
+
+def _resolve_prompt_variant(
+    config: dict, prompt_key: str | None
+) -> tuple[dict, str, list]:
+    """Resolve the prompt variant to use and the list of available options."""
+
+    prompts = config.get("prompts")
+    options = [{"key": p.get("key"), "label": p.get("label")} for p in prompts]
+
+    key = prompt_key or config.get("default_key") or prompts[0].get("key")
+
+    variant = next((p for p in prompts if p.get("key") == key), None)
+
+    if prompt_key and not variant:
+        raise ValidationError(
+            "Versão de prompt inválida",
+            "errors.invalidParam",
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    if not variant or not variant.get("prompt"):
+        raise ValidationError(
+            "Configuração da evolução SOAP não encontrada.",
+            "errors.businessRules",
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+    model_id = variant.get("model_id") or config.get("model_id")
+
+    if not model_id:
+        raise ValidationError(
+            "Configuração da evolução SOAP não encontrada.",
+            "errors.businessRules",
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+    resolved = {
+        "prompt": variant.get("prompt"),
+        "model_id": model_id,
+        "max_tokens": variant.get("max_tokens")
+        or config.get("max_tokens")
+        or SOAP_DEFAULT_MAX_TOKENS,
+    }
+
+    return resolved, key, options
 
 
 def _get_note_content(note: ClinicalNotes) -> str:

--- a/tests/integration/test_notes_soap.py
+++ b/tests/integration/test_notes_soap.py
@@ -43,6 +43,57 @@ def soap_test_data():
     session_commit()
 
 
+@pytest.fixture
+def soap_v2_test_data():
+    """Insert legacy + multi-prompt (v2) soap configs and a source clinical note"""
+    session.execute(
+        text(
+            "INSERT INTO public.memoria (tipo, valor, update_at, update_by) "
+            "VALUES ('nav-soap-config', CAST(:value AS json), now(), 1)"
+        ),
+        {"value": '{"prompt": "legacy prompt", "model_id": "test-model-id"}'},
+    )
+    session.execute(
+        text(
+            "INSERT INTO public.memoria (tipo, valor, update_at, update_by) "
+            "VALUES ('nav-soap-config-v2', CAST(:value AS json), now(), 1)"
+        ),
+        {
+            "value": '{"model_id": "test-model-id", "default_key": "guide", '
+            '"prompts": ['
+            '{"key": "guide", "label": "Novo formato", "prompt": "guide prompt"}, '
+            '{"key": "classic", "label": "Padrão", "prompt": "classic prompt"}'
+            "]}"
+        },
+    )
+    session.execute(
+        text(
+            "INSERT INTO demo.evolucao "
+            "(fkevolucao, nratendimento, texto, dtevolucao, cargo, exame, formulario) "
+            "VALUES (:id, :admission, 'Pré-Consulta de teste', now(), "
+            "'Farmacêutica', false, CAST(:form AS json))"
+        ),
+        {
+            "id": SOAP_NOTE_ID,
+            "admission": ADMISSION_NUMBER,
+            "form": '{"pre-consulta": {"condicao": "AVCi"}}',
+        },
+    )
+    session_commit()
+    yield
+    session.execute(
+        text("DELETE FROM demo.evolucao WHERE fkevolucao = :id"),
+        {"id": SOAP_NOTE_ID},
+    )
+    session.execute(
+        text(
+            "DELETE FROM public.memoria "
+            "WHERE tipo IN ('nav-soap-config', 'nav-soap-config-v2')"
+        )
+    )
+    session_commit()
+
+
 def test_generate_soap_no_token(client):
     """POST /notes/soap — returns 401 without authentication"""
     response = client.post(
@@ -80,11 +131,79 @@ def test_generate_soap(client, navigator_headers, soap_test_data, monkeypatch):
     response = client.post(URL, json={"id": SOAP_NOTE_ID}, headers=navigator_headers)
 
     assert response.status_code == 200
-    assert response.get_json()["data"]["text"] == FAKE_SOAP_TEXT
+    data = response.get_json()["data"]
+    assert data["text"] == FAKE_SOAP_TEXT
+    # legacy single-prompt config: no variant used and no options exposed
+    assert data["prompt_key"] is None
+    assert data["prompt_options"] == []
     assert captured["system"] == "test soap prompt"
     # the note's form answers and text must be part of the LLM input
     assert "AVCi" in captured["messages"][0]["content"]
     assert "Pré-Consulta de teste" in captured["messages"][0]["content"]
+
+
+def test_generate_soap_v2_default_prompt(
+    client, navigator_headers, soap_v2_test_data, monkeypatch
+):
+    """POST /notes/soap — v2 config takes precedence and uses the default variant"""
+    captured = {}
+
+    def fake_prompt(messages, system, config):
+        captured["system"] = system
+        captured["config"] = config
+        return FAKE_SOAP_TEXT
+
+    monkeypatch.setattr(soap_service, "_prompt_soap", fake_prompt)
+
+    response = client.post(URL, json={"id": SOAP_NOTE_ID}, headers=navigator_headers)
+
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert data["text"] == FAKE_SOAP_TEXT
+    assert data["prompt_key"] == "guide"
+    assert data["prompt_options"] == [
+        {"key": "guide", "label": "Novo formato"},
+        {"key": "classic", "label": "Padrão"},
+    ]
+    assert captured["system"] == "guide prompt"
+    assert captured["config"]["model_id"] == "test-model-id"
+
+
+def test_generate_soap_v2_selected_prompt(
+    client, navigator_headers, soap_v2_test_data, monkeypatch
+):
+    """POST /notes/soap — an explicit prompt_key selects that variant"""
+    captured = {}
+
+    def fake_prompt(messages, system, config):
+        captured["system"] = system
+        return FAKE_SOAP_TEXT
+
+    monkeypatch.setattr(soap_service, "_prompt_soap", fake_prompt)
+
+    response = client.post(
+        URL,
+        json={"id": SOAP_NOTE_ID, "prompt_key": "classic"},
+        headers=navigator_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert data["prompt_key"] == "classic"
+    assert captured["system"] == "classic prompt"
+
+
+def test_generate_soap_v2_unknown_prompt_key(
+    client, navigator_headers, soap_v2_test_data
+):
+    """POST /notes/soap — returns 400 for a prompt_key not present in the config"""
+    response = client.post(
+        URL,
+        json={"id": SOAP_NOTE_ID, "prompt_key": "does-not-exist"},
+        headers=navigator_headers,
+    )
+
+    assert response.status_code == 400
 
 
 def test_generate_soap_missing_config(client, navigator_headers):

--- a/tests/unit/test_soap_service.py
+++ b/tests/unit/test_soap_service.py
@@ -7,7 +7,11 @@ the database or the Bedrock client, so they run as fast unit tests.
 
 import json
 
+import pytest
+
+from exception.validation_error import ValidationError
 from services import soap_service
+from utils import status
 
 
 class _Note:
@@ -125,6 +129,118 @@ class TestGetFormContent:
         form = {"known": "sim", "empty": ""}
         result = soap_service._get_form_content(form=form, template=template)
         assert "Pergunta: empty" not in result
+
+
+class TestResolvePromptVariant:
+    """Tests for soap_service._resolve_prompt_variant (multi-prompt config)."""
+
+    def _config(self, **overrides):
+        """Build a valid multi-prompt config dict, allowing per-test overrides."""
+        config = {
+            "model_id": "top-model",
+            "max_tokens": 2048,
+            "default_key": "guide",
+            "prompts": [
+                {"key": "guide", "label": "Novo formato", "prompt": "guide prompt"},
+                {"key": "classic", "label": "Padrão", "prompt": "classic prompt"},
+            ],
+        }
+        config.update(overrides)
+        return config
+
+    def test_explicit_key_selects_variant(self):
+        """An explicit prompt_key picks the matching variant."""
+        resolved, key, _ = soap_service._resolve_prompt_variant(
+            config=self._config(), prompt_key="classic"
+        )
+        assert key == "classic"
+        assert resolved["prompt"] == "classic prompt"
+
+    def test_default_key_used_when_no_key(self):
+        """Without a prompt_key the config's default_key is used."""
+        resolved, key, _ = soap_service._resolve_prompt_variant(
+            config=self._config(), prompt_key=None
+        )
+        assert key == "guide"
+        assert resolved["prompt"] == "guide prompt"
+
+    def test_first_variant_used_without_default_key(self):
+        """Without default_key the first prompts entry is the default."""
+        config = self._config()
+        del config["default_key"]
+        _, key, _ = soap_service._resolve_prompt_variant(config=config, prompt_key=None)
+        assert key == "guide"
+
+    def test_options_list_all_variants(self):
+        """The options list exposes key/label of every configured variant."""
+        _, _, options = soap_service._resolve_prompt_variant(
+            config=self._config(), prompt_key=None
+        )
+        assert options == [
+            {"key": "guide", "label": "Novo formato"},
+            {"key": "classic", "label": "Padrão"},
+        ]
+
+    def test_unknown_explicit_key_raises_400(self):
+        """A prompt_key not present in the config is a client error."""
+        with pytest.raises(ValidationError) as error:
+            soap_service._resolve_prompt_variant(
+                config=self._config(), prompt_key="nope"
+            )
+        assert error.value.httpStatus == status.HTTP_400_BAD_REQUEST
+
+    def test_broken_default_key_raises_500(self):
+        """A default_key pointing to no variant is a config error, not a 400."""
+        with pytest.raises(ValidationError) as error:
+            soap_service._resolve_prompt_variant(
+                config=self._config(default_key="ghost"), prompt_key=None
+            )
+        assert error.value.httpStatus == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    def test_variant_model_id_overrides_top_level(self):
+        """A variant-level model_id wins over the top-level one."""
+        config = self._config()
+        config["prompts"][0]["model_id"] = "variant-model"
+        resolved, _, _ = soap_service._resolve_prompt_variant(
+            config=config, prompt_key="guide"
+        )
+        assert resolved["model_id"] == "variant-model"
+
+    def test_top_level_model_id_fallback(self):
+        """Variants without model_id inherit the top-level model_id."""
+        resolved, _, _ = soap_service._resolve_prompt_variant(
+            config=self._config(), prompt_key="guide"
+        )
+        assert resolved["model_id"] == "top-model"
+
+    def test_missing_model_id_raises_500(self):
+        """No resolvable model_id anywhere is a config error."""
+        config = self._config()
+        del config["model_id"]
+        with pytest.raises(ValidationError) as error:
+            soap_service._resolve_prompt_variant(config=config, prompt_key="guide")
+        assert error.value.httpStatus == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    def test_max_tokens_fallback_chain(self):
+        """max_tokens resolves variant -> top-level -> module default."""
+        config = self._config()
+        config["prompts"][0]["max_tokens"] = 1024
+        resolved, _, _ = soap_service._resolve_prompt_variant(
+            config=config, prompt_key="guide"
+        )
+        assert resolved["max_tokens"] == 1024
+
+        resolved, _, _ = soap_service._resolve_prompt_variant(
+            config=self._config(), prompt_key="guide"
+        )
+        assert resolved["max_tokens"] == 2048
+
+        config = self._config()
+        del config["max_tokens"]
+        resolved, _, _ = soap_service._resolve_prompt_variant(
+            config=config, prompt_key="guide"
+        )
+        assert resolved["max_tokens"] == soap_service.SOAP_DEFAULT_MAX_TOKENS
 
 
 class TestGetNoteContent:


### PR DESCRIPTION
## Summary

Implement support for multi-prompt SOAP configurations (v2) that allow users to select between different prompt variants when generating pharmaceutical evolution notes. The system maintains backward compatibility with legacy single-prompt configs while prioritizing the new v2 format when available.

## Key Changes

- **New multi-prompt config model**: Added `NAV_SOAP_CONFIG_V2` enum and `_get_prompts_config()` function to load v2 configurations from global memory
- **Prompt variant resolution**: Implemented `_resolve_prompt_variant()` to handle:
  - Explicit prompt selection via `prompt_key` parameter
  - Default variant fallback when no selection is made
  - Model ID and max_tokens inheritance (variant-level overrides top-level config)
  - Proper error handling (400 for invalid user selection, 500 for config errors)
- **API enhancements**:
  - Added optional `prompt_key` parameter to `GenerateSoapRequest`
  - Extended response to include `prompt_key` (selected variant) and `prompt_options` (available variants with labels)
  - Legacy configs return `null` for prompt_key and empty options list
- **Redis timeout optimization**: Made socket timeouts environment-aware (0 in development, 2s in production) to improve local development experience
- **Comprehensive test coverage**:
  - Integration tests for v2 config with default and explicit variant selection
  - Error handling tests for invalid prompt keys
  - Unit tests for variant resolution logic including fallback chains and error conditions

## Implementation Details

The `_resolve_prompt_variant()` function implements a robust resolution strategy:
1. Resolves the active prompt key (explicit > default_key > first variant)
2. Validates the selected variant exists (400 error if explicit key not found)
3. Builds options list exposing all available variants to the client
4. Merges configuration with proper precedence: variant-level > top-level > module defaults
5. Returns the resolved config, selected key, and available options

The system gracefully handles both legacy and v2 configs, with v2 taking precedence when both exist.

https://claude.ai/code/session_01Q4Qw2cTg8JBDYRMm3heziw