### PR TITLE
test: cover prescription fast search and patient tags

### DIFF
--- a/tests/integration/test_patient_tags.py
+++ b/tests/integration/test_patient_tags.py
@@ -1,0 +1,242 @@
+"""Integration tests for patient tags and the observation history.
+
+Covers the tag branch of POST /patient/<admissionNumber>
+(patient_service.save_patient / patient_service._get_tags) and
+GET /patient/<admissionNumber>/observation-history.
+
+Tag rules exercised here:
+  * names are stored uppercased;
+  * at most 10 tags per patient;
+  * an unknown name creates a marcador row, typed by the caller's role;
+  * a navigator may only create tags prefixed with NAVEGACAO_;
+  * a caller without READ_NAV keeps the navigation tags already on the patient.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_prescription import create_prescription
+
+from models.enums import TagTypeEnum
+from models.prescription import Patient
+
+# outside the ranges used by the shared counters, inside the cleanup range
+ADMISSION = 991001
+PRESCRIPTION = 991010
+
+TAG_EXISTING = "ZZTEST_PAT_EXISTING"
+TAG_NEW = "ZZTEST_PAT_NEW"
+TAG_NAV = "NAVEGACAO_ZZTESTPAT"
+TAG_PREFIX = "ZZTEST_PAT"
+
+
+@pytest.fixture
+def patient():
+    """Create a patient with one prescription and drop every trace afterwards."""
+    create_prescription(
+        id=PRESCRIPTION,
+        admissionNumber=ADMISSION,
+        idPatient=1,
+        date=datetime.now(),
+    )
+
+    p = Patient()
+    p.admissionNumber = ADMISSION
+    p.idPatient = 1
+    p.idHospital = 1
+    p.admissionDate = datetime.now()
+    session.add(p)
+
+    session.execute(
+        text(
+            "INSERT INTO demo.marcador "
+            "(nome, tp_marcador, ativo, created_at, created_by) "
+            "VALUES (:nome, :tp, true, now(), 1)"
+        ),
+        {"nome": TAG_EXISTING, "tp": TagTypeEnum.PATIENT.value},
+    )
+    session_commit()
+
+    yield p
+
+    session.execute(
+        text("DELETE FROM demo.pessoa_audit WHERE nratendimento = :admission"),
+        {"admission": ADMISSION},
+    )
+    session.execute(
+        text("DELETE FROM demo.pessoa WHERE nratendimento = :admission"),
+        {"admission": ADMISSION},
+    )
+    session.execute(
+        text("DELETE FROM demo.prescricao WHERE fkprescricao = :id"),
+        {"id": PRESCRIPTION},
+    )
+    session.execute(
+        text(
+            "DELETE FROM demo.marcador "
+            "WHERE nome LIKE :patient_prefix OR nome LIKE :nav_prefix"
+        ),
+        {"patient_prefix": f"{TAG_PREFIX}%", "nav_prefix": f"{TAG_NAV}%"},
+    )
+    session_commit()
+
+
+def _save(client, headers, data):
+    """POST the given payload to the patient endpoint."""
+    return client.post(f"/patient/{ADMISSION}", json=data, headers=headers)
+
+
+def _stored_tags():
+    """Read the tags currently persisted for the patient."""
+    session.expire_all()
+    return session.get(Patient, ADMISSION).tags
+
+
+def _tag_type(name):
+    """Return the marcador type stored for a tag name, or None when absent."""
+    row = session.execute(
+        text("SELECT tp_marcador FROM demo.marcador WHERE nome = :nome"),
+        {"nome": name},
+    ).first()
+
+    return row[0] if row else None
+
+
+def test_save_tags_permission_denied(client, viewer_headers, patient):
+    """A viewer cannot write patient tags [401 UNAUTHORIZED]."""
+    response = _save(client, viewer_headers, {"tags": [TAG_NEW]})
+
+    assert response.status_code == 401
+    assert _stored_tags() is None
+
+
+def test_save_tags_uppercases_and_persists(client, analyst_headers, patient):
+    """Tags are stored uppercased [200 OK]."""
+    response = _save(client, analyst_headers, {"tags": [TAG_EXISTING.lower()]})
+
+    assert response.status_code == 200
+    assert _stored_tags() == [TAG_EXISTING]
+
+
+def test_save_tags_creates_missing_tag(client, analyst_headers, patient):
+    """An unknown tag is registered as a regular patient tag."""
+    response = _save(client, analyst_headers, {"tags": [TAG_EXISTING, TAG_NEW]})
+
+    assert response.status_code == 200
+    assert _stored_tags() == [TAG_EXISTING, TAG_NEW]
+    assert _tag_type(TAG_NEW) == TagTypeEnum.PATIENT.value
+
+
+def test_save_tags_empty_list_clears_tags(client, analyst_headers, patient):
+    """An empty list removes the tags instead of storing an empty array."""
+    assert _save(client, analyst_headers, {"tags": [TAG_EXISTING]}).status_code == 200
+
+    response = _save(client, analyst_headers, {"tags": []})
+
+    assert response.status_code == 200
+    assert _stored_tags() is None
+
+
+def test_save_tags_above_limit(client, analyst_headers, patient):
+    """More than 10 tags is rejected [400 BAD REQUEST]."""
+    tags = [f"{TAG_PREFIX}_{i:02d}" for i in range(11)]
+    response = _save(client, analyst_headers, {"tags": tags})
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.businessRules"
+    assert _stored_tags() is None
+
+
+def test_save_tags_name_too_long(client, analyst_headers, patient):
+    """A tag longer than the 40 char limit is rejected [400 BAD REQUEST]."""
+    response = _save(client, analyst_headers, {"tags": ["Z" * 41]})
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_save_tags_name_too_short(client, analyst_headers, patient):
+    """A tag shorter than 3 chars is rejected [400 BAD REQUEST]."""
+    response = _save(client, analyst_headers, {"tags": ["ZZ"]})
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_navigator_tag_requires_prefix(client, navigator_headers, patient):
+    """A navigator creating a tag without the NAVEGACAO_ prefix is rejected."""
+    response = _save(client, navigator_headers, {"tags": [TAG_NEW]})
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.businessRules"
+    assert _tag_type(TAG_NEW) is None
+
+
+def test_navigator_tag_with_prefix_is_navigation_type(
+    client, navigator_headers, patient
+):
+    """A navigator's new tag is registered as a navigation tag [200 OK]."""
+    response = _save(client, navigator_headers, {"tags": [TAG_NAV]})
+
+    assert response.status_code == 200
+    assert _stored_tags() == [TAG_NAV]
+    assert _tag_type(TAG_NAV) == TagTypeEnum.PATIENT_NAVIGATION.value
+
+
+def test_non_navigator_keeps_navigation_tags(
+    client, analyst_headers, navigator_headers, patient
+):
+    """A caller without READ_NAV cannot drop the navigation tags already set."""
+    assert _save(client, navigator_headers, {"tags": [TAG_NAV]}).status_code == 200
+
+    response = _save(client, analyst_headers, {"tags": [TAG_EXISTING]})
+
+    assert response.status_code == 200
+    assert _stored_tags() == [TAG_EXISTING, TAG_NAV]
+
+
+def test_save_name_without_permission(client, analyst_headers, patient):
+    """Editing the patient name requires WRITE_NAME [401 UNAUTHORIZED]."""
+    response = _save(client, analyst_headers, {"name": {"name": "zztest"}})
+
+    assert response.status_code == 401
+
+
+def test_observation_history_permission_denied(client, navigator_headers, patient):
+    """The observation history requires READ_PRESCRIPTION [401 UNAUTHORIZED]."""
+    response = client.get(
+        f"/patient/{ADMISSION}/observation-history", headers=navigator_headers
+    )
+
+    assert response.status_code == 401
+
+
+def test_observation_history_records_changes(client, analyst_headers, patient):
+    """Each observation change is recorded once and returned newest first."""
+    assert _save(client, analyst_headers, {"observation": "first"}).status_code == 200
+    # saving the same text again must not create another record
+    assert _save(client, analyst_headers, {"observation": "first"}).status_code == 200
+    assert _save(client, analyst_headers, {"observation": "second"}).status_code == 200
+
+    response = client.get(
+        f"/patient/{ADMISSION}/observation-history", headers=analyst_headers
+    )
+    data = response.get_json()["data"]
+
+    assert response.status_code == 200
+    assert [item["text"] for item in data] == ["second", "first"]
+    assert all(item["createdAt"] for item in data)
+    assert all(item["createdBy"] for item in data)
+
+
+def test_observation_history_empty(client, analyst_headers, patient):
+    """A patient with no observation change has an empty history [200 OK]."""
+    response = client.get(
+        f"/patient/{ADMISSION}/observation-history", headers=analyst_headers
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == []

--- a/tests/integration/test_prescription_search.py
+++ b/tests/integration/test_prescription_search.py
@@ -1,0 +1,226 @@
+"""Integration tests for GET /prescriptions/search (prescription_service.search).
+
+The fast search accepts a single term and matches it against:
+  * a prescription id;
+  * an admission number, restricted to aggregated prescriptions already in
+    effect (agg = true and date <= today);
+  * an admission number of a conciliation prescription (concilia is not null).
+
+Regulation solicitations are also searched, but only when the caller holds
+READ_REGULATION *and* the REGULATION feature is enabled for the schema — the
+test schema has no regulation configuration, so that branch is covered only by
+the permission assertions below.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import get_access, make_headers, session, session_commit
+from tests.utils.utils_test_prescription import create_prescription
+
+from models.prescription import Patient
+from security.role import Role
+
+# ids/admission numbers well above the ranges used by the shared counters in
+# tests/utils/utils_test_prescription.py, still inside the cleanup range (>= 100000)
+ADMISSION = 990001
+OTHER_ADMISSION = 990002
+
+PRESC_AGG_TODAY = 990010
+PRESC_REGULAR = 990011
+PRESC_AGG_FUTURE = 990012
+PRESC_CONCILIA = 990013
+PRESC_OTHER_ADMISSION = 990020
+
+BIRTHDATE = datetime(1980, 5, 4)
+ADMISSION_DATE = datetime(2020, 12, 1)
+
+
+@pytest.fixture
+def seed_search_data():
+    """Create a patient with prescriptions covering every search branch."""
+    patient = Patient()
+    patient.admissionNumber = ADMISSION
+    patient.idPatient = 1
+    patient.idHospital = 1
+    patient.admissionDate = ADMISSION_DATE
+    patient.birthdate = BIRTHDATE
+    patient.gender = "F"
+    session.add(patient)
+    session_commit()
+
+    now = datetime.now()
+
+    # aggregated and already in effect: reachable by id and by admission number
+    create_prescription(
+        id=PRESC_AGG_TODAY,
+        admissionNumber=ADMISSION,
+        idPatient=1,
+        date=now - timedelta(hours=1),
+        agg=True,
+        status="0",
+    )
+    # not aggregated: reachable by id only
+    create_prescription(
+        id=PRESC_REGULAR,
+        admissionNumber=ADMISSION,
+        idPatient=1,
+        date=now - timedelta(hours=2),
+        status="s",
+    )
+    # aggregated but dated in the future: not reachable by admission number
+    create_prescription(
+        id=PRESC_AGG_FUTURE,
+        admissionNumber=ADMISSION,
+        idPatient=1,
+        date=now + timedelta(days=5),
+        agg=True,
+    )
+    # conciliation: reachable by admission number through the conciliation query
+    create_prescription(
+        id=PRESC_CONCILIA,
+        admissionNumber=ADMISSION,
+        idPatient=1,
+        date=now - timedelta(days=3),
+        concilia="s",
+    )
+    # belongs to another admission: must never show up
+    create_prescription(
+        id=PRESC_OTHER_ADMISSION,
+        admissionNumber=OTHER_ADMISSION,
+        idPatient=2,
+        date=now,
+        agg=True,
+    )
+
+    yield
+
+    session.execute(
+        text("DELETE FROM demo.prescricao WHERE fkprescricao >= :first"),
+        {"first": PRESC_AGG_TODAY},
+    )
+    session.execute(
+        text("DELETE FROM demo.pessoa WHERE nratendimento = :admission"),
+        {"admission": ADMISSION},
+    )
+    session_commit()
+
+
+def _search(client, headers, term=None):
+    """Call the endpoint, omitting the term entirely when it is None."""
+    url = "/prescriptions/search"
+    if term is not None:
+        url = f"{url}?term={term}"
+
+    return client.get(url, headers=headers)
+
+
+def _ids(response):
+    """Extract the returned prescription ids, preserving order."""
+    return [item["idPrescription"] for item in response.get_json()["data"]]
+
+
+def test_search_permission_denied(client):
+    """A user without any of the search permissions gets [401 UNAUTHORIZED]."""
+    headers = make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+    response = _search(client, headers, term=PRESC_AGG_TODAY)
+
+    assert response.status_code == 401
+
+
+def test_search_without_term(client, analyst_headers):
+    """Omitting the term is rejected with [400 BAD REQUEST]."""
+    response = _search(client, analyst_headers)
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.invalidParam"
+
+
+def test_search_by_prescription_id(client, analyst_headers, seed_search_data):
+    """A prescription id matches that prescription regardless of agg or date."""
+    response = _search(client, analyst_headers, term=PRESC_REGULAR)
+
+    assert response.status_code == 200
+    assert _ids(response) == [str(PRESC_REGULAR)]
+
+
+def test_search_by_prescription_id_returns_patient_data(
+    client, analyst_headers, seed_search_data
+):
+    """The result carries the patient and department data joined to the prescription."""
+    response = _search(client, analyst_headers, term=PRESC_AGG_TODAY)
+    item = response.get_json()["data"][0]
+
+    assert item["admissionNumber"] == ADMISSION
+    assert item["agg"] is True
+    assert item["concilia"] is None
+    assert item["status"] == "0"
+    assert item["type"] == "prescription"
+    # dtnascimento is a date column, so it comes back without a time part
+    assert item["birthdate"] == BIRTHDATE.date().isoformat()
+    assert item["gender"] == "F"
+    assert item["admissionDate"] == ADMISSION_DATE.isoformat()
+    assert item["department"] == "Setor Adulto 1"
+    assert item["date"] is not None
+
+
+def test_search_by_admission_number(client, analyst_headers, seed_search_data):
+    """An admission number returns the in-effect aggregated prescription and the
+    conciliation, leaving out non-aggregated and future-dated ones."""
+    response = _search(client, analyst_headers, term=ADMISSION)
+    returned = _ids(response)
+
+    assert response.status_code == 200
+    assert set(returned) == {str(PRESC_AGG_TODAY), str(PRESC_CONCILIA)}
+    assert str(PRESC_REGULAR) not in returned
+    assert str(PRESC_AGG_FUTURE) not in returned
+
+
+def test_search_by_admission_number_ordering(client, analyst_headers, seed_search_data):
+    """The regular prescription is listed before the conciliation."""
+    response = _search(client, analyst_headers, term=ADMISSION)
+    data = response.get_json()["data"]
+
+    assert data[0]["idPrescription"] == str(PRESC_AGG_TODAY)
+    assert data[0]["concilia"] is None
+    assert data[1]["idPrescription"] == str(PRESC_CONCILIA)
+    assert data[1]["concilia"] == "s"
+
+
+def test_search_does_not_leak_other_admissions(
+    client, analyst_headers, seed_search_data
+):
+    """Prescriptions of a different admission are never returned."""
+    response = _search(client, analyst_headers, term=ADMISSION)
+
+    assert str(PRESC_OTHER_ADMISSION) not in _ids(response)
+
+
+def test_search_no_match(client, analyst_headers, seed_search_data):
+    """A term that matches nothing returns an empty list [200 OK]."""
+    response = _search(client, analyst_headers, term=999999999)
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == []
+
+
+def test_search_discharge_summary_permission(client, seed_search_data):
+    """READ_DISCHARGE_SUMMARY alone is enough to search prescriptions."""
+    headers = make_headers(get_access(client, roles=[Role.DISCHARGE_MANAGER.value]))
+    response = _search(client, headers, term=PRESC_AGG_TODAY)
+
+    assert response.status_code == 200
+    assert _ids(response) == [str(PRESC_AGG_TODAY)]
+
+
+def test_search_regulation_permission_skips_prescriptions(client, seed_search_data):
+    """READ_REGULATION grants access to the endpoint but not to prescriptions."""
+    headers = make_headers(get_access(client, roles=[Role.REGULATOR.value]))
+    response = _search(client, headers, term=PRESC_AGG_TODAY)
+
+    assert response.status_code == 200
+    # no prescription results, and no regulation results either since the
+    # REGULATION feature is not enabled for the test schema
+    assert response.get_json()["data"] == []


### PR DESCRIPTION
## Summary

Adds integration tests for two features that had **no coverage at all**. Test-only change — no production code touched.

Picked by running the suite with coverage and looking for whole functions at 0%.

### 1. Prescription fast search — `tests/integration/test_prescription_search.py`

`GET /prescriptions/search` → `prescription_service.search()` was entirely untested (lines 46–176). 10 tests covering:

- match by prescription id (regardless of `agg`/date)
- match by admission number, restricted to `agg = true` **and** `date <= today` — asserts the non-aggregated and future-dated prescriptions are *not* returned
- the conciliation branch (`concilia is not null`) and the resulting ordering (regular prescription before the conciliation)
- the joined payload: `birthdate`, `gender`, `admissionDate` from `pessoa`, `department` from `setor`
- prescriptions of another admission are never leaked
- no match → empty list
- the missing-`term` validation error (`400`, `errors.invalidParam`)
- each of the three permissions that reach the endpoint: `READ_PRESCRIPTION`, `READ_DISCHARGE_SUMMARY`, `READ_REGULATION` (the last one grants access but returns no prescriptions), plus a `401` for a role holding none of them

Note: the regulation-solicitation branch is only reachable with the `REGULATION` feature enabled, and the regulation tables come from `noharm-create-regulation.sql`, which the CI database setup does not load. That branch is therefore covered only by the permission assertions.

### 2. Patient tags and observation history — `tests/integration/test_patient_tags.py`

The tag branch of `POST /patient/<admissionNumber>` (`save_patient` / `_get_tags`) and `GET /patient/<admissionNumber>/observation-history` were untested. 14 tests covering:

- names stored uppercased; an empty list clears the column instead of storing `[]`
- an unknown name creates a `marcador` row typed `PATIENT`
- the 10-tag limit, the 40-char maximum and the 3-char minimum (all `400 errors.businessRules`)
- a navigator may only create tags prefixed `NAVEGACAO_`, and those are typed `PATIENT_NAVIGATION`
- a caller without `READ_NAV` cannot drop the navigation tags already on the patient
- the `WRITE_NAME` gate on the `name` payload (`401`)
- the observation audit trail: one record per actual change (re-saving the same text adds nothing), returned newest first, and empty for an untouched patient
- `401` for a viewer writing tags and for a navigator reading the history (needs `READ_PRESCRIPTION`)

## Test isolation

Both files use self-cleaning fixtures with reserved id/name ranges (prescriptions `≥ 990010`/`991010`, admissions `≥ 990001`, tags prefixed `ZZTEST_PAT` / `NAVEGACAO_ZZTESTPAT`), so no change to `tests/conftest.py` was needed and the suite stays re-runnable.

## Verification

Ran against a local PostgreSQL loaded from `noharm-ai/database` with the same SQL files CI uses:

- `ENV=test pytest` — **1564 passed** (was 1540; 24 new tests)
- `ruff check .` — all checks passed

Coverage of the touched services:

| file | before | after |
|---|---|---|
| `services/patient_service.py` | 54% | 82% |
| `services/prescription_service.py` | 50% | 57% |

---
_Generated by [Claude Code](https://claude.ai/code/session_01GByvNCzdsZqdeBHDEw6kYP)_