### PR TITLE
test: cover annotation removal and protocol drug search

### DIFF
--- a/tests/integration/test_drug_search.py
+++ b/tests/integration/test_drug_search.py
@@ -1,0 +1,265 @@
+"""Integration tests for the protocol drug search and resolution feature.
+
+Three endpoints back the drug picker used when a protocol condition targets
+specific drugs:
+
+- ``GET /drugs/find``        searches by name, restricted to drugs that have
+                            outliers (i.e. drugs the scoring pipeline knows).
+- ``GET /drugs/resolve``     turns a list of already-picked ids back into
+                            names, with no outlier restriction.
+- ``GET /drugs/frequencies`` lists the frequencies available to the schema.
+
+The outlier restriction on ``find`` and its absence on ``resolve`` are the two
+behaviours that matter most here: a drug that stopped being scored must remain
+resolvable, otherwise a saved protocol would render with a blank drug.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from security.role import Role
+from tests.conftest import get_access, make_headers, session, session_commit
+
+FIND_URL = "/drugs/find"
+RESOLVE_URL = "/drugs/resolve"
+FREQUENCIES_URL = "/drugs/frequencies"
+
+# unit-conversion/test drug ids use >= 90000
+DRUG_WITHOUT_OUTLIER = 90001
+DRUG_WITH_OUTLIER = 90002
+
+DRUG_WITHOUT_OUTLIER_NAME = "ZZTEST BUSCA SEM OUTLIER"
+DRUG_WITH_OUTLIER_NAME = "ZZTEST BUSCA COM OUTLIER"
+TEST_DRUG_TERM = "ZZTEST BUSCA"
+
+# seed drugs, all of them scored (present in the outlier table)
+SEED_DRUG_ALOPURINOL = 2
+SEED_DRUG_PARACETAMOL = 15
+SEED_DRUG_OMEPRAZOL = 24
+SEED_DRUG_OMEPRAZOL_NAME = "OMEPRAZOL 20mg CP"
+
+INVALID_DRUG_ID = 999999
+
+
+@pytest.fixture
+def dispensing_headers(client):
+    """Headers with DISPENSING_MANAGER role — has neither READ_BASIC_FEATURES nor READ_PRESCRIPTION"""
+    return make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+
+
+@pytest.fixture
+def search_drugs():
+    """Two drugs with the same name prefix, only one of them scored"""
+    for id, name in (
+        (DRUG_WITHOUT_OUTLIER, DRUG_WITHOUT_OUTLIER_NAME),
+        (DRUG_WITH_OUTLIER, DRUG_WITH_OUTLIER_NAME),
+    ):
+        session.execute(
+            text(
+                "INSERT INTO demo.medicamento (fkmedicamento, fkhospital, nome) "
+                "VALUES (:id, 1, :name)"
+            ),
+            {"id": id, "name": name},
+        )
+
+    session.execute(
+        text(
+            "INSERT INTO demo.outlier "
+            "(fkmedicamento, idsegmento, contagem, doseconv, frequenciadia, escore) "
+            "VALUES (:id, 1, 10, 1, 1, 1)"
+        ),
+        {"id": DRUG_WITH_OUTLIER},
+    )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM demo.outlier WHERE fkmedicamento >= 90000"),
+    )
+    session.execute(
+        text("DELETE FROM demo.medicamento WHERE fkmedicamento >= 90000"),
+    )
+    session_commit()
+
+
+def _names(data):
+    """Drug names of a search/resolve response, in response order"""
+    return [item["name"] for item in data]
+
+
+def test_find_no_token(client):
+    """GET /drugs/find — returns 401 without authentication"""
+    response = client.get(f"{FIND_URL}?term=omeprazol")
+
+    assert response.status_code == 401
+
+
+def test_find_permission_denied(client, dispensing_headers):
+    """GET /drugs/find — returns 401 for a role without READ_BASIC_FEATURES"""
+    response = client.get(f"{FIND_URL}?term=omeprazol", headers=dispensing_headers)
+
+    assert response.status_code == 401
+
+
+def test_find_empty_term(client, analyst_headers):
+    """GET /drugs/find — returns 400 when the term is empty"""
+    response = client.get(f"{FIND_URL}?term=", headers=analyst_headers)
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.invalidParams"
+
+
+def test_find_missing_term(client, analyst_headers):
+    """GET /drugs/find — returns 400 when the term parameter is absent"""
+    response = client.get(FIND_URL, headers=analyst_headers)
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.invalidParams"
+
+
+def test_find_is_case_insensitive_and_partial(client, analyst_headers):
+    """GET /drugs/find — matches part of the name regardless of case"""
+    response = client.get(f"{FIND_URL}?term=omeprazol", headers=analyst_headers)
+
+    assert response.status_code == 200
+
+    data = response.get_json()["data"]
+    assert {
+        "idDrug": str(SEED_DRUG_OMEPRAZOL),
+        "name": SEED_DRUG_OMEPRAZOL_NAME,
+    } in data
+
+
+def test_find_returns_results_sorted_by_name(client, analyst_headers):
+    """GET /drugs/find — returns the matches sorted by name"""
+    response = client.get(f"{FIND_URL}?term=CP", headers=analyst_headers)
+
+    assert response.status_code == 200
+
+    names = _names(response.get_json()["data"])
+    assert len(names) > 1
+    assert names == sorted(names)
+
+
+def test_find_only_returns_scored_drugs(client, analyst_headers, search_drugs):
+    """GET /drugs/find — a drug without outliers is not searchable"""
+    response = client.get(f"{FIND_URL}?term={TEST_DRUG_TERM}", headers=analyst_headers)
+
+    assert response.status_code == 200
+
+    data = response.get_json()["data"]
+    assert data == [{"idDrug": str(DRUG_WITH_OUTLIER), "name": DRUG_WITH_OUTLIER_NAME}]
+
+
+def test_find_without_matches(client, analyst_headers):
+    """GET /drugs/find — returns an empty list when nothing matches"""
+    response = client.get(
+        f"{FIND_URL}?term=ZZTEST INEXISTENTE", headers=analyst_headers
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == []
+
+
+def test_resolve_no_token(client):
+    """GET /drugs/resolve — returns 401 without authentication"""
+    response = client.get(f"{RESOLVE_URL}?ids={SEED_DRUG_OMEPRAZOL}")
+
+    assert response.status_code == 401
+
+
+def test_resolve_permission_denied(client, dispensing_headers):
+    """GET /drugs/resolve — returns 401 for a role without READ_BASIC_FEATURES"""
+    response = client.get(
+        f"{RESOLVE_URL}?ids={SEED_DRUG_OMEPRAZOL}", headers=dispensing_headers
+    )
+
+    assert response.status_code == 401
+
+
+def test_resolve_without_ids(client, analyst_headers):
+    """GET /drugs/resolve — returns an empty list when no id is given"""
+    response = client.get(f"{RESOLVE_URL}?ids=", headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == []
+
+
+def test_resolve_ignores_non_numeric_ids(client, analyst_headers):
+    """GET /drugs/resolve — a non-numeric id resolves to nothing instead of failing"""
+    response = client.get(f"{RESOLVE_URL}?ids=abc,-,1.5", headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == []
+
+
+def test_resolve_mixes_valid_and_invalid_ids(client, analyst_headers):
+    """GET /drugs/resolve — resolves the numeric ids and drops the rest"""
+    response = client.get(
+        f"{RESOLVE_URL}?ids=abc,{SEED_DRUG_OMEPRAZOL},{INVALID_DRUG_ID}",
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == [
+        {"idDrug": str(SEED_DRUG_OMEPRAZOL), "name": SEED_DRUG_OMEPRAZOL_NAME}
+    ]
+
+
+def test_resolve_returns_names_sorted_by_name(client, analyst_headers):
+    """GET /drugs/resolve — returns the drugs sorted by name, not in the requested order"""
+    ids = f"{SEED_DRUG_OMEPRAZOL},{SEED_DRUG_ALOPURINOL},{SEED_DRUG_PARACETAMOL}"
+    response = client.get(f"{RESOLVE_URL}?ids={ids}", headers=analyst_headers)
+
+    assert response.status_code == 200
+
+    data = response.get_json()["data"]
+    assert len(data) == 3
+    assert _names(data) == sorted(_names(data))
+    assert [item["idDrug"] for item in data] == [
+        str(SEED_DRUG_ALOPURINOL),
+        str(SEED_DRUG_OMEPRAZOL),
+        str(SEED_DRUG_PARACETAMOL),
+    ]
+
+
+def test_resolve_returns_drugs_without_outliers(client, analyst_headers, search_drugs):
+    """GET /drugs/resolve — resolves a drug without outliers, which find() would not return"""
+    response = client.get(
+        f"{RESOLVE_URL}?ids={DRUG_WITHOUT_OUTLIER}", headers=analyst_headers
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == [
+        {"idDrug": str(DRUG_WITHOUT_OUTLIER), "name": DRUG_WITHOUT_OUTLIER_NAME}
+    ]
+
+
+def test_frequencies_no_token(client):
+    """GET /drugs/frequencies — returns 401 without authentication"""
+    response = client.get(FREQUENCIES_URL)
+
+    assert response.status_code == 401
+
+
+def test_frequencies_permission_denied(client, dispensing_headers):
+    """GET /drugs/frequencies — returns 401 for a role without READ_PRESCRIPTION"""
+    response = client.get(FREQUENCIES_URL, headers=dispensing_headers)
+
+    assert response.status_code == 401
+
+
+def test_frequencies_list(client, analyst_headers):
+    """GET /drugs/frequencies — lists every distinct frequency of the schema, sorted by description"""
+    response = client.get(FREQUENCIES_URL, headers=analyst_headers)
+
+    assert response.status_code == 200
+
+    data = response.get_json()["data"]
+    expected = session.execute(
+        text("SELECT DISTINCT fkfrequencia, nome FROM demo.frequencia ORDER BY nome")
+    ).fetchall()
+
+    assert len(data) == len(expected)
+    assert data == [{"id": row[0], "description": row[1]} for row in expected]

--- a/tests/integration/test_notes_annotation.py
+++ b/tests/integration/test_notes_annotation.py
@@ -1,0 +1,326 @@
+"""Integration tests for the clinical-note annotation removal feature.
+
+``POST /notes/remove-annotation`` lets a pharmacist drop a wrong allergy or
+dialysis annotation that the text-mining step wrote on a clinical note. The
+removal is not limited to the note that was clicked: every note of the same
+admission carrying the *same* annotation text is cleared, so the annotation
+stops showing up on the patient timeline. These tests cover that fan-out, the
+boundaries it must respect (other texts, other admissions), the validation
+rules and the audit record.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import UserAuditTypeEnum
+from models.notes import ClinicalNotes
+from services import clinical_notes_service
+from tests.conftest import session, session_commit
+
+URL = "/notes/remove-annotation"
+
+# test-generated ids use >= 100000
+NOTE_ALLERGY = 100920
+NOTE_ALLERGY_SAME_TEXT = 100921
+NOTE_ALLERGY_OTHER_TEXT = 100922
+NOTE_DIALYSIS = 100923
+NOTE_OTHER_ADMISSION = 100924
+
+NOTE_IDS = [
+    NOTE_ALLERGY,
+    NOTE_ALLERGY_SAME_TEXT,
+    NOTE_ALLERGY_OTHER_TEXT,
+    NOTE_DIALYSIS,
+    NOTE_OTHER_ADMISSION,
+]
+
+ADMISSION_NUMBER = 5
+OTHER_ADMISSION_NUMBER = 6
+
+ALLERGY_TEXT = "ZZTEST alergia a dipirona"
+OTHER_ALLERGY_TEXT = "ZZTEST alergia a penicilina"
+DIALYSIS_TEXT = "ZZTEST hemodialise 3x na semana"
+
+INVALID_NOTE_ID = 999999
+
+
+def _insert_note(id, admission_number, allergy_text=None, dialysis_text=None):
+    """Insert a clinical note carrying the given annotation texts"""
+    session.execute(
+        text(
+            "INSERT INTO demo.evolucao "
+            "(fkevolucao, nratendimento, texto, dtevolucao, cargo, exame, "
+            "alergia, alergiatexto, dialise, dialisetexto) "
+            "VALUES (:id, :admission, 'Evolução de teste', now(), "
+            "'Farmacêutica', false, :allergy, :allergy_text, "
+            ":dialysis, :dialysis_text)"
+        ),
+        {
+            "id": id,
+            "admission": admission_number,
+            "allergy": 1 if allergy_text else 0,
+            "allergy_text": allergy_text,
+            "dialysis": 1 if dialysis_text else 0,
+            "dialysis_text": dialysis_text,
+        },
+    )
+
+
+class _StubRedis:
+    """Records the cache commands the annotation removal issues.
+
+    The real client cannot be reached from the test environment, so it is
+    replaced: removing an annotation also refreshes the allergy/dialysis cache
+    of the admission, and that refresh is part of what these tests assert.
+    """
+
+    def __init__(self):
+        self.deleted_keys = []
+
+    def delete(self, key):
+        self.deleted_keys.append(key)
+
+    def zadd(self, key, mapping):
+        pass
+
+    def expire(self, key, ttl):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def stub_redis(monkeypatch):
+    """Replace the cache client used while refreshing the annotation caches"""
+    stub = _StubRedis()
+    monkeypatch.setattr(clinical_notes_service, "redis_client", stub)
+
+    return stub
+
+
+@pytest.fixture
+def annotation_notes():
+    """Notes covering the removal fan-out and the boundaries it must respect"""
+    _insert_note(NOTE_ALLERGY, ADMISSION_NUMBER, allergy_text=ALLERGY_TEXT)
+    _insert_note(NOTE_ALLERGY_SAME_TEXT, ADMISSION_NUMBER, allergy_text=ALLERGY_TEXT)
+    _insert_note(
+        NOTE_ALLERGY_OTHER_TEXT, ADMISSION_NUMBER, allergy_text=OTHER_ALLERGY_TEXT
+    )
+    _insert_note(NOTE_DIALYSIS, ADMISSION_NUMBER, dialysis_text=DIALYSIS_TEXT)
+    _insert_note(
+        NOTE_OTHER_ADMISSION, OTHER_ADMISSION_NUMBER, allergy_text=ALLERGY_TEXT
+    )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM demo.evolucao WHERE fkevolucao = ANY(:ids)"),
+        {"ids": NOTE_IDS},
+    )
+    session.execute(
+        text(
+            "DELETE FROM public.usuario_audit "
+            "WHERE tp_audit = :audit_type "
+            "AND CAST(extra->>'fkevolucao' AS bigint) = ANY(:ids)"
+        ),
+        {
+            "audit_type": UserAuditTypeEnum.REMOVE_CLINICAL_NOTE_ANNOTATION.value,
+            "ids": NOTE_IDS,
+        },
+    )
+    session_commit()
+
+
+def _get_note(id):
+    """Read a note back from the database, bypassing the identity map"""
+    session.expire_all()
+    return session.get(ClinicalNotes, id)
+
+
+def test_remove_annotation_no_token(client, annotation_notes):
+    """POST /notes/remove-annotation — returns 401 without authentication"""
+    response = client.post(
+        URL,
+        json={"idClinicalNotes": NOTE_ALLERGY, "annotationType": "allergy"},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_remove_annotation_permission_denied(client, viewer_headers, annotation_notes):
+    """POST /notes/remove-annotation — a read-only role cannot remove an annotation"""
+    response = client.post(
+        URL,
+        json={"idClinicalNotes": NOTE_ALLERGY, "annotationType": "allergy"},
+        headers=viewer_headers,
+    )
+
+    assert response.status_code == 401
+
+    # the annotation is still there
+    assert _get_note(NOTE_ALLERGY).allergy == 1
+
+
+def test_remove_annotation_invalid_note(client, analyst_headers, annotation_notes):
+    """POST /notes/remove-annotation — returns 400 when the note does not exist"""
+    response = client.post(
+        URL,
+        json={"idClinicalNotes": INVALID_NOTE_ID, "annotationType": "allergy"},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_remove_annotation_missing_note_id(client, analyst_headers, annotation_notes):
+    """POST /notes/remove-annotation — returns 400 when idClinicalNotes is missing"""
+    response = client.post(
+        URL, json={"annotationType": "allergy"}, headers=analyst_headers
+    )
+
+    assert response.status_code == 400
+
+
+def test_remove_annotation_invalid_type(client, analyst_headers, annotation_notes):
+    """POST /notes/remove-annotation — returns 400 for an unsupported annotation type"""
+    response = client.post(
+        URL,
+        json={"idClinicalNotes": NOTE_ALLERGY, "annotationType": "signs"},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.businessRules"
+
+    # nothing was cleared
+    assert _get_note(NOTE_ALLERGY).allergy == 1
+    assert _get_note(NOTE_ALLERGY).allergyText == ALLERGY_TEXT
+
+
+def test_remove_allergy_clears_every_note_with_the_same_text(
+    client, analyst_headers, annotation_notes
+):
+    """POST /notes/remove-annotation — removing an allergy clears every note of the admission sharing that text"""
+    response = client.post(
+        URL,
+        json={"idClinicalNotes": NOTE_ALLERGY, "annotationType": "allergy"},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] is True
+
+    for id in (NOTE_ALLERGY, NOTE_ALLERGY_SAME_TEXT):
+        note = _get_note(id)
+        assert note.allergy == 0
+        assert note.allergyText is None
+
+
+def test_remove_allergy_keeps_other_texts_and_admissions(
+    client, analyst_headers, annotation_notes
+):
+    """POST /notes/remove-annotation — removing an allergy spares other texts and other admissions"""
+    response = client.post(
+        URL,
+        json={"idClinicalNotes": NOTE_ALLERGY, "annotationType": "allergy"},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 200
+
+    # a different allergy on the same admission is untouched
+    other_text = _get_note(NOTE_ALLERGY_OTHER_TEXT)
+    assert other_text.allergy == 1
+    assert other_text.allergyText == OTHER_ALLERGY_TEXT
+
+    # the same allergy text on another admission is untouched
+    other_admission = _get_note(NOTE_OTHER_ADMISSION)
+    assert other_admission.allergy == 1
+    assert other_admission.allergyText == ALLERGY_TEXT
+
+
+def test_remove_allergy_keeps_dialysis_annotation(
+    client, analyst_headers, annotation_notes
+):
+    """POST /notes/remove-annotation — removing an allergy does not touch dialysis annotations"""
+    response = client.post(
+        URL,
+        json={"idClinicalNotes": NOTE_ALLERGY, "annotationType": "allergy"},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 200
+
+    dialysis_note = _get_note(NOTE_DIALYSIS)
+    assert dialysis_note.dialysis == 1
+    assert dialysis_note.dialysisText == DIALYSIS_TEXT
+
+
+def test_remove_dialysis_annotation(
+    client, analyst_headers, annotation_notes, stub_redis
+):
+    """POST /notes/remove-annotation — removing a dialysis annotation clears its flag and text"""
+    response = client.post(
+        URL,
+        json={"idClinicalNotes": NOTE_DIALYSIS, "annotationType": "dialysis"},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 200
+
+    note = _get_note(NOTE_DIALYSIS)
+    assert note.dialysis == 0
+    assert note.dialysisText is None
+
+    # allergies of the same admission are untouched
+    allergy_note = _get_note(NOTE_ALLERGY)
+    assert allergy_note.allergy == 1
+    assert allergy_note.allergyText == ALLERGY_TEXT
+
+    # the dialysis cache of the admission was rebuilt
+    assert f"demo:{ADMISSION_NUMBER}:dialise" in stub_redis.deleted_keys
+
+
+def test_remove_allergy_refreshes_the_allergy_cache(
+    client, analyst_headers, annotation_notes, stub_redis
+):
+    """POST /notes/remove-annotation — rebuilds the allergy cache of the admission"""
+    response = client.post(
+        URL,
+        json={"idClinicalNotes": NOTE_ALLERGY, "annotationType": "allergy"},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 200
+    assert stub_redis.deleted_keys == [f"demo:{ADMISSION_NUMBER}:alergia"]
+
+
+def test_remove_annotation_creates_audit(client, analyst_headers, annotation_notes):
+    """POST /notes/remove-annotation — records the removal, keeping the old text, in the audit table"""
+    response = client.post(
+        URL,
+        json={"idClinicalNotes": NOTE_ALLERGY, "annotationType": "allergy"},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == 200
+
+    session_commit()
+    audit = session.execute(
+        text(
+            "SELECT extra FROM public.usuario_audit "
+            "WHERE tp_audit = :audit_type "
+            "AND CAST(extra->>'fkevolucao' AS bigint) = :id"
+        ),
+        {
+            "audit_type": UserAuditTypeEnum.REMOVE_CLINICAL_NOTE_ANNOTATION.value,
+            "id": NOTE_ALLERGY,
+        },
+    ).fetchall()
+
+    assert len(audit) == 1
+
+    extra = audit[0][0]
+    assert extra["type"] == "allergy"
+    assert extra["notes"] == ALLERGY_TEXT


### PR DESCRIPTION
Adds integration coverage for two features that had none. Test-only change — no production code touched.

## 1. Clinical-note annotation removal — `tests/integration/test_notes_annotation.py`

`POST /notes/remove-annotation` lets a pharmacist drop a wrong allergy or dialysis annotation written by the text-mining step. The removal fans out: every note of the same admission carrying the *same* annotation text is cleared, so the annotation stops showing on the patient timeline. Nothing exercised this before.

Covered (11 tests):
- the fan-out — both notes sharing the allergy text are cleared;
- the boundaries it must respect — a different allergy text on the same admission, the same text on another admission, and the dialysis annotation are all left intact;
- dialysis removal, symmetrically;
- validation — unknown note id, missing `idClinicalNotes`, unsupported annotation type (all 400, with the annotation left in place);
- authorization — no token and a read-only role both 401;
- the audit record, including the old text it preserves;
- the allergy/dialysis cache refresh the removal triggers.

## 2. Protocol drug search and resolution — `tests/integration/test_drug_search.py`

The three endpoints behind the protocol drug picker: `GET /drugs/find`, `GET /drugs/resolve`, `GET /drugs/frequencies`.

Covered (18 tests):
- `find` is restricted to drugs present in the outlier table, and `resolve` deliberately is not — a drug that stopped being scored must stay resolvable, or a saved protocol renders with a blank drug. Both halves are asserted with a fixture that inserts one scored and one unscored drug;
- `find` — case-insensitive partial match, name ordering, empty and missing term (400), no matches (empty list);
- `resolve` — empty input, non-numeric ids dropped instead of failing, mixed valid/invalid ids, unknown ids, name ordering independent of requested order;
- `frequencies` — full list compared against the schema's distinct frequencies;
- authorization on all three (no token, plus a role lacking the required permission).

## Note for reviewers

The annotation tests stub the cache client. With `REDIS_PORT` unset the real client raises `ValueError: invalid literal for int() with base 10: ''`, which is not a `RedisError`, so `cache_service.tolerate_failure` does not absorb it — the endpoint then returns 500 and the api_endpoint handler rolls back, losing the removal. Production configures redis so this is an environment-configuration edge, and the stub keeps the tests focused on the feature. Worth deciding separately whether `tolerate_failure` should also absorb a misconfigured client.

## Verification

- `make test` — 1540 passed (1511 before; +29).
- `ruff check .` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UN4r4gEPsjTG62n9JLqmtk)_