### PR TITLE
Dispatch presmed checado marking as async lambda event

### DIFF
--- a/decorators/api_endpoint_decorator.py
+++ b/decorators/api_endpoint_decorator.py
@@ -15,7 +15,7 @@ from exception.authorization_error import AuthorizationError
 from exception.validation_error import ValidationError
 from models.enums import NoHarmENV
 from models.main import User, db, dbSession
-from utils import logger, status
+from utils import logger, post_commit, status
 
 
 def api_endpoint(download_headers=None, is_admin=False):
@@ -46,6 +46,8 @@ def api_endpoint(download_headers=None, is_admin=False):
                 db.session.commit()
                 db.session.close()
                 db.session.remove()
+
+                post_commit.run_post_commit_callbacks()
 
                 # Handle download response with custom headers
                 if download_headers:

--- a/services/prescription_check_service.py
+++ b/services/prescription_check_service.py
@@ -1,9 +1,11 @@
 """Service: Prescription Check related operations"""
 
-from datetime import datetime, timedelta
+import json
+from datetime import datetime
 
 from sqlalchemy import func, text
 
+from config import Config
 from decorators.has_permission_decorator import Permission, has_permission
 from decorators.timed_decorator import timed
 from exception.validation_error import ValidationError
@@ -28,7 +30,7 @@ from services import (
     segment_service,
     user_service,
 )
-from utils import status
+from utils import aws, logger, post_commit, status
 from utils.db_utils import run_with_deadlock_retry
 
 
@@ -48,15 +50,22 @@ def check_prescription(
     """
     Check or uncheck a prescription.
 
-    The presmed UPDATE inside this flow can deadlock against the external
-    integration process that writes to the same table concurrently.
-    run_with_deadlock_retry handles PostgreSQL deadlock errors (40P01) by
-    rolling back and retrying up to 3 times with exponential back-off.
-    with_for_update() on the initial prescription read serialises concurrent
-    requests from this application on the same prescription row.
+    The presmed "checado" marking is NOT done here: presmed rows are also
+    written by the external integration process, so updating them inside
+    this transaction blocks on (and deadlocks against) that process. The
+    marking is dispatched after commit as an async event to the internal
+    lambda (see _dispatch_presmed_checked); everything clinically
+    authoritative (prescription status, audit record, checkedindex insert)
+    stays in this single transaction.
+
+    run_with_deadlock_retry is kept as a safety net for PostgreSQL deadlock
+    errors (40P01): it rolls back and retries up to 3 times with exponential
+    back-off. with_for_update() on the initial prescription read serialises
+    concurrent requests from this application on the same prescription row.
     """
 
     def _do_check():
+        presmed_mark_ids = []
         p = (
             db.session.query(Prescription)
             .filter(Prescription.id == idPrescription)
@@ -134,6 +143,7 @@ def check_prescription(
                 user=user_context,
                 has_lock_feature=has_lock_feature,
                 extra=extra_info,
+                presmed_mark_ids=presmed_mark_ids,
             )
             single = _check_single_prescription(
                 prescription=p,
@@ -141,6 +151,7 @@ def check_prescription(
                 user=user_context,
                 has_lock_feature=has_lock_feature,
                 extra=extra_info,
+                presmed_mark_ids=presmed_mark_ids,
             )
 
             for i in internals:
@@ -155,35 +166,75 @@ def check_prescription(
                 user=user_context,
                 has_lock_feature=has_lock_feature,
                 extra=extra_info,
+                presmed_mark_ids=presmed_mark_ids,
             )
             _update_agg_status(prescription=p, user=user_context, extra=extra_info)
 
             if single:
                 results.append(single)
 
-        _clean_checkedindex(user_context=user_context)
-
         if p_status == "s":
             user_activity_repository.increment_checks(user_context.id)
 
-        return results
+        return results, presmed_mark_ids
 
-    return run_with_deadlock_retry(
+    results, presmed_mark_ids = run_with_deadlock_retry(
         _do_check,
         on_retry=lambda: dbSession.setSchema(user_context.schema),
     )
 
+    # dispatched only after the transaction commits, so presmed is never
+    # marked for a check that ends up rolled back
+    if presmed_mark_ids:
+        post_commit.on_commit(
+            lambda: _dispatch_presmed_checked(
+                user_context=user_context, id_prescription_list=presmed_mark_ids
+            )
+        )
 
-@timed()
-def _clean_checkedindex(user_context: User):
-    """delete old checked index records to force revalidation"""
+    return results
 
-    db.session.execute(
-        text(
-            f"""DELETE FROM {user_context.schema}.checkedindex WHERE created_at < :maxDate"""
-        ),
-        {"maxDate": (datetime.today() - timedelta(days=4))},
-    )
+
+def _dispatch_presmed_checked(user_context: User, id_prescription_list: list):
+    """
+    Fire-and-forget async event to mark presmed rows as checked
+    (checado = true). Runs outside the check transaction because presmed is
+    written concurrently by the external integration process. A dispatch
+    failure is logged but never fails the request: the check itself is
+    already committed.
+    """
+    if not id_prescription_list:
+        return
+
+    if not Config.BACKEND_FUNCTION_NAME:
+        logger.backend_logger.warning(
+            "BACKEND_FUNCTION_NAME not configured; skipping presmed checado marking for prescriptions: %s",
+            id_prescription_list,
+        )
+        return
+
+    try:
+        lambda_client = aws.get_client(
+            "lambda", region_name=Config.NIFI_SQS_QUEUE_REGION
+        )
+        lambda_client.invoke(
+            FunctionName=Config.BACKEND_FUNCTION_NAME,
+            InvocationType="Event",
+            Payload=json.dumps(
+                {
+                    "command": "lambda_check.mark_presmed_checked",
+                    "schema": user_context.schema,
+                    "id_user": user_context.id,
+                    "id_prescription_list": [str(i) for i in id_prescription_list],
+                }
+            ),
+        )
+    except Exception:
+        logger.backend_logger.exception(
+            "failed to dispatch presmed checado event | schema: %s | prescriptions: %s",
+            user_context.schema,
+            id_prescription_list,
+        )
 
 
 def _update_agg_status(prescription: Prescription, user: User, extra={}):
@@ -228,7 +279,7 @@ def _update_agg_status(prescription: Prescription, user: User, extra={}):
 
 @timed()
 def _check_agg_internal_prescriptions(
-    prescription, p_status, user, has_lock_feature=False, extra={}
+    prescription, p_status, user, has_lock_feature=False, extra={}, presmed_mark_ids=None
 ):
     is_pmc = memory_service.has_feature_nouser(FeatureEnum.PRIMARY_CARE.value)
     is_cpoe = segment_service.is_cpoe(id_segment=prescription.idSegment)
@@ -257,6 +308,7 @@ def _check_agg_internal_prescriptions(
             parent_agg_date=prescription.date,
             has_lock_feature=has_lock_feature,
             extra=extra,
+            presmed_mark_ids=presmed_mark_ids,
         )
 
         if result:
@@ -267,7 +319,13 @@ def _check_agg_internal_prescriptions(
 
 @timed()
 def _check_single_prescription(
-    prescription, p_status, user, parent_agg_date=None, has_lock_feature=False, extra={}
+    prescription,
+    p_status,
+    user,
+    parent_agg_date=None,
+    has_lock_feature=False,
+    extra={},
+    presmed_mark_ids=None,
 ):
     if p_status == "0" and prescription.user != user.id:
         if has_lock_feature:
@@ -285,7 +343,9 @@ def _check_single_prescription(
         extra=extra,
     )
 
-    _add_checkedindex(prescription=prescription, user=user)
+    indexed_id = _add_checkedindex(prescription=prescription, user=user)
+    if indexed_id is not None and presmed_mark_ids is not None:
+        presmed_mark_ids.append(indexed_id)
 
     db.session.flush()
 
@@ -294,21 +354,15 @@ def _check_single_prescription(
 
 @timed()
 def _add_checkedindex(prescription: Prescription, user: User):
+    """
+    Insert checkedindex records for the prescription and return its id when
+    it qualifies (checked, not agg, not concilia), None otherwise. The
+    returned ids feed the async presmed "checado" marking dispatched after
+    commit (_dispatch_presmed_checked) — presmed is not updated here to
+    avoid lock contention with the external integration process.
+    """
     if prescription.status != "s" or prescription.agg or prescription.concilia != None:
-        return
-
-    # first update presmed to mark as checked
-    db.session.execute(
-        text(
-            f"""
-                UPDATE {user.schema}.presmed
-                SET checado = true
-                WHERE fkprescricao = :idPrescription
-                  AND dtsuspensao IS NULL
-                """
-        ),
-        {"idPrescription": prescription.id},
-    )
+        return None
 
     query = text(
         f"""
@@ -352,6 +406,8 @@ def _add_checkedindex(prescription: Prescription, user: User):
             "idPrescription": prescription.id,
         },
     )
+
+    return prescription.id
 
 
 @timed()

--- a/tests/integration/test_prescription_check.py
+++ b/tests/integration/test_prescription_check.py
@@ -1,9 +1,11 @@
 """Tests: Prescription Check related operations"""
 
+import json
 import threading
 import time
+from contextlib import contextmanager
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from mobile import app as flask_app
 from tests.conftest import session, session_commit
@@ -11,6 +13,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 
 import services.prescription_check_service as prescription_check_service
+from config import Config
 from models.enums import DrugTypeEnum, PrescriptionAuditTypeEnum
 from models.prescription import Prescription, PrescriptionAudit, PrescriptionDrug
 from static import prescalc
@@ -36,6 +39,26 @@ def _check_payload(id_prescription, status="s"):
     }
 
 
+@contextmanager
+def _mock_presmed_dispatch(function_name="test-backend-function"):
+    """Patch BACKEND_FUNCTION_NAME and the lambda client so tests can assert
+    the async presmed 'checado' dispatch without touching AWS"""
+    lambda_client = MagicMock()
+    with patch.object(Config, "BACKEND_FUNCTION_NAME", function_name), patch(
+        "services.prescription_check_service.aws.get_client",
+        return_value=lambda_client,
+    ):
+        yield lambda_client
+
+
+def _dispatched_payloads(lambda_client):
+    """Return the decoded payloads of every lambda invoke performed"""
+    return [
+        json.loads(call.kwargs["Payload"])
+        for call in lambda_client.invoke.call_args_list
+    ]
+
+
 def test_check_prescription_sets_status(client, analyst_headers):
     """Check prescription: sets prescription status to 's'"""
     prescription = create_basic_prescription()
@@ -52,17 +75,30 @@ def test_check_prescription_sets_status(client, analyst_headers):
     assert p.status == "s"
 
 
-def test_check_prescription_sets_checado_on_active_drugs(client, analyst_headers):
-    """Check prescription: sets checado=true on all active presmed rows"""
+def test_check_prescription_dispatches_presmed_event(client, analyst_headers):
+    """Check prescription: dispatches an async event to mark presmed as
+    checado instead of updating presmed inside the check transaction"""
     prescription = create_basic_prescription()
     id_pres = prescription.id
 
-    response = client.post(
-        CHECK_URL, json=_check_payload(id_pres), headers=analyst_headers
-    )
+    with _mock_presmed_dispatch() as lambda_client:
+        response = client.post(
+            CHECK_URL, json=_check_payload(id_pres), headers=analyst_headers
+        )
 
     assert response.status_code == 200
 
+    assert lambda_client.invoke.call_count == 1
+    invoke_kwargs = lambda_client.invoke.call_args.kwargs
+    assert invoke_kwargs["FunctionName"] == "test-backend-function"
+    assert invoke_kwargs["InvocationType"] == "Event"
+
+    payload = _dispatched_payloads(lambda_client)[0]
+    assert payload["command"] == "lambda_check.mark_presmed_checked"
+    assert payload["schema"] == "demo"
+    assert payload["id_prescription_list"] == [str(id_pres)]
+
+    # presmed itself must NOT be touched in-process anymore
     session.expire_all()
     drugs = (
         session.query(PrescriptionDrug)
@@ -70,10 +106,51 @@ def test_check_prescription_sets_checado_on_active_drugs(client, analyst_headers
         .filter(PrescriptionDrug.suspendedDate == None)
         .all()
     )
-
     assert len(drugs) > 0
     for drug in drugs:
-        assert drug.checked is True
+        assert drug.checked is not True
+
+
+def test_check_prescription_no_dispatch_without_function_name(
+    client, analyst_headers
+):
+    """Check prescription: when BACKEND_FUNCTION_NAME is not configured the
+    presmed marking is skipped entirely and the check still succeeds"""
+    prescription = create_basic_prescription()
+    id_pres = prescription.id
+
+    with _mock_presmed_dispatch(function_name="") as lambda_client:
+        response = client.post(
+            CHECK_URL, json=_check_payload(id_pres), headers=analyst_headers
+        )
+
+    assert response.status_code == 200
+    lambda_client.invoke.assert_not_called()
+
+    session.expire_all()
+    p = session.query(Prescription).filter(Prescription.id == id_pres).first()
+    assert p.status == "s"
+
+
+def test_check_prescription_dispatch_failure_does_not_fail_request(
+    client, analyst_headers
+):
+    """Check prescription: a lambda dispatch failure is logged but the check
+    is already committed and the request succeeds"""
+    prescription = create_basic_prescription()
+    id_pres = prescription.id
+
+    with _mock_presmed_dispatch() as lambda_client:
+        lambda_client.invoke.side_effect = Exception("lambda unavailable")
+        response = client.post(
+            CHECK_URL, json=_check_payload(id_pres), headers=analyst_headers
+        )
+
+    assert response.status_code == 200
+
+    session.expire_all()
+    p = session.query(Prescription).filter(Prescription.id == id_pres).first()
+    assert p.status == "s"
 
 
 def test_check_prescription_audit_total_itens_excludes_diet(client, analyst_headers):
@@ -148,7 +225,9 @@ def test_check_prescription_audit_total_itens_excludes_diet(client, analyst_head
 
 
 def test_check_prescription_skips_suspended_drugs(client, analyst_headers):
-    """Check prescription: does not set checado on suspended presmed rows"""
+    """Check prescription: suspended presmed rows are excluded from
+    checkedindex (the checado marking of suspended rows is handled by the
+    async lambda handler, tested in backend-private)"""
 
     id_pres = test_counters["id_prescription"]
     admission = test_counters["admission_number"]
@@ -182,12 +261,19 @@ def test_check_prescription_skips_suspended_drugs(client, analyst_headers):
     assert response.status_code == 200
 
     session.expire_all()
-    suspended = (
-        session.query(PrescriptionDrug)
-        .filter(PrescriptionDrug.id == id_suspended)
-        .first()
+    result = session.execute(
+        text(
+            "SELECT COUNT(*) FROM demo.checkedindex WHERE fkprescricao = :id AND fkmedicamento = 44"
+        ),
+        {"id": id_pres},
     )
-    assert suspended.checked is not True
+    assert result.scalar() == 0
+
+    result = session.execute(
+        text("SELECT COUNT(*) FROM demo.checkedindex WHERE fkprescricao = :id"),
+        {"id": id_pres},
+    )
+    assert result.scalar() == 1
 
 
 def test_check_prescription_already_checked_returns_error(client, analyst_headers):
@@ -207,38 +293,31 @@ def test_check_prescription_already_checked_returns_error(client, analyst_header
     assert response.status_code == 400
 
 
-def test_uncheck_preserves_checado(client, analyst_headers):
-    """Uncheck prescription: checado flag on presmed rows is preserved after unchecking"""
+def test_uncheck_does_not_dispatch_presmed_event(client, analyst_headers):
+    """Uncheck prescription: the presmed checado event is only dispatched on
+    check, never on uncheck (checado is preserved on uncheck)"""
 
     prescription = create_basic_prescription()
     id_pres = prescription.id
 
-    # Check first
-    client.post(
-        CHECK_URL, json=_check_payload(id_pres, status="s"), headers=analyst_headers
-    )
+    with _mock_presmed_dispatch() as lambda_client:
+        # Check first — dispatches the event
+        client.post(
+            CHECK_URL, json=_check_payload(id_pres, status="s"), headers=analyst_headers
+        )
+        assert lambda_client.invoke.call_count == 1
 
-    # Then uncheck
-    response = client.post(
-        CHECK_URL, json=_check_payload(id_pres, status="0"), headers=analyst_headers
-    )
+        # Then uncheck — must not dispatch again
+        response = client.post(
+            CHECK_URL, json=_check_payload(id_pres, status="0"), headers=analyst_headers
+        )
 
     assert response.status_code == 200
+    assert lambda_client.invoke.call_count == 1
 
     session.expire_all()
     p = session.query(Prescription).filter(Prescription.id == id_pres).first()
     assert p.status == "0"
-
-    drugs = (
-        session.query(PrescriptionDrug)
-        .filter(PrescriptionDrug.idPrescription == id_pres)
-        .filter(PrescriptionDrug.suspendedDate == None)
-        .all()
-    )
-
-    assert len(drugs) > 0
-    for drug in drugs:
-        assert drug.checked is True
 
 
 def test_check_prescription_viewer_unauthorized(client, viewer_headers):
@@ -270,11 +349,18 @@ def test_check_aggregate_prescription(client, analyst_headers):
     )
 
     # Check the aggregate prescription
-    client.post(
-        CHECK_URL,
-        json={"status": "s", "idPrescription": id},
-        headers=analyst_headers,
-    )
+    with _mock_presmed_dispatch() as lambda_client:
+        client.post(
+            CHECK_URL,
+            json={"status": "s", "idPrescription": id},
+            headers=analyst_headers,
+        )
+
+    # the presmed event carries only the internal prescription that was
+    # checked — never the agg record nor prescriptions outside the agg
+    payloads = _dispatched_payloads(lambda_client)
+    assert len(payloads) == 1
+    assert payloads[0]["id_prescription_list"] == [str(prescriptionid1)]
 
     pInAg = (
         session.query(Prescription)

--- a/utils/post_commit.py
+++ b/utils/post_commit.py
@@ -1,0 +1,34 @@
+"""Post-commit callback registry.
+
+Some operations must only happen after the request/operation transaction is
+durably committed (e.g. dispatching async events that reference the
+committed data). Services register callbacks here; the transaction owners
+(api_endpoint decorator and execute_with_static_context) run them right
+after a successful db.session.commit(). On rollback the request context is
+discarded and the callbacks never run.
+"""
+
+from flask import g
+
+from utils import logger
+
+
+def on_commit(callback):
+    """Register a callback to run after the current transaction commits."""
+    if not hasattr(g, "post_commit_callbacks"):
+        g.post_commit_callbacks = []
+
+    g.post_commit_callbacks.append(callback)
+
+
+def run_post_commit_callbacks():
+    """Run and clear registered callbacks. Failures are logged, never raised:
+    the transaction is already committed."""
+    callbacks = getattr(g, "post_commit_callbacks", [])
+    g.post_commit_callbacks = []
+
+    for callback in callbacks:
+        try:
+            callback()
+        except Exception:
+            logger.backend_logger.exception("post-commit callback failed")

--- a/utils/static_context.py
+++ b/utils/static_context.py
@@ -10,7 +10,7 @@ from exception.authorization_error import AuthorizationError
 from exception.validation_error import ValidationError
 from mobile import app
 from models.main import User, db
-from utils import logger, status
+from utils import logger, post_commit, status
 
 
 def _handle_validation_error(e: ValidationError, user_context: User):
@@ -144,6 +144,8 @@ def execute_with_static_context(schema: str, operation_func, params: dict):
             db.session.commit()
             db.session.close()
             db.session.remove()
+
+            post_commit.run_post_commit_callbacks()
 
             return json.dumps(
                 {"status": "success", "data": result, "httpCode": status.HTTP_200_OK}


### PR DESCRIPTION
## Summary

Refactor prescription check flow to dispatch presmed "checado" (checked) marking as an asynchronous AWS Lambda event instead of updating presmed rows synchronously within the transaction. This eliminates lock contention and deadlock risk with the external integration process that writes to presmed concurrently.

## Key Changes

- **Async presmed marking**: Introduced `_dispatch_presmed_checked()` function that fires a Lambda event after transaction commit to mark presmed rows as checked, rather than updating them in-process
- **Post-commit callback system**: Added new `utils/post_commit.py` module with `on_commit()` and `run_post_commit_callbacks()` to safely execute operations after transaction commit
- **Integration points**: Updated `api_endpoint_decorator.py` and `utils/static_context.py` to invoke post-commit callbacks after successful commits
- **Presmed ID tracking**: Modified `_check_single_prescription()` and `_add_checkedindex()` to collect prescription IDs that qualify for presmed marking and return them for async dispatch
- **Configuration-aware dispatch**: Lambda dispatch is skipped gracefully if `BACKEND_FUNCTION_NAME` is not configured; dispatch failures are logged but never fail the request
- **Removed synchronous presmed update**: Deleted the direct `UPDATE presmed SET checado = true` query from `_add_checkedindex()` and removed the `_clean_checkedindex()` function
- **Comprehensive test coverage**: Added three new test cases covering successful dispatch, missing configuration, and dispatch failure scenarios; updated existing tests to verify presmed rows are no longer modified in-process

## Implementation Details

- Presmed marking is now fire-and-forget: the check transaction commits first, then the Lambda event is dispatched asynchronously
- The Lambda payload includes `command: "lambda_check.mark_presmed_checked"`, schema, user ID, and prescription ID list
- Suspended drugs are excluded from presmed marking (via existing checkedindex logic)
- Uncheck operations do not dispatch presmed events; checado state is preserved on uncheck
- Post-commit callbacks use Flask's `g` object for request-scoped storage and are cleared after execution

https://claude.ai/code/session_01HmD1JcyzTba3oDLcCtvSGD