### PR TITLE
Add Ruff linter configuration and fix code style issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,20 @@ permissions:
   pull-requests: write
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: 3.12
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - name: Install ruff
+        run: sfw pip install "$(grep '^ruff==' requirements.txt)"
+      - name: Run ruff
+        run: ruff check . --output-format github
   build:
     runs-on: ubuntu-latest
     services:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test-setup test test-unit test-integration test-file test-cov db-start db-stop db-reset
+.PHONY: dev lint test-setup test test-unit test-integration test-file test-cov db-start db-stop db-reset
 
 COMPOSE = docker compose -f docker-compose.test.yml
 
@@ -6,6 +6,10 @@ COMPOSE = docker compose -f docker-compose.test.yml
 dev:
 	@test -f .env || (echo ".env not found — copy .env.example to .env and fill in values" && exit 1)
 	. env/bin/activate && set -a && . .env && set +a && python3 mobile.py
+
+## Run the linter (same check as CI)
+lint:
+	ruff check .
 
 ## First-time setup: start Docker and load the database
 test-setup:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pytest-cov==7.1.0
 pytest-order==1.5.0
 mock==5.2.0
 pylint==4.0.6
+ruff==0.15.8
 flask-mail==0.10.0
 random-password-generator==2.2.0
 PyJWT==2.13.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,15 @@
+# Ruff linter configuration — enforced in CI (see .github/workflows/build.yml)
+target-version = "py312"
+
+# "env" is the local virtualenv; "database" is cloned into the workspace by CI
+extend-exclude = ["env", "database"]
+
+[lint]
+# Uses ruff's default rule set (pyflakes "F" + pycodestyle errors "E4/E7/E9")
+ignore = [
+    # Comparisons to None/True/False are intentional SQLAlchemy filter syntax
+    # (e.g. `Model.field == None` compiles to "IS NULL"). Rewriting them to
+    # `is None` would silently break the queries.
+    "E711",
+    "E712",
+]

--- a/security/role.py
+++ b/security/role.py
@@ -282,7 +282,7 @@ class Role(Enum):
             try:
                 role = Role(str(r).upper())
                 user_permissions = user_permissions + role.permissions
-            except:
+            except Exception:
                 pass
 
         return user_permissions

--- a/services/alert_interaction_service.py
+++ b/services/alert_interaction_service.py
@@ -216,8 +216,8 @@ def find_relations(drug_list, id_patient: int, is_cpoe: bool):
                     uniq_invert_key = f"""{invert_key}-{drug_from["expireDate"]}"""
 
                 if (
-                    not uniq_key in unique_relations
-                    and not uniq_invert_key in unique_relations
+                    uniq_key not in unique_relations
+                    and uniq_invert_key not in unique_relations
                 ):
                     stats[kind] += 1
                     unique_relations[uniq_key] = 1

--- a/services/memory_service.py
+++ b/services/memory_service.py
@@ -78,7 +78,7 @@ def has_feature(feature: str):
         user_features = (
             user.config["features"] if user.config and "features" in user.config else []
         )
-    except:
+    except Exception:
         user_features = []
 
     if feature in user_features:

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -90,7 +90,7 @@ def reset_password(token: str, password: str):
 
     try:
         user_token = decode_token(token)
-    except:
+    except Exception:
         raise ValidationError(
             "Token expirado. Você precisa fazer uma nova solicitação de troca de senha.",
             "errors.businessRules",

--- a/tests/integration/test_memory.py
+++ b/tests/integration/test_memory.py
@@ -27,7 +27,7 @@ def _delete_memory(key):
 
 
 def _delete_memory_by_kind(kind):
-    session.execute(text(f"DELETE FROM demo.memoria WHERE tipo = :kind"), {"kind": kind})
+    session.execute(text("DELETE FROM demo.memoria WHERE tipo = :kind"), {"kind": kind})
     session_commit()
 
 

--- a/tests/integration/test_static_context.py
+++ b/tests/integration/test_static_context.py
@@ -11,7 +11,6 @@ a pure unit test.
 
 import json
 
-import pytest
 
 from exception.authorization_error import AuthorizationError
 from exception.validation_error import ValidationError

--- a/tests/unit/test_clinical_notes_convert.py
+++ b/tests/unit/test_clinical_notes_convert.py
@@ -16,7 +16,6 @@ from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import pytest
 
 from services import clinical_notes_service
 

--- a/utils/emailutils.py
+++ b/utils/emailutils.py
@@ -35,6 +35,6 @@ def sendEmail(subject, sender, emails, html):
         msg.recipients = emails
         msg.html = html
         mail.send(msg)
-    except:
+    except Exception:
         logger = logging.getLogger("noharm.backend")
         logger.error("Could not send new user email")

--- a/utils/numberutils.py
+++ b/utils/numberutils.py
@@ -6,5 +6,5 @@ def is_float(s):
     try:
         float(s)
         return True
-    except:
+    except Exception:
         return False

--- a/utils/sessionutils.py
+++ b/utils/sessionutils.py
@@ -20,7 +20,7 @@ def tryCommit(db, recId, allow=True):
         db.session.remove()
 
         return {"status": "success", "data": recId}, status.HTTP_200_OK
-    except AuthorizationError as e:
+    except AuthorizationError:
         db.session.rollback()
         db.session.close()
         db.session.remove()


### PR DESCRIPTION
## Summary
Introduces Ruff linter configuration to enforce code quality standards in CI and fixes all identified code style violations across the codebase.

## Key Changes

- **Added Ruff configuration** (`ruff.toml`):
  - Target Python 3.12
  - Configured to ignore E711/E712 (None/True/False comparisons) due to intentional SQLAlchemy filter syntax usage
  - Excludes local virtualenv and database directories

- **Integrated Ruff into CI** (`.github/workflows/build.yml`):
  - New `lint` job runs before `build` job
  - Installs Ruff from requirements.txt and runs linting with GitHub output format
  - Uses SocketDev firewall-free mode for dependency security

- **Added lint target to Makefile**:
  - `make lint` command for local linting (same check as CI)

- **Fixed code style violations**:
  - Replaced bare `except:` with `except Exception:` in 5 files (security/role.py, services/memory_service.py, services/user_service.py, utils/emailutils.py, utils/numberutils.py)
  - Fixed membership test syntax: `not x in y` → `x not in y` (services/alert_interaction_service.py)
  - Removed unused exception variable binding: `except AuthorizationError as e:` → `except AuthorizationError:` (utils/sessionutils.py)
  - Removed f-string from SQL query (tests/integration/test_memory.py)
  - Removed unused `pytest` imports (tests/integration/test_static_context.py, tests/unit/test_clinical_notes_convert.py)

- **Updated dependencies** (requirements.txt):
  - Added `ruff==0.15.8`

## Implementation Details

The Ruff configuration preserves intentional SQLAlchemy filter patterns (E711/E712) that use `== None` and `== True/False` comparisons, which compile to proper SQL semantics (IS NULL, etc.) and would break if rewritten to use `is` operators.

All fixes follow Python best practices: explicit exception handling, idiomatic membership testing, and removal of unused imports.

https://claude.ai/code/session_01DVHDxUKcFiMx89mqoanCKw