### PR TITLE
feat: leitura de gráficos de outro relatório customizado (copy source)

### DIFF
--- a/models/requests/admin/admin_report_request.py
+++ b/models/requests/admin/admin_report_request.py
@@ -9,3 +9,25 @@ class UpdateReportGraphsRequest(BaseModel):
     """Request model for updating report graphs"""
 
     graphs: Optional[Any] = Field(None, description="Graph configurations as JSON")
+
+
+class CopySourceListRequest(BaseModel):
+    """Request model for listing the reports usable as a chart copy source.
+
+    The field is named sourceSchema rather than schema to stay clear of
+    BaseModel.schema. The pattern is defense in depth only: the schema is
+    authorized against public.schema_config before it reaches a query.
+    """
+
+    sourceSchema: Optional[str] = Field(
+        None,
+        max_length=64,
+        pattern=r"^[a-z][a-z0-9_]*$",
+        description="Schema to read the copy sources from. Defaults to the user's own",
+    )
+
+
+class CopySourceGraphsRequest(CopySourceListRequest):
+    """Request model for reading the charts of a copy-source report"""
+
+    idReport: int = Field(description="Report to copy the charts from")

--- a/repository/reports/reports_repository.py
+++ b/repository/reports/reports_repository.py
@@ -3,6 +3,7 @@
 from sqlalchemy import and_
 
 from models.appendix import Report
+from models.enums import ReportTypeEnum
 from models.main import User, db
 
 
@@ -27,3 +28,23 @@ def get_custom_reports(schema: str, all: bool = False):
 def get_report(id_report: int):
     """Get single report by ID."""
     return db.session.query(Report).filter(Report.id == id_report).first()
+
+
+def get_active_custom_reports_from_session(db_session):
+    """List the active custom reports visible through an explicitly scoped session.
+
+    The schema comes from the session's schema_translate_map, so a caller reading
+    another schema never builds a schema name into the query.
+    """
+    return (
+        db_session.query(Report)
+        .filter(Report.active)
+        .filter(Report.report_type == ReportTypeEnum.CUSTOM.value)
+        .order_by(Report.name)
+        .all()
+    )
+
+
+def get_report_from_session(db_session, id_report: int):
+    """Get a single report by ID through an explicitly scoped session."""
+    return db_session.query(Report).filter(Report.id == id_report).first()

--- a/routes/admin/admin_report.py
+++ b/routes/admin/admin_report.py
@@ -3,7 +3,11 @@
 from flask import Blueprint, request
 
 from decorators.api_endpoint_decorator import api_endpoint
-from models.requests.admin.admin_report_request import UpdateReportGraphsRequest
+from models.requests.admin.admin_report_request import (
+    CopySourceGraphsRequest,
+    CopySourceListRequest,
+    UpdateReportGraphsRequest,
+)
 from services.admin import admin_report_service
 
 app_admin_report = Blueprint("app_admin_report", __name__)
@@ -16,4 +20,29 @@ def update_report_graphs(id_report: int):
     return admin_report_service.update_report_graphs(
         id_report=id_report,
         request_data=UpdateReportGraphsRequest(**request.get_json()),
+    )
+
+
+@app_admin_report.route("/admin/report/copy-source/list", methods=["GET"])
+@api_endpoint(is_admin=True)
+def get_copy_source_reports():
+    """List the reports whose charts may be copied, optionally from another schema."""
+    return admin_report_service.get_copy_source_reports(
+        request_data=CopySourceListRequest(
+            sourceSchema=request.args.get("sourceSchema", None)
+        ),
+    )
+
+
+@app_admin_report.route(
+    "/admin/report/copy-source/<int:id_report>/graphs", methods=["GET"]
+)
+@api_endpoint(is_admin=True)
+def get_copy_source_graphs(id_report: int):
+    """Get the charts of a copy-source report."""
+    return admin_report_service.get_copy_source_graphs(
+        request_data=CopySourceGraphsRequest(
+            idReport=id_report,
+            sourceSchema=request.args.get("sourceSchema", None),
+        ),
     )

--- a/services/admin/admin_report_service.py
+++ b/services/admin/admin_report_service.py
@@ -1,13 +1,22 @@
 """Service for admin reports."""
 
+import json
 from datetime import datetime
 
+from flask_sqlalchemy.session import Session
+
 from decorators.has_permission_decorator import Permission, has_permission
+from exception.authorization_error import AuthorizationError
 from exception.validation_error import ValidationError
 from models.main import User, db
-from models.requests.admin.admin_report_request import UpdateReportGraphsRequest
+from models.requests.admin.admin_report_request import (
+    CopySourceGraphsRequest,
+    CopySourceListRequest,
+    UpdateReportGraphsRequest,
+)
 from repository.reports import reports_repository
-from utils import status
+from services import auth_service
+from utils import logger, status
 
 
 @has_permission(Permission.WRITE_CUSTOM_REPORTS_GRAPHS)
@@ -31,3 +40,110 @@ def update_report_graphs(
     db.session.flush()
 
     return {"id": report.id, "graphs": report.graphs}
+
+
+@has_permission(Permission.WRITE_CUSTOM_REPORTS_GRAPHS)
+def get_copy_source_reports(request_data: CopySourceListRequest, user_context: User):
+    """List the custom reports whose charts may be copied into another report."""
+    source_schema = _authorize_source_schema(
+        user_context=user_context, source_schema=request_data.sourceSchema
+    )
+
+    db_session = _open_schema_session(schema=source_schema)
+    try:
+        reports = reports_repository.get_active_custom_reports_from_session(
+            db_session=db_session
+        )
+
+        return [
+            {
+                "id": report.id,
+                "name": report.name,
+                "description": report.description,
+                "status": report.status,
+                "processedAt": (
+                    report.processed_at.isoformat() if report.processed_at else None
+                ),
+                "graphCount": len(_normalize_graphs(report.graphs)),
+            }
+            for report in reports
+        ]
+    finally:
+        db_session.close()
+
+
+@has_permission(Permission.WRITE_CUSTOM_REPORTS_GRAPHS)
+def get_copy_source_graphs(request_data: CopySourceGraphsRequest, user_context: User):
+    """Get the chart configurations of a copy-source report."""
+    source_schema = _authorize_source_schema(
+        user_context=user_context, source_schema=request_data.sourceSchema
+    )
+
+    db_session = _open_schema_session(schema=source_schema)
+    try:
+        report = reports_repository.get_report_from_session(
+            db_session=db_session, id_report=request_data.idReport
+        )
+
+        if not report or not report.active:
+            raise ValidationError(
+                "Relatório de origem não encontrado",
+                "errors.invalidRecord",
+                status.HTTP_400_BAD_REQUEST,
+            )
+
+        return {
+            "id": report.id,
+            "name": report.name,
+            "sourceSchema": source_schema,
+            "graphs": _normalize_graphs(report.graphs),
+        }
+    finally:
+        db_session.close()
+
+
+def _authorize_source_schema(user_context: User, source_schema: str) -> str:
+    """Resolve and authorize the schema the charts are copied from."""
+    if not source_schema or source_schema == user_context.schema:
+        return user_context.schema
+
+    if not auth_service.can_read_foreign_schema_as_maintainer(
+        user=user_context, target_schema=source_schema
+    ):
+        raise AuthorizationError()
+
+    logger.backend_logger.info(
+        "cross-schema report chart read: user=%s from=%s to=%s",
+        user_context.id,
+        source_schema,
+        user_context.schema,
+    )
+
+    return source_schema
+
+
+def _open_schema_session(schema: str) -> Session:
+    """Open a session bound to `schema`, isolated from the request session.
+
+    A rollback on the request session clears its schema_translate_map, so the
+    foreign read gets its own session instead of re-pointing the current one.
+    """
+    db_session = Session(db)
+    db_session.connection(execution_options={"schema_translate_map": {None: schema}})
+
+    return db_session
+
+
+def _normalize_graphs(raw) -> list:
+    """Return the stored charts as a list.
+
+    The chart editor writes a JSON string into the JSON column, while rows
+    written elsewhere hold a real array, so both shapes reach this point.
+    """
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except ValueError:
+            return []
+
+    return raw if isinstance(raw, list) else []

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -128,6 +128,22 @@ def _schema_exists(schema: str) -> bool:
     )
 
 
+def can_read_foreign_schema_as_maintainer(user: User, target_schema: str) -> bool:
+    """Check whether the user may read data from another schema.
+
+    The user's own schema is always allowed. Any other schema requires MAINTAINER
+    and must be configured: the existence check is what keeps an arbitrary string
+    out of a schema_translate_map, so it runs for every foreign schema.
+    """
+    if target_schema == user.schema:
+        return True
+
+    if Permission.MAINTAINER not in Role.get_permissions_from_user(user=user):
+        return False
+
+    return _schema_exists(schema=target_schema)
+
+
 def _auth_user(
     user,
     force_schema=None,

--- a/tests/integration/test_admin_report_copy.py
+++ b/tests/integration/test_admin_report_copy.py
@@ -1,0 +1,386 @@
+"""Integration tests for the /admin/report/copy-source endpoints.
+
+Covers the read side of copying charts between custom reports: which reports are
+offered as a copy source, the charts they expose, and — since relatorio is a
+schema-local table — who may read a source that lives in another schema.
+
+A throwaway schema holds the foreign source, so the cross-schema path is
+exercised against a real second schema instead of a stub.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import ReportStatusEnum, ReportTypeEnum
+from tests.conftest import session, session_commit
+from utils import status
+
+LIST_URL = "/admin/report/copy-source/list"
+GRAPHS_URL = "/admin/report/copy-source/{id_report}/graphs"
+
+# every report written by this module is named with this prefix
+_PREFIX = "ZZTEST_RPT_COPY"
+
+# the stored query of the seeded reports; incidental to the copy source
+_VALID_SQL = "select fkprescricao from demo.prescricao"
+
+# id of the user that owns the rows seeded by this module
+_SEED_USER_ID = 1
+
+# throwaway schema holding the foreign copy source
+_FOREIGN_SCHEMA = "zztest_copy"
+
+_A_CHART = {"id": "c1", "type": "bar", "xKeys": ["leito"], "yKeys": ["__count__"]}
+
+
+def _insert_report(
+    name: str,
+    graphs=None,
+    active: bool = True,
+    report_type: int = ReportTypeEnum.CUSTOM.value,
+    schema: str = "demo",
+    raw_graphs: str = None,
+) -> int:
+    """Insert a processed custom report and return its id.
+
+    `graphs` is stored as a JSON array; `raw_graphs` is stored verbatim, which is
+    how the chart editor writes its configuration (a JSON string inside the JSON
+    column).
+    """
+    if raw_graphs is not None:
+        stored = raw_graphs
+    else:
+        stored = json.dumps(graphs) if graphs is not None else None
+
+    result = session.execute(
+        text(
+            f"INSERT INTO {schema}.relatorio "
+            "(nome, descricao, tp_relatorio, sql, ativo, tp_status, erro, graficos, "
+            " processed_at, processed_by, created_at, created_by) "
+            "VALUES (:name, :description, :report_type, :sql, :active, :status, null, "
+            " CAST(:graphs AS json), now(), :user, now(), :user) "
+            "RETURNING idrelatorio"
+        ),
+        {
+            "name": name,
+            "description": "seeded by test_admin_report_copy",
+            "report_type": report_type,
+            "sql": _VALID_SQL,
+            "active": active,
+            "status": ReportStatusEnum.PROCESSED.value,
+            "graphs": stored,
+            "user": _SEED_USER_ID,
+        },
+    )
+    return result.scalar()
+
+
+def _cleanup():
+    """Remove every reserved report this module may have created."""
+    session.execute(
+        text("DELETE FROM demo.relatorio WHERE nome LIKE :prefix"),
+        {"prefix": f"{_PREFIX}%"},
+    )
+    session_commit()
+
+
+@pytest.fixture(autouse=True)
+def clean_reports():
+    """Drop the reserved reports before and after each test."""
+    _cleanup()
+    yield
+    _cleanup()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def foreign_schema():
+    """A second schema with its own relatorio table, configured in schema_config.
+
+    Without the schema_config row the schema is not readable at all, which is the
+    guarantee the "unknown schema" test relies on.
+    """
+    session.execute(text(f"CREATE SCHEMA IF NOT EXISTS {_FOREIGN_SCHEMA}"))
+    session.execute(
+        text(
+            f"CREATE TABLE IF NOT EXISTS {_FOREIGN_SCHEMA}.relatorio "
+            "(LIKE demo.relatorio INCLUDING ALL)"
+        )
+    )
+    session.execute(
+        text(
+            "INSERT INTO public.schema_config "
+            "(schema_name, created_at, status, tp_noharm_care, tp_pep, "
+            " integracao_retorno, tp_prescalc) "
+            "VALUES (:schema, now(), 1, 0, 'OTHER', false, 0) "
+            "ON CONFLICT (schema_name) DO NOTHING"
+        ),
+        {"schema": _FOREIGN_SCHEMA},
+    )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM public.schema_config WHERE schema_name = :schema"),
+        {"schema": _FOREIGN_SCHEMA},
+    )
+    session.execute(text(f"DROP SCHEMA IF EXISTS {_FOREIGN_SCHEMA} CASCADE"))
+    session_commit()
+
+
+def _list(client, headers, source_schema=None):
+    """Call the copy-source listing endpoint."""
+    url = LIST_URL
+    if source_schema is not None:
+        url = f"{LIST_URL}?sourceSchema={source_schema}"
+
+    return client.get(url, headers=headers)
+
+
+def _graphs(client, headers, id_report, source_schema=None):
+    """Call the copy-source graphs endpoint."""
+    url = GRAPHS_URL.format(id_report=id_report)
+    if source_schema is not None:
+        url = f"{url}?sourceSchema={source_schema}"
+
+    return client.get(url, headers=headers)
+
+
+def _find(rows, id_report):
+    """Return the listed row of a report, or None when it was not offered."""
+    return next((row for row in rows if row["id"] == id_report), None)
+
+
+# ---------------------------------------------------------------------------
+# listing copy sources
+# ---------------------------------------------------------------------------
+
+
+def test_list_offers_the_reports_of_the_current_schema(client, admin_headers):
+    """Without a source schema the copy sources come from the user's own schema."""
+    id_report = _insert_report(name=f"{_PREFIX} own", graphs=[_A_CHART, _A_CHART])
+    session_commit()
+
+    response = _list(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    row = _find(response.get_json()["data"], id_report)
+    assert row["name"] == f"{_PREFIX} own"
+    assert row["graphCount"] == 2
+
+
+def test_list_requires_the_graphs_permission(client, analyst_headers):
+    """Listing copy sources without WRITE_CUSTOM_REPORTS_GRAPHS is refused [401]."""
+    response = _list(client, analyst_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_list_omits_inactive_reports(client, admin_headers):
+    """An inactive report cannot be picked as a copy source."""
+    id_report = _insert_report(name=f"{_PREFIX} inactive", active=False)
+    session_commit()
+
+    response = _list(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _find(response.get_json()["data"], id_report) is None
+
+
+def test_list_counts_charts_stored_as_a_json_string(client, admin_headers):
+    """The chart editor stores a JSON string, so the count still has to work."""
+    id_report = _insert_report(
+        name=f"{_PREFIX} string graphs", raw_graphs=json.dumps(json.dumps([_A_CHART]))
+    )
+    session_commit()
+
+    response = _list(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _find(response.get_json()["data"], id_report)["graphCount"] == 1
+
+
+def test_list_of_own_schema_does_not_require_maintainer(client, admin_headers):
+    """Naming your own schema explicitly is the same as not naming one at all."""
+    id_report = _insert_report(name=f"{_PREFIX} explicit own")
+    session_commit()
+
+    response = _list(client, admin_headers, source_schema="demo")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _find(response.get_json()["data"], id_report) is not None
+
+
+def test_list_of_an_unknown_schema_is_refused(client, admin_headers):
+    """A schema missing from schema_config is unreadable even for a maintainer [401]."""
+    response = _list(client, admin_headers, source_schema="zztest_does_not_exist")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_list_of_a_malformed_schema_is_refused(client, admin_headers):
+    """A schema name that is not a plain identifier never reaches the query [400]."""
+    response = _list(client, admin_headers, source_schema="demo;drop")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_list_reads_the_foreign_schema_for_a_maintainer(client, admin_headers):
+    """A maintainer may list the copy sources of another configured schema."""
+    id_own = _insert_report(name=f"{_PREFIX} own")
+    id_foreign = _insert_report(
+        name=f"{_PREFIX} foreign", graphs=[_A_CHART], schema=_FOREIGN_SCHEMA
+    )
+    session_commit()
+
+    response = _list(client, admin_headers, source_schema=_FOREIGN_SCHEMA)
+
+    assert response.status_code == status.HTTP_200_OK
+    rows = response.get_json()["data"]
+    assert _find(rows, id_foreign)["name"] == f"{_PREFIX} foreign"
+    assert _find(rows, id_own) is None
+
+
+def test_reading_a_foreign_schema_leaves_the_request_schema_intact(
+    client, admin_headers
+):
+    """The foreign read is isolated, so the next call still sees the own schema."""
+    id_own = _insert_report(name=f"{_PREFIX} own")
+    _insert_report(name=f"{_PREFIX} foreign", schema=_FOREIGN_SCHEMA)
+    session_commit()
+
+    assert (
+        _list(client, admin_headers, source_schema=_FOREIGN_SCHEMA).status_code
+        == status.HTTP_200_OK
+    )
+
+    response = _list(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _find(response.get_json()["data"], id_own) is not None
+
+
+# ---------------------------------------------------------------------------
+# reading the charts of a copy source
+# ---------------------------------------------------------------------------
+
+
+def test_graphs_returns_the_stored_charts(client, admin_headers):
+    """The charts of a copy source are returned as a list."""
+    id_report = _insert_report(name=f"{_PREFIX} graphs", graphs=[_A_CHART])
+    session_commit()
+
+    response = _graphs(client, admin_headers, id_report)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.get_json()["data"]
+    assert data["graphs"] == [_A_CHART]
+    assert data["sourceSchema"] == "demo"
+
+
+def test_graphs_parses_charts_stored_as_a_json_string(client, admin_headers):
+    """Charts written by the editor arrive as a string and are parsed for the caller."""
+    id_report = _insert_report(
+        name=f"{_PREFIX} string", raw_graphs=json.dumps(json.dumps([_A_CHART]))
+    )
+    session_commit()
+
+    response = _graphs(client, admin_headers, id_report)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["graphs"] == [_A_CHART]
+
+
+@pytest.mark.parametrize(
+    "raw_graphs",
+    [
+        pytest.param(json.dumps("not json"), id="unparseable string"),
+        pytest.param(json.dumps({"type": "bar"}), id="object instead of list"),
+        pytest.param(None, id="null"),
+    ],
+)
+def test_graphs_of_an_unusable_configuration_is_empty(
+    client, admin_headers, raw_graphs
+):
+    """A configuration that is not a chart list is reported as having no charts."""
+    id_report = _insert_report(name=f"{_PREFIX} broken", raw_graphs=raw_graphs)
+    session_commit()
+
+    response = _graphs(client, admin_headers, id_report)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["graphs"] == []
+
+
+def test_graphs_requires_the_graphs_permission(client, analyst_headers):
+    """Reading a copy source without WRITE_CUSTOM_REPORTS_GRAPHS is refused [401]."""
+    id_report = _insert_report(name=f"{_PREFIX} graphs", graphs=[_A_CHART])
+    session_commit()
+
+    response = _graphs(client, analyst_headers, id_report)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_graphs_of_an_unknown_report_is_refused(client, admin_headers):
+    """Reading a report that does not exist is a business error [400 BAD REQUEST]."""
+    response = _graphs(client, admin_headers, 99999999)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRecord"
+
+
+def test_graphs_of_an_inactive_report_is_refused(client, admin_headers):
+    """An inactive report is not offered, so it cannot be read directly either [400]."""
+    id_report = _insert_report(name=f"{_PREFIX} inactive", active=False)
+    session_commit()
+
+    response = _graphs(client, admin_headers, id_report)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_graphs_of_an_unknown_schema_is_refused(client, admin_headers):
+    """An unconfigured schema is unreadable even for a maintainer [401]."""
+    id_report = _insert_report(name=f"{_PREFIX} graphs", graphs=[_A_CHART])
+    session_commit()
+
+    response = _graphs(
+        client, admin_headers, id_report, source_schema="zztest_does_not_exist"
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_graphs_reads_the_foreign_schema_for_a_maintainer(client, admin_headers):
+    """A maintainer may read the charts of a report in another configured schema."""
+    foreign_chart = {**_A_CHART, "title": "foreign"}
+    id_foreign = _insert_report(
+        name=f"{_PREFIX} foreign", graphs=[foreign_chart], schema=_FOREIGN_SCHEMA
+    )
+    session_commit()
+
+    response = _graphs(
+        client, admin_headers, id_foreign, source_schema=_FOREIGN_SCHEMA
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.get_json()["data"]
+    assert data["graphs"] == [foreign_chart]
+    assert data["sourceSchema"] == _FOREIGN_SCHEMA
+
+
+def test_graphs_does_not_reach_a_foreign_report_through_the_own_schema(
+    client, admin_headers
+):
+    """Without the source schema the id is resolved in the caller's schema only."""
+    id_foreign = _insert_report(
+        name=f"{_PREFIX} foreign", graphs=[_A_CHART], schema=_FOREIGN_SCHEMA
+    )
+    session_commit()
+
+    response = _graphs(client, admin_headers, id_foreign)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/unit/test_auth_foreign_schema.py
+++ b/tests/unit/test_auth_foreign_schema.py
@@ -1,0 +1,100 @@
+"""Unit tests for auth_service.can_read_foreign_schema_as_maintainer.
+
+The helper decides whether a user may read data out of another tenant's schema —
+the check that stands between a copy-source request and a schema_translate_map.
+Its rules are: your own schema is always readable, another schema requires
+MAINTAINER, and a schema that is not configured is never readable. The roles that
+grant chart editing today (ADMIN, CURATOR) all carry MAINTAINER, so the negative
+branches are only reachable from here.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from models.main import User
+from security.role import Role
+from services import auth_service
+
+
+def _user(roles, schema="own_schema"):
+    """Build a User carrying the given role names in its config."""
+    user = User()
+    user.id = 42
+    user.schema = schema
+    user.config = {"roles": roles}
+    return user
+
+
+def _db_with_schema_config(schema_row):
+    """Mock db whose SchemaConfig query resolves ``.first()`` to schema_row."""
+    mock_db = MagicMock()
+    (mock_db.session.query.return_value.filter.return_value.first.return_value) = (
+        schema_row
+    )
+    return mock_db
+
+
+def test_own_schema_is_readable_without_any_role():
+    """Reading your own schema is not a cross-schema access at all."""
+    assert (
+        auth_service.can_read_foreign_schema_as_maintainer(
+            user=_user([]), target_schema="own_schema"
+        )
+        is True
+    )
+
+
+def test_foreign_schema_is_refused_without_maintainer():
+    """MULTI_SCHEMA alone does not open another tenant's data.
+
+    TRAINING carries MULTI_SCHEMA (and TRAINING_RECORDING) but not MAINTAINER.
+    """
+    assert (
+        auth_service.can_read_foreign_schema_as_maintainer(
+            user=_user([Role.TRAINING.value]), target_schema="other_schema"
+        )
+        is False
+    )
+
+
+def test_foreign_schema_is_refused_for_a_user_without_roles():
+    """A user with no roles has no cross-schema access."""
+    assert (
+        auth_service.can_read_foreign_schema_as_maintainer(
+            user=_user([]), target_schema="other_schema"
+        )
+        is False
+    )
+
+
+def test_maintainer_may_read_a_configured_schema():
+    """A maintainer reaches another schema once it is known to schema_config."""
+    with patch.object(auth_service, "db", _db_with_schema_config(MagicMock())):
+        assert (
+            auth_service.can_read_foreign_schema_as_maintainer(
+                user=_user([Role.ADMIN.value]), target_schema="other_schema"
+            )
+            is True
+        )
+
+
+def test_maintainer_may_not_read_an_unconfigured_schema():
+    """An unknown schema name is refused before it can reach a query."""
+    with patch.object(auth_service, "db", _db_with_schema_config(None)):
+        assert (
+            auth_service.can_read_foreign_schema_as_maintainer(
+                user=_user([Role.ADMIN.value]), target_schema="not_a_schema"
+            )
+            is False
+        )
+
+
+def test_non_maintainer_never_reaches_the_schema_lookup():
+    """The role check comes first, so an unauthorized user costs no query."""
+    mock_db = _db_with_schema_config(MagicMock())
+
+    with patch.object(auth_service, "db", mock_db):
+        auth_service.can_read_foreign_schema_as_maintainer(
+            user=_user([Role.VIEWER.value]), target_schema="other_schema"
+        )
+
+    mock_db.session.query.assert_not_called()


### PR DESCRIPTION
Lado de leitura da nova funcionalidade de **copiar gráficos entre relatórios customizados**. O frontend correspondente está em noharm-ai/frontend#607.

## O que entra

Dois endpoints somente-leitura em `routes/admin/admin_report.py`:

- `GET /admin/report/copy-source/list` — relatórios que podem servir de origem (id, nome, descrição, status, `processedAt`, `graphCount`)
- `GET /admin/report/copy-source/<id>/graphs` — a configuração de gráficos de um relatório de origem

Ambos com `@api_endpoint(is_admin=True)`, consistente com o `PATCH /admin/report/<id>/graphs` que já existia — a gestão de gráficos segue restrita a ambientes não-produção.

## Multischema: por que é seguro

`relatorio` é uma tabela **por schema**, então ler uma origem de outro schema exige cuidado. A ordem de autorização em `_authorize_source_schema` é:

1. `@has_permission(Permission.WRITE_CUSTOM_REPORTS_GRAPHS)` — hoje só ADMIN e CURATOR concedem
2. Se `sourceSchema` é vazio ou igual ao próprio → usa o schema do usuário, **sem exigir MAINTAINER** (são os dados do próprio cliente)
3. Qualquer outro schema → `auth_service.can_read_foreign_schema_as_maintainer`: exige `Permission.MAINTAINER` **e** existência em `public.schema_config`

A checagem de existência roda para todo schema estrangeiro, inclusive para MAINTAINER — é ela que impede uma string arbitrária de chegar ao `schema_translate_map`. Note que o `_has_force_schema_permission` existente **não** faz essa checagem no ramo MAINTAINER, por isso o helper novo em vez de reaproveitá-lo.

O nome do schema nunca vira texto de SQL: há o `pattern=^[a-z][a-z0-9_]*$` no request model (defesa em profundidade) e a consulta roda numa `Session` própria via `schema_translate_map`, ou seja, configuração do SQLAlchemy e não interpolação.

A sessão é própria de propósito: um rollback na sessão do request limpa o `schema_translate_map` dela (ver `utils/db_utils.py`), então re-apontar a sessão corrente seria frágil. Ela é fechada em `finally` e nunca commitada.

## Detalhe de dados

`relatorio.graficos` é uma coluna JSON, mas o editor de gráficos grava uma **string JSON** dentro dela, enquanto linhas escritas por outros caminhos guardam um array. `_normalize_graphs` aceita os dois formatos e devolve lista; qualquer outra coisa (JSON inválido, objeto, null) vira `[]`.

## Testes

`tests/integration/test_admin_report_copy.py` (20 casos) e `tests/unit/test_auth_foreign_schema.py` (6 casos). Cobrem, entre outros:

- leitura cross-schema real contra um segundo schema criado no setup do módulo, com asserção de que a sessão do request continua no schema original
- schema inexistente recusado **mesmo para maintainer**
- nome de schema malformado barrado no pydantic (400)
- usuário sem `WRITE_CUSTOM_REPORTS_GRAPHS` → 401 nas duas rotas
- id de relatório estrangeiro **inalcançável** pelo schema do chamador
- `graficos` como string, como array, inválido e null
- usuário com MULTI_SCHEMA mas sem MAINTAINER (papel TRAINING) → negado, e a checagem de papel acontece antes de qualquer consulta ao banco

Suíte completa: 1609 testes passando. `ruff check` limpo.

## Ponto de atenção para o review

Os dois únicos papéis com `WRITE_CUSTOM_REPORTS_GRAPHS` (ADMIN e CURATOR) **também** carregam MAINTAINER. Ou seja, a exigência de MAINTAINER não filtra ninguém no elenco atual de papéis — ela vale como defesa caso algum papel futuro ganhe a permissão de gráficos sem ser mantenedor. Vale confirmar se essa é a política desejada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)