### PR TITLE
test: cover internal reports and prescription evaluation presence

### DIFF
--- a/tests/integration/test_prescription_evaluation.py
+++ b/tests/integration/test_prescription_evaluation.py
@@ -1,0 +1,335 @@
+"""Tests: POST /prescriptions/start-evaluation and POST /prescriptions/status-list
+
+Two pharmacists may open the same prescription at once, so the frontend polls
+these endpoints to show who else is on the screen and whether a prescription has
+been checked in the meantime.
+
+The presence store itself is DynamoDB, and it short-circuits under ENV=test (see
+``repository.prescription_presence_repository``), so it is replaced here with a
+recorder. What is left is exactly the backend's own share of the feature, and
+that is what these tests pin down:
+
+* an unknown or missing prescription id is refused before the store is touched;
+* the heartbeat -- "I am editing this" -- is only recorded for a caller who can
+  actually write the prescription, so a read-only viewer never appears as one of
+  the editors;
+* the partition key carries the caller's schema, so presence never leaks across
+  tenants;
+* whatever the store returns is normalised before it reaches the client.
+
+``status-list`` is the cheap companion poll, and it has its own contract: it
+never joins, it drops ids that are not numbers, and it stays silent about
+prescriptions that do not exist.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from repository import prescription_presence_repository
+from tests.conftest import session, session_commit
+from tests.utils import utils_test_prescription
+from utils import status
+
+START_URL = "/prescriptions/start-evaluation"
+STATUS_URL = "/prescriptions/status-list"
+
+# the user behind every fixture in tests.conftest.get_access
+CALLER_ID = 1
+CALLER_NAME = "Demonstração"
+CALLER_SCHEMA = "demo"
+
+# far outside the seed range and outside the >= 100000 range the test helpers use
+MISSING_PRESCRIPTION = 999999999
+
+# demo.prescricao.status, as set by /prescriptions/status
+CHECKED = "s"
+OPEN = "0"
+
+
+def _create_prescription(prescription_status: str) -> int:
+    """Write a prescription in a known status and return its id.
+
+    Written rather than taken from the seed dump: the poll asserts on the status,
+    and the seed statuses are mutated by other modules. The id comes from the
+    shared >= 100000 counter, so tests.conftest cleans it up.
+
+    The status is set with an UPDATE because the BEFORE INSERT trigger on
+    demo.prescricao rewrites the row through public.upsert_prescricao, which
+    normalises a new prescription back to "not checked".
+    """
+    id_prescription = utils_test_prescription.test_counters["id_prescription"]
+    utils_test_prescription.test_counters["id_prescription"] += 1
+
+    utils_test_prescription.create_prescription(
+        id=id_prescription,
+        admissionNumber=1,
+        idPatient=1,
+    )
+
+    session.execute(
+        text("UPDATE demo.prescricao SET status = :status WHERE fkprescricao = :id"),
+        {"status": prescription_status, "id": id_prescription},
+    )
+    session_commit()
+
+    return id_prescription
+
+
+@pytest.fixture
+def open_prescription() -> int:
+    """A prescription still waiting to be checked."""
+    return _create_prescription(OPEN)
+
+
+@pytest.fixture
+def checked_prescription() -> int:
+    """A prescription a pharmacist has already checked."""
+    return _create_prescription(CHECKED)
+
+
+@pytest.fixture(autouse=True)
+def presence(monkeypatch):
+    """Replace the DynamoDB presence store with a recorder.
+
+    ``heartbeats`` collects every call, and ``viewers`` is what the store hands
+    back for the prescription being opened.
+    """
+    recorder = {"heartbeats": [], "viewers": []}
+
+    def _record_heartbeat(schema, id_prescription, user_id, user_name):
+        recorder["heartbeats"].append(
+            {
+                "schema": schema,
+                "id_prescription": id_prescription,
+                "user_id": user_id,
+                "user_name": user_name,
+            }
+        )
+        return {}
+
+    def _get_active_viewers(schema, id_prescription):
+        recorder["queried"] = {"schema": schema, "id_prescription": id_prescription}
+        return recorder["viewers"]
+
+    monkeypatch.setattr(
+        prescription_presence_repository, "record_heartbeat", _record_heartbeat
+    )
+    monkeypatch.setattr(
+        prescription_presence_repository, "get_active_viewers", _get_active_viewers
+    )
+
+    return recorder
+
+
+def _start(client, headers, id_prescription):
+    """Open a prescription for evaluation."""
+    return client.post(
+        START_URL,
+        data=json.dumps({"idPrescription": id_prescription}),
+        headers=headers,
+    )
+
+
+def _status(client, headers, id_prescription_list):
+    """Poll the status of a list of prescriptions."""
+    return client.post(
+        STATUS_URL,
+        data=json.dumps({"idPrescriptionList": id_prescription_list}),
+        headers=headers,
+    )
+
+
+def _data(response):
+    """The payload of a successful api_endpoint response."""
+    return json.loads(response.data)["data"]
+
+
+# --- the prescription has to exist --------------------------------------------
+
+
+def test_an_unknown_prescription_is_refused(client, analyst_headers, presence):
+    """No heartbeat is recorded for a prescription that does not exist [400]."""
+    response = _start(client, analyst_headers, MISSING_PRESCRIPTION)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRegister"
+    assert presence["heartbeats"] == []
+
+
+def test_a_missing_prescription_id_is_refused(client, analyst_headers, presence):
+    """An absent idPrescription is the same case, not a lookup for NULL [400]."""
+    response = client.post(START_URL, data=json.dumps({}), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRegister"
+    assert presence["heartbeats"] == []
+
+
+# --- who counts as an editor --------------------------------------------------
+
+
+def test_a_user_who_can_write_is_recorded_as_editing(
+    client, analyst_headers, presence, open_prescription
+):
+    """PRESCRIPTION_ANALYST holds WRITE_PRESCRIPTION, so the heartbeat lands.
+
+    The recorded name is read from the database rather than the token, since it
+    is what the other viewers will see on their screen.
+    """
+    response = _start(client, analyst_headers, open_prescription)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert presence["heartbeats"] == [
+        {
+            "schema": CALLER_SCHEMA,
+            "id_prescription": open_prescription,
+            "user_id": CALLER_ID,
+            "user_name": CALLER_NAME,
+        }
+    ]
+
+
+def test_a_read_only_user_is_not_recorded_as_editing(
+    client, viewer_headers, presence, open_prescription
+):
+    """VIEWER can read the prescription but not write it, so it stays invisible
+    to the other viewers -- and still gets the list of who is editing [200 OK]."""
+    presence["viewers"] = [
+        {"userId": "7", "userName": "Outro", "startDate": "2026-01-01T12:00:00"}
+    ]
+
+    response = _start(client, viewer_headers, open_prescription)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert presence["heartbeats"] == []
+    assert _data(response) == [
+        {"userId": 7, "userName": "Outro", "startDate": "2026-01-01T12:00:00"}
+    ]
+
+
+def test_presence_is_queried_within_the_callers_schema(
+    client, analyst_headers, presence, open_prescription
+):
+    """The lookup is scoped by the JWT schema, never by the request [200 OK]."""
+    _start(client, analyst_headers, open_prescription)
+
+    assert presence["queried"] == {
+        "schema": CALLER_SCHEMA,
+        "id_prescription": open_prescription,
+    }
+
+
+# --- what the client is told ---------------------------------------------------
+
+
+def test_nobody_else_on_the_screen_is_an_empty_list(
+    client, analyst_headers, presence, open_prescription
+):
+    """The common case: the caller is alone [200 OK]."""
+    presence["viewers"] = []
+
+    assert _data(_start(client, analyst_headers, open_prescription)) == []
+
+
+def test_viewers_are_normalised_before_they_reach_the_client(
+    client, analyst_headers, presence, open_prescription
+):
+    """DynamoDB hands back numbers as Decimal and may omit attributes, so ids
+    are coerced to int and the optional fields default to None [200 OK]."""
+    presence["viewers"] = [
+        {"userId": "12", "userName": "Com nome", "startDate": "2026-01-01T12:00:00"},
+        {"userId": 13},
+    ]
+
+    assert _data(_start(client, analyst_headers, open_prescription)) == [
+        {"userId": 12, "userName": "Com nome", "startDate": "2026-01-01T12:00:00"},
+        {"userId": 13, "userName": None, "startDate": None},
+    ]
+
+
+def test_a_role_without_read_prescription_cannot_open_one(
+    client, user_manager_headers, presence, open_prescription
+):
+    """USER_MANAGER holds no READ_PRESCRIPTION [401]."""
+    response = _start(client, user_manager_headers, open_prescription)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert presence["heartbeats"] == []
+
+
+# --- the status poll ----------------------------------------------------------
+
+
+def test_status_list_returns_the_status_of_each_prescription(
+    client, analyst_headers, open_prescription, checked_prescription
+):
+    """The poll answers with the stored status, ids as strings for the frontend."""
+    response = _status(
+        client, analyst_headers, [open_prescription, checked_prescription]
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    by_id = {r["idPrescription"]: r["status"] for r in _data(response)}
+    assert by_id == {
+        str(open_prescription): OPEN,
+        str(checked_prescription): CHECKED,
+    }
+
+
+def test_status_list_stays_silent_about_prescriptions_that_do_not_exist(
+    client, analyst_headers, open_prescription
+):
+    """Unknown ids are dropped rather than reported as an error [200 OK]."""
+    response = _status(
+        client, analyst_headers, [open_prescription, MISSING_PRESCRIPTION]
+    )
+
+    assert [r["idPrescription"] for r in _data(response)] == [str(open_prescription)]
+
+
+@pytest.mark.parametrize(
+    "id_list",
+    [[], [None], [0], ["not-a-number"]],
+    ids=["empty", "null", "zero", "text"],
+)
+def test_status_list_never_queries_on_unusable_input(client, analyst_headers, id_list):
+    """The poll runs on every screen refresh, so bad input is answered with an
+    empty list instead of a 500."""
+    response = _status(client, analyst_headers, id_list)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response) == []
+
+
+def test_one_bad_id_discards_the_whole_batch(
+    client, analyst_headers, open_prescription
+):
+    """The route parses the batch as a unit, so a single unparseable id costs the
+    good ones too. Pinned because the frontend must re-poll, not show stale rows."""
+    response = _status(client, analyst_headers, [open_prescription, "not-a-number"])
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response) == []
+
+
+def test_status_list_accepts_ids_sent_as_strings(
+    client, analyst_headers, open_prescription
+):
+    """The frontend sends ids as strings, since they overflow a JS number."""
+    response = _status(client, analyst_headers, [str(open_prescription)])
+
+    assert _data(response) == [
+        {"idPrescription": str(open_prescription), "status": OPEN}
+    ]
+
+
+def test_a_role_without_read_prescription_cannot_poll_status(
+    client, user_manager_headers, open_prescription
+):
+    """The poll is gated by the same permission as the prescription itself [401]."""
+    response = _status(client, user_manager_headers, [open_prescription])
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/integration/test_prescription_evaluation.py
+++ b/tests/integration/test_prescription_evaluation.py
@@ -18,8 +18,8 @@ that is what these tests pin down:
 * whatever the store returns is normalised before it reaches the client.
 
 ``status-list`` is the cheap companion poll, and it has its own contract: it
-never joins, it drops ids that are not numbers, and it stays silent about
-prescriptions that do not exist.
+runs on every screen refresh, so unusable input is answered with an empty list
+rather than an error, and it stays silent about prescriptions that do not exist.
 """
 
 import json
@@ -40,7 +40,7 @@ CALLER_ID = 1
 CALLER_NAME = "Demonstração"
 CALLER_SCHEMA = "demo"
 
-# far outside the seed range and outside the >= 100000 range the test helpers use
+# above every id the test helpers hand out, so no run can make it exist
 MISSING_PRESCRIPTION = 999999999
 
 # demo.prescricao.status, as set by /prescriptions/status

--- a/tests/integration/test_reports_general.py
+++ b/tests/integration/test_reports_general.py
@@ -1,0 +1,332 @@
+"""Tests: GET /reports/general/<report> and GET /reports/config
+
+The internal-report feature is a thin layer over the S3 cache, and everything
+worth pinning down happens *before* the bucket is touched:
+
+* only names in ``ReportEnum`` are reports at all;
+* a report listed in the caller's own ``usuario.relatorios["ignore"]`` is
+  refused even though the role grants READ_REPORTS -- that per-user opt-out is
+  the only place a report is taken away from someone who could otherwise see
+  it;
+* the resource path is built from the caller's schema, so one client can never
+  name another client's file, and a crafted ``filename`` must not escape the
+  prefix;
+* ``/reports/config`` applies the same ignore list to the report *menu*, and
+  ignoring ``CUSTOM`` blanks the external list wholesale.
+
+S3 is stubbed throughout: the tests assert on the resource path the service
+asks for, which is the part the backend actually decides.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import MemoryEnum, ReportEnum
+from services.reports import reports_cache_service
+from tests.conftest import session, session_commit
+from utils import status
+
+CONFIG_URL = "/reports/config"
+
+# the user behind every fixture in tests.conftest.get_access
+CALLER_ID = 1
+CALLER_SCHEMA = "demo"
+
+# a real report name, used whenever the test is not about the name itself
+A_REPORT = ReportEnum.RPT_PRESCRIPTION.value
+
+# menu entries seeded into demo.memoria; both kinds are absent from the seed
+# dump, so the rows are dropped again rather than restored
+INTERNAL_MENU = [ReportEnum.RPT_PRESCRIPTION.value, ReportEnum.RPT_ECONOMY.value]
+EXTERNAL_MENU = [
+    {"title": "Painel externo", "url": "https://example.invalid/a"},
+    {"title": "Painel externo 2", "url": "https://example.invalid/b"},
+]
+
+
+def _report_url(report: str, filename: str = None):
+    """URL for the single-report endpoint, optionally naming a history file."""
+    url = f"/reports/general/{report}"
+
+    return f"{url}?filename={filename}" if filename is not None else url
+
+
+def _set_ignored_reports(ignored: list):
+    """Write the caller's per-user report opt-out list."""
+    session.execute(
+        text(
+            "UPDATE public.usuario SET relatorios = CAST(:value AS json) WHERE idusuario = :id"
+        ),
+        {"value": json.dumps({"ignore": ignored}), "id": CALLER_ID},
+    )
+    session_commit()
+
+
+def _seed_menu(kind: str, value):
+    """Insert one demo.memoria row holding a report menu."""
+    session.execute(
+        text(
+            "INSERT INTO demo.memoria (tipo, valor, update_at, update_by) "
+            "VALUES (:kind, CAST(:value AS json), now(), :user)"
+        ),
+        {"kind": kind, "value": json.dumps(value), "user": CALLER_ID},
+    )
+    session_commit()
+
+
+def _cleanup():
+    """Undo the caller's opt-out list and drop the seeded menus."""
+    session.execute(
+        text("UPDATE public.usuario SET relatorios = NULL WHERE idusuario = :id"),
+        {"id": CALLER_ID},
+    )
+    session.execute(
+        text("DELETE FROM demo.memoria WHERE tipo IN (:external, :internal)"),
+        {
+            "external": MemoryEnum.REPORTS.value,
+            "internal": MemoryEnum.REPORTS_INTERNAL.value,
+        },
+    )
+    session_commit()
+
+
+@pytest.fixture(autouse=True)
+def clean_report_config():
+    """The seed dump has neither an opt-out list nor a report menu: keep it so."""
+    _cleanup()
+    yield
+    _cleanup()
+
+
+@pytest.fixture(autouse=True)
+def cache(monkeypatch):
+    """Replace S3 with a recorder.
+
+    ``paths`` collects every resource path the service asked about, and
+    ``link`` is what ``generate_link`` hands back -- ``None`` standing for "the
+    report was never generated for this client".
+    """
+    recorder = {"paths": [], "link": None, "history": []}
+
+    def _generate_link(resource_path: str):
+        recorder["paths"].append(resource_path)
+        return recorder["link"]
+
+    monkeypatch.setattr(reports_cache_service, "generate_link", _generate_link)
+    monkeypatch.setattr(
+        reports_cache_service,
+        "list_available_reports",
+        lambda schema, report: recorder["history"],  # noqa: ARG005
+    )
+    # the custom-report list rides along in /reports/config
+    monkeypatch.setattr(
+        reports_cache_service,
+        "list_available_custom_reports",
+        lambda schema, id_report: [],  # noqa: ARG005
+    )
+
+    return recorder
+
+
+def _data(response):
+    """The payload of a successful api_endpoint response."""
+    return json.loads(response.data)["data"]
+
+
+# --- which names are reports ---------------------------------------------------
+
+
+def test_unknown_report_name_is_rejected(client, analyst_headers, cache):
+    """A name outside ReportEnum is not a report, and S3 is never asked [400]."""
+    response = client.get(_report_url("NOT_A_REPORT"), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRecord"
+    assert cache["paths"] == []
+
+
+@pytest.mark.parametrize("report", [r.value for r in ReportEnum])
+def test_every_enum_member_is_accepted(client, analyst_headers, report):
+    """Every shipped report name reaches the cache lookup [200 OK]."""
+    response = client.get(_report_url(report), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+# --- the per-user opt-out list -------------------------------------------------
+
+
+def test_ignored_report_is_refused(client, analyst_headers, cache):
+    """The role grants READ_REPORTS, but this user opted out of this report [401]."""
+    _set_ignored_reports([A_REPORT])
+
+    response = client.get(_report_url(A_REPORT), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.get_json()["code"] == "errors.invalidPermission"
+    assert cache["paths"] == []
+
+
+def test_ignoring_one_report_leaves_the_others_alone(client, analyst_headers):
+    """The opt-out is per report, not a blanket revocation [200 OK]."""
+    _set_ignored_reports([ReportEnum.RPT_ECONOMY.value])
+
+    response = client.get(_report_url(A_REPORT), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_an_empty_opt_out_list_ignores_nothing(client, analyst_headers):
+    """``{"ignore": []}`` is the shipped default and must not lock anyone out [200]."""
+    _set_ignored_reports([])
+
+    response = client.get(_report_url(A_REPORT), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+# --- cache hit and miss --------------------------------------------------------
+
+
+def test_a_report_never_generated_is_reported_as_uncached(
+    client, analyst_headers, cache
+):
+    """No file in the bucket yet: say so, and do not list a history [200 OK]."""
+    cache["link"] = None
+
+    response = client.get(_report_url(A_REPORT), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response) == {"cached": False}
+
+
+def test_a_generated_report_returns_its_link_and_history(
+    client, analyst_headers, cache
+):
+    """With a file present the caller gets the presigned link plus older runs."""
+    cache["link"] = "https://cache.invalid/signed"
+    cache["history"] = [{"name": "20240102", "updateAt": "2024-01-02T00:00:00"}]
+
+    response = client.get(_report_url(A_REPORT), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response) == {
+        "cached": True,
+        "url": "https://cache.invalid/signed",
+        "availableReports": cache["history"],
+    }
+
+
+# --- the resource path is the tenant boundary ---------------------------------
+
+
+def test_the_resource_path_is_scoped_to_the_callers_schema(
+    client, analyst_headers, cache
+):
+    """The path is derived from the JWT schema, never from the request [200 OK]."""
+    client.get(_report_url(A_REPORT), headers=analyst_headers)
+
+    assert cache["paths"] == [f"reports/{CALLER_SCHEMA}/{A_REPORT}/current.gz"]
+
+
+def test_a_named_history_file_is_fetched_instead_of_current(
+    client, analyst_headers, cache
+):
+    """``filename`` selects an older run inside the same prefix [200 OK]."""
+    client.get(_report_url(A_REPORT, filename="20240102"), headers=analyst_headers)
+
+    assert cache["paths"] == [f"reports/{CALLER_SCHEMA}/{A_REPORT}/20240102.gz"]
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "../../../etc/passwd",
+        "..%2f..%2fother",
+        "sub\\current",
+        "with space",
+    ],
+)
+def test_a_filename_that_leaves_the_prefix_is_rejected(
+    client, analyst_headers, cache, filename
+):
+    """Traversal, encoded traversal and stray characters never reach S3 [400]."""
+    response = client.get(
+        _report_url(A_REPORT, filename=filename), headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidFilename"
+    assert cache["paths"] == []
+
+
+# --- the report menu ----------------------------------------------------------
+
+
+def test_config_returns_both_menus_and_the_custom_list(client, analyst_headers):
+    """With nothing ignored the caller sees every configured entry [200 OK]."""
+    _seed_menu(MemoryEnum.REPORTS.value, EXTERNAL_MENU)
+    _seed_menu(MemoryEnum.REPORTS_INTERNAL.value, INTERNAL_MENU)
+
+    response = client.get(CONFIG_URL, headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    data = _data(response)
+    assert data["internal"] == INTERNAL_MENU
+    assert data["external"] == EXTERNAL_MENU
+    assert data["custom"] == []
+
+
+def test_config_hides_the_reports_the_user_opted_out_of(client, analyst_headers):
+    """Internal entries match by name, external ones by title [200 OK]."""
+    _seed_menu(MemoryEnum.REPORTS.value, EXTERNAL_MENU)
+    _seed_menu(MemoryEnum.REPORTS_INTERNAL.value, INTERNAL_MENU)
+    _set_ignored_reports([ReportEnum.RPT_ECONOMY.value, "Painel externo"])
+
+    data = _data(client.get(CONFIG_URL, headers=analyst_headers))
+
+    assert data["internal"] == [ReportEnum.RPT_PRESCRIPTION.value]
+    assert [r["title"] for r in data["external"]] == ["Painel externo 2"]
+
+
+def test_ignoring_custom_drops_every_external_report(client, analyst_headers):
+    """CUSTOM in the opt-out list blanks the whole external menu [200 OK]."""
+    _seed_menu(MemoryEnum.REPORTS.value, EXTERNAL_MENU)
+    _seed_menu(MemoryEnum.REPORTS_INTERNAL.value, INTERNAL_MENU)
+    _set_ignored_reports(["CUSTOM"])
+
+    data = _data(client.get(CONFIG_URL, headers=analyst_headers))
+
+    assert data["external"] == []
+    # only the external menu is affected
+    assert data["internal"] == INTERNAL_MENU
+
+
+def test_config_is_empty_when_no_menu_is_configured(client, analyst_headers):
+    """A schema with no memoria rows gets empty lists, not an error [200 OK]."""
+    data = _data(client.get(CONFIG_URL, headers=analyst_headers))
+
+    assert data == {"external": [], "internal": [], "custom": []}
+
+
+# --- permission ---------------------------------------------------------------
+
+
+def test_a_role_without_read_reports_cannot_fetch_a_report(
+    client, user_manager_headers, cache
+):
+    """USER_MANAGER holds no READ_REPORTS, so the report is out of reach [401]."""
+    response = client.get(_report_url(A_REPORT), headers=user_manager_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert cache["paths"] == []
+
+
+def test_a_role_without_read_reports_cannot_read_the_menu(client, user_manager_headers):
+    """The menu is gated by the same permission as the reports it lists [401]."""
+    response = client.get(CONFIG_URL, headers=user_manager_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/unit/test_prescription_evaluation_window.py
+++ b/tests/unit/test_prescription_evaluation_window.py
@@ -1,0 +1,79 @@
+"""Unit tests for prescription_service.is_being_evaluated
+
+The prescription list and the prioritization queue both decorate a row with
+``isBeingEvaluated`` so a pharmacist can see that someone else is already on it.
+The flag is computed from the ``evaluation.startDate`` kept in the prescription's
+``features`` JSON, and it goes stale on its own after five minutes -- nothing
+ever clears it, so the window *is* the feature.
+
+The function is deprecated in favour of the DynamoDB presence store, but both
+call sites still use it, so its edges are worth holding still.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from services.prescription_service import is_being_evaluated
+
+WINDOW_MINUTES = 5
+
+
+def _features(minutes_ago: float):
+    """A features JSON whose evaluation started ``minutes_ago`` minutes back."""
+    started = datetime.today() - timedelta(minutes=minutes_ago)
+
+    return {"evaluation": {"startDate": started.isoformat()}}
+
+
+# --- nothing recorded ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "features",
+    [None, {}, {"evaluation": {}}, {"evaluation": {"other": "x"}}],
+    ids=["no features", "no evaluation", "empty evaluation", "no startDate"],
+)
+def test_a_prescription_nobody_opened_is_not_being_evaluated(features):
+    """Absent data means "free", never an error: the flag decorates every row."""
+    assert is_being_evaluated(features) is False
+
+
+# --- the five-minute window ---------------------------------------------------
+
+
+def test_an_evaluation_started_moments_ago_is_active():
+    """The normal case: a colleague has the prescription open right now."""
+    assert is_being_evaluated(_features(minutes_ago=1)) is True
+
+
+def test_an_evaluation_older_than_the_window_has_lapsed():
+    """Nothing clears the marker, so it has to expire by itself."""
+    assert is_being_evaluated(_features(minutes_ago=WINDOW_MINUTES * 2)) is False
+
+
+def test_the_window_edge_still_counts_as_active():
+    """The boundary is inclusive; pinned so a refactor cannot quietly flip it."""
+    assert is_being_evaluated(_features(minutes_ago=WINDOW_MINUTES - 0.01)) is True
+
+
+def test_just_past_the_window_is_inactive():
+    """One tick past the boundary and the prescription is free again."""
+    assert is_being_evaluated(_features(minutes_ago=WINDOW_MINUTES + 0.01)) is False
+
+
+def test_a_start_date_in_the_future_is_treated_as_active():
+    """Clock skew between the app servers must not free a prescription someone
+    is holding: a future timestamp stays inside the window rather than falling
+    outside it."""
+    assert is_being_evaluated(_features(minutes_ago=-30)) is True
+
+
+# --- malformed data -----------------------------------------------------------
+
+
+def test_an_unparseable_start_date_raises():
+    """The timestamp comes from the prescription's own features JSON, so a value
+    that is not ISO-8601 is a data bug and is not silently read as "free"."""
+    with pytest.raises(ValueError):
+        is_being_evaluated({"evaluation": {"startDate": "not-a-date"}})


### PR DESCRIPTION
Two features had no tests of their own. Both are small layers of backend decision-making in front of an external store (S3, DynamoDB), and it was the decisions that were untested — so in both cases the external store is stubbed and the tests assert on what the backend actually decides.

51 new tests. Suite goes **1460 → 1511** passing.

## 1. Internal reports — `services/reports/reports_general_service.py` (33% → 100%)

`tests/integration/test_reports_general.py`, covering `GET /reports/general/<report>` and `GET /reports/config`:

- **Which names are reports at all** — a name outside `ReportEnum` is refused, and every shipped enum member is accepted.
- **The per-user opt-out** — `usuario.relatorios["ignore"]` is the only place a report is taken away from someone whose role grants `READ_REPORTS`. Covers a report being refused, the opt-out staying per-report rather than blanket, and the shipped `{"ignore": []}` default locking nobody out.
- **The resource path as the tenant boundary** — the path is derived from the JWT schema, never the request; `filename` selects an older run inside the same prefix; traversal, encoded traversal and stray characters are rejected before S3 is reached.
- **Cache hit and miss** — a report never generated is reported as uncached; a generated one returns its presigned link plus older runs.
- **The report menu** — the same opt-out filters internal entries by name and external ones by title, and ignoring `CUSTOM` blanks the external list wholesale.
- **Permission** — a role without `READ_REPORTS` reaches neither the report nor the menu.

## 2. Prescription evaluation presence — `services/prescription_service.py` (40% → 50%)

`tests/integration/test_prescription_evaluation.py`, covering `POST /prescriptions/start-evaluation` and `POST /prescriptions/status-list`:

- **Validation first** — an unknown or missing prescription id is refused before the presence store is touched, so a bad id can never create a presence row.
- **Who counts as an editor** — the heartbeat is recorded only for a caller who holds `WRITE_PRESCRIPTION`, so a read-only `VIEWER` never appears to the others as one of the editors while still seeing who is.
- **Tenancy** — the presence lookup is scoped by the JWT schema.
- **Normalisation** — ids coerced to `int`, optional attributes defaulting to `None`.
- **The status poll** — statuses returned per prescription, unknown ids dropped silently, unusable input answered with an empty list rather than a 500, ids accepted as strings. Also pins the current behaviour that one unparseable id discards the whole batch, since the route parses it as a unit.

`tests/unit/test_prescription_evaluation_window.py` covers the five-minute `is_being_evaluated` window that the prescription list and the prioritization queue both rely on: nothing recorded, inside and outside the window, both sides of the boundary, a future timestamp from clock skew, and an unparseable date.

## Notes

- The DynamoDB presence store short-circuits under `ENV=test`, so it is replaced with a recorder that captures the heartbeats and serves the viewer list.
- Prescriptions are written per test rather than taken from the seed dump: the status poll asserts on statuses that other test modules mutate. The status is applied with an `UPDATE` because the `BEFORE INSERT` trigger on `demo.prescricao` routes the row through `public.upsert_prescricao`, which normalises a new prescription back to "not checked".
- Ids come from the shared `>= 100000` counter, and both new integration modules clean up after themselves, so the suite stays re-runnable.


---
_Generated by [Claude Code](https://claude.ai/code/session_018NoPzZQPqmFANRq68CXW7o)_