### PR TITLE
test: cover prescription review and last clinical notes

### DIFF
--- a/tests/integration/test_notes_last.py
+++ b/tests/integration/test_notes_last.py
@@ -1,0 +1,471 @@
+"""Tests: GET /notes/single/<id>, /notes/get-user-last and /notes/get-user-last-list
+
+Three read-only endpoints the prescription screen leans on. ``get-user-last``
+and ``get-user-last-list`` answer "what did a pharmacist last write about this
+admission?" -- the single most recent note and the last five of them -- and
+``single`` fetches one clinical note by id when the user opens it.
+
+The pair matters because it has two entirely different sources depending on a
+schema feature. With MULTI_CLINICAL_NOTES off, a prescription carries at most
+one note in ``demo.prescricao.evolucao``, so the notes are read from the
+prescriptions themselves. With it on, notes are rows in
+``demo.prescricao_evolucao`` and a prescription may carry several. The demo
+schema has the feature on, so both paths are exercised here -- the second by
+taking the flag away for the length of a test.
+
+What these tests pin down:
+
+* the newest note wins, and prescriptions carrying no note are passed over
+  rather than answered with an empty note;
+* an admission nobody has written about answers with null / an empty list, not
+  an error;
+* the list is capped at five and ordered newest first, and under
+  MULTI_CLINICAL_NOTES an edited note is ordered by when it was edited, not by
+  when it was created;
+* the feature really does switch the source, so a note stored one way is not
+  served while the other way is configured;
+* ``single`` returns the note's own fields, cuts a pathologically long text
+  rather than shipping it, and refuses an id that does not exist;
+* none of the three is readable by a caller without READ_PRESCRIPTION.
+"""
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import FeatureEnum
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_prescription import create_prescription, test_counters
+from utils import status
+
+SINGLE_URL = "/notes/single"
+LAST_URL = "/notes/get-user-last"
+LAST_LIST_URL = "/notes/get-user-last-list"
+
+MULTI = FeatureEnum.MULTI_CLINICAL_NOTES.value
+
+# clinical notes written here; kept above the seed range and wiped per test
+CLINICAL_NOTE_ID = 100000
+
+# above every id the test helpers hand out, so no run can make it exist
+MISSING_NOTE = 999999999
+
+# clinical_notes_service.convert_notes cuts a text longer than this
+MAX_NOTE_LENGTH = 700000
+
+
+def _next_admission() -> int:
+    """Reserve an admission number no other test uses."""
+    admission = test_counters["admission_number"]
+    test_counters["admission_number"] += 1
+    return admission
+
+
+def _create_prescription_with_note(admission: int, note: str, date: datetime) -> int:
+    """Write a prescription carrying `note` in demo.prescricao.evolucao.
+
+    The note is set with an UPDATE because the BEFORE INSERT trigger on
+    demo.prescricao rewrites the row through public.upsert_prescricao. Passing
+    note=None leaves the column null, which is how a prescription nobody has
+    written about looks.
+    """
+    id_prescription = test_counters["id_prescription"]
+    test_counters["id_prescription"] += 1
+
+    create_prescription(
+        id=id_prescription, admissionNumber=admission, idPatient=1, date=date
+    )
+
+    if note is not None:
+        session.execute(
+            text(
+                "UPDATE demo.prescricao SET evolucao = :note WHERE fkprescricao = :id"
+            ),
+            {"note": note, "id": id_prescription},
+        )
+        session_commit()
+
+    return id_prescription
+
+
+def _create_prescription_note(
+    admission: int,
+    note: str,
+    created_at: datetime,
+    updated_at: datetime = None,
+) -> int:
+    """Write a demo.prescricao_evolucao row -- the MULTI_CLINICAL_NOTES source."""
+    id_prescription = _create_prescription_with_note(
+        admission=admission, note=None, date=created_at
+    )
+
+    session.execute(
+        text(
+            "INSERT INTO demo.prescricao_evolucao "
+            "(fkprescricao, nratendimento, texto, tp_status, created_at, created_by, updated_at) "
+            "VALUES (:id_prescription, :admission, :note, 0, :created_at, 1, :updated_at)"
+        ),
+        {
+            "id_prescription": id_prescription,
+            "admission": admission,
+            "note": note,
+            "created_at": created_at,
+            "updated_at": updated_at,
+        },
+    )
+    session_commit()
+
+    return id_prescription
+
+
+def _create_clinical_note(
+    admission: int, note: str, date: datetime, prescriber: str, position: str
+) -> int:
+    """Write a demo.evolucao row -- what /notes/single reads."""
+    session.execute(
+        text(
+            "INSERT INTO demo.evolucao "
+            "(fkevolucao, nratendimento, texto, dtevolucao, prescritor, cargo, exame) "
+            "VALUES (:id, :admission, :note, :date, :prescriber, :position, false)"
+        ),
+        {
+            "id": CLINICAL_NOTE_ID,
+            "admission": admission,
+            "note": note,
+            "date": date,
+            "prescriber": prescriber,
+            "position": position,
+        },
+    )
+    session_commit()
+
+    return CLINICAL_NOTE_ID
+
+
+def _read_features() -> list:
+    """The feature list currently stored in the demo schema."""
+    row = session.execute(
+        text("SELECT valor FROM demo.memoria WHERE tipo = 'features'")
+    ).first()
+    return list(row[0]) if row else []
+
+
+def _write_features(features: list):
+    """Overwrite the demo schema feature list."""
+    session.execute(
+        text(
+            "UPDATE demo.memoria SET valor = CAST(:value AS json) WHERE tipo = 'features'"
+        ),
+        {"value": json.dumps(features)},
+    )
+    session_commit()
+
+
+@pytest.fixture
+def single_notes_source():
+    """Take MULTI_CLINICAL_NOTES away, so notes come from the prescriptions."""
+    original = _read_features()
+    _write_features([f for f in original if f != MULTI])
+    yield
+    _write_features(original)
+
+
+@pytest.fixture(autouse=True)
+def clean_notes():
+    """Drop the notes this module writes -- tests.conftest does not know them."""
+    yield
+    session.execute(
+        text("DELETE FROM demo.prescricao_evolucao WHERE nratendimento >= 100000")
+    )
+    session.execute(text("DELETE FROM demo.evolucao WHERE fkevolucao >= 100000"))
+    session_commit()
+
+
+#
+# GET /notes/get-user-last
+#
+
+
+def test_get_user_last_returns_the_most_recent_note(
+    client, analyst_headers, single_notes_source
+):
+    """Teste get /notes/get-user-last - Deve retornar a evolução da prescrição mais recente"""
+    admission = _next_admission()
+    now = datetime.now()
+
+    _create_prescription_with_note(admission, "nota antiga", now - timedelta(days=2))
+    _create_prescription_with_note(admission, "nota recente", now)
+
+    response = client.get(
+        LAST_URL, query_string={"admissionNumber": admission}, headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.get_json()["data"]
+    assert data["text"] == "nota recente"
+    assert datetime.fromisoformat(data["date"])
+
+
+def test_get_user_last_skips_prescriptions_without_a_note(
+    client, analyst_headers, single_notes_source
+):
+    """Teste get /notes/get-user-last - Deve ignorar prescrições sem evolução"""
+    admission = _next_admission()
+    now = datetime.now()
+
+    _create_prescription_with_note(admission, "unica nota", now - timedelta(days=2))
+    # newer, but nobody wrote about it
+    _create_prescription_with_note(admission, None, now)
+
+    response = client.get(
+        LAST_URL, query_string={"admissionNumber": admission}, headers=analyst_headers
+    )
+
+    assert response.get_json()["data"]["text"] == "unica nota"
+
+
+def test_get_user_last_returns_null_when_nothing_was_written(
+    client, analyst_headers, single_notes_source
+):
+    """Teste get /notes/get-user-last - Atendimento sem evolução deve retornar nulo"""
+    admission = _next_admission()
+    _create_prescription_with_note(admission, None, datetime.now())
+
+    response = client.get(
+        LAST_URL, query_string={"admissionNumber": admission}, headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] is None
+
+
+def test_get_user_last_requires_read_prescription(client, user_manager_headers):
+    """Teste get /notes/get-user-last - Usuário sem READ_PRESCRIPTION deve receber [401 UNAUTHORIZED]"""
+    response = client.get(
+        LAST_URL,
+        query_string={"admissionNumber": _next_admission()},
+        headers=user_manager_headers,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+#
+# GET /notes/get-user-last-list
+#
+
+
+def test_get_user_last_list_returns_notes_newest_first(client, analyst_headers):
+    """Teste get /notes/get-user-last-list - Deve listar as evoluções da mais recente para a mais antiga"""
+    admission = _next_admission()
+    now = datetime.now()
+
+    _create_prescription_note(admission, "primeira", now - timedelta(days=2))
+    _create_prescription_note(admission, "segunda", now - timedelta(days=1))
+    _create_prescription_note(admission, "terceira", now)
+
+    response = client.get(
+        LAST_LIST_URL,
+        query_string={"admissionNumber": admission},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert [n["text"] for n in response.get_json()["data"]] == [
+        "terceira",
+        "segunda",
+        "primeira",
+    ]
+
+
+def test_get_user_last_list_returns_at_most_five_notes(client, analyst_headers):
+    """Teste get /notes/get-user-last-list - Deve retornar no máximo cinco evoluções"""
+    admission = _next_admission()
+    now = datetime.now()
+
+    for i in range(7):
+        _create_prescription_note(admission, f"nota {i}", now - timedelta(days=i))
+
+    response = client.get(
+        LAST_LIST_URL,
+        query_string={"admissionNumber": admission},
+        headers=analyst_headers,
+    )
+
+    data = response.get_json()["data"]
+    assert len(data) == 5
+    # the five newest, so the two oldest are the ones dropped
+    assert [n["text"] for n in data] == [
+        "nota 0",
+        "nota 1",
+        "nota 2",
+        "nota 3",
+        "nota 4",
+    ]
+
+
+def test_get_user_last_list_orders_an_edited_note_by_its_edit_date(
+    client, analyst_headers
+):
+    """Teste get /notes/get-user-last-list - Uma evolução editada é ordenada pela data de edição"""
+    admission = _next_admission()
+    now = datetime.now()
+
+    # written first but edited last, so it must come out on top
+    _create_prescription_note(
+        admission,
+        "editada",
+        created_at=now - timedelta(days=5),
+        updated_at=now,
+    )
+    # never edited, so it is ordered by its creation date
+    _create_prescription_note(admission, "intocada", created_at=now - timedelta(days=1))
+
+    response = client.get(
+        LAST_LIST_URL,
+        query_string={"admissionNumber": admission},
+        headers=analyst_headers,
+    )
+
+    assert [n["text"] for n in response.get_json()["data"]] == ["editada", "intocada"]
+
+
+def test_get_user_last_list_returns_empty_when_nothing_was_written(
+    client, analyst_headers
+):
+    """Teste get /notes/get-user-last-list - Atendimento sem evolução deve retornar lista vazia"""
+    response = client.get(
+        LAST_LIST_URL,
+        query_string={"admissionNumber": _next_admission()},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == []
+
+
+def test_get_user_last_list_reads_prescriptions_without_the_multi_feature(
+    client, analyst_headers, single_notes_source
+):
+    """Teste get /notes/get-user-last-list - Sem MULTI_CLINICAL_NOTES a origem são as prescrições"""
+    admission = _next_admission()
+    now = datetime.now()
+
+    _create_prescription_with_note(admission, "nota da prescricao", now)
+    # stored in the other source, so it must not show up
+    _create_prescription_note(admission, "nota multipla", now)
+
+    response = client.get(
+        LAST_LIST_URL,
+        query_string={"admissionNumber": admission},
+        headers=analyst_headers,
+    )
+
+    assert [n["text"] for n in response.get_json()["data"]] == ["nota da prescricao"]
+
+
+def test_get_user_last_list_reads_prescription_notes_with_the_multi_feature(
+    client, analyst_headers
+):
+    """Teste get /notes/get-user-last-list - Com MULTI_CLINICAL_NOTES a origem é prescricao_evolucao"""
+    admission = _next_admission()
+    now = datetime.now()
+
+    _create_prescription_with_note(admission, "nota da prescricao", now)
+    _create_prescription_note(admission, "nota multipla", now)
+
+    response = client.get(
+        LAST_LIST_URL,
+        query_string={"admissionNumber": admission},
+        headers=analyst_headers,
+    )
+
+    assert [n["text"] for n in response.get_json()["data"]] == ["nota multipla"]
+
+
+def test_get_user_last_list_requires_read_prescription(client, user_manager_headers):
+    """Teste get /notes/get-user-last-list - Usuário sem READ_PRESCRIPTION deve receber [401 UNAUTHORIZED]"""
+    response = client.get(
+        LAST_LIST_URL,
+        query_string={"admissionNumber": _next_admission()},
+        headers=user_manager_headers,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+#
+# GET /notes/single/<id>
+#
+
+
+def test_get_single_note_returns_the_note(client, analyst_headers):
+    """Teste get /notes/single/<id> - Deve retornar os dados da evolução"""
+    admission = _next_admission()
+    date = datetime(2024, 3, 4, 5, 6, 7)
+
+    id_note = _create_clinical_note(
+        admission=admission,
+        note="texto da evolucao",
+        date=date,
+        prescriber="Dr. Teste",
+        position="MEDICO",
+    )
+
+    response = client.get(f"{SINGLE_URL}/{id_note}", headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.get_json()["data"]
+    assert data["id"] == str(id_note)
+    assert data["admissionNumber"] == admission
+    assert data["text"] == "texto da evolucao"
+    assert data["date"] == date.isoformat()
+    assert data["prescriber"] == "Dr. Teste"
+    assert data["position"] == "MEDICO"
+    # the primary-care fields are never filled by this endpoint
+    assert data["form"] is None
+    assert data["template"] is None
+
+
+def test_get_single_note_cuts_a_very_long_text(client, analyst_headers):
+    """Teste get /notes/single/<id> - Texto muito longo deve ser cortado"""
+    id_note = _create_clinical_note(
+        admission=_next_admission(),
+        note="a" * (MAX_NOTE_LENGTH + 10),
+        date=datetime.now(),
+        prescriber="Dr. Teste",
+        position="MEDICO",
+    )
+
+    response = client.get(f"{SINGLE_URL}/{id_note}", headers=analyst_headers)
+
+    assert (
+        response.get_json()["data"]["text"]
+        == "a" * MAX_NOTE_LENGTH + "<p>Evolução cortada por texto muito longo.</p>"
+    )
+
+
+def test_get_single_note_rejects_a_missing_note(client, analyst_headers):
+    """Teste get /notes/single/<id> - Evolução inexistente deve retornar erro [400 BAD REQUEST]"""
+    response = client.get(f"{SINGLE_URL}/{MISSING_NOTE}", headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_get_single_note_requires_read_prescription(client, user_manager_headers):
+    """Teste get /notes/single/<id> - Usuário sem READ_PRESCRIPTION deve receber [401 UNAUTHORIZED]"""
+    id_note = _create_clinical_note(
+        admission=_next_admission(),
+        note="texto da evolucao",
+        date=datetime.now(),
+        prescriber="Dr. Teste",
+        position="MEDICO",
+    )
+
+    response = client.get(f"{SINGLE_URL}/{id_note}", headers=user_manager_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/integration/test_prescription_review.py
+++ b/tests/integration/test_prescription_review.py
@@ -1,0 +1,350 @@
+"""Tests: POST /prescriptions/review
+
+Checking a prescription and *reviewing* a patient are two different acts. A
+check is per prescription; a review is the pharmacist saying "I have looked at
+this patient as a whole", so it is only offered on the aggregated prescription
+that stands for the admission. The flag is a toggle -- it can be set and taken
+back -- and every flip has to leave a trail, because the review counters in the
+reports are built from that trail rather than from the flag itself.
+
+That is what these tests pin down:
+
+* the toggle persists, in both directions, and the response says which way it
+  went and who did it;
+* each flip appends a ``prescricao_audit`` row, REVISION on the way in and
+  UNDO_REVISION on the way out, carrying the item count and the time the
+  pharmacist spent on the screen;
+* the three refusals that keep the trail honest -- an individual prescription
+  cannot be reviewed, an unknown prescription is not invented, and a review
+  status outside the enum is not stored;
+* a caller who cannot write a prescription cannot review one either.
+"""
+
+import json
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import (
+    DrugTypeEnum,
+    PrescriptionAuditTypeEnum,
+    PrescriptionReviewTypeEnum,
+)
+from models.prescription import Prescription, PrescriptionAudit
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_prescription import (
+    create_prescription,
+    create_prescription_drug,
+    test_counters,
+)
+from utils import status
+
+URL = "/prescriptions/review"
+
+REVIEWED = PrescriptionReviewTypeEnum.REVIEWED.value
+PENDING = PrescriptionReviewTypeEnum.PENDING.value
+
+# the user behind every fixture in tests.conftest.get_access
+CALLER_NAME = "Demonstração"
+
+# above every id the test helpers hand out, so no run can make it exist
+MISSING_PRESCRIPTION = 999999999
+
+
+def _create_agg_prescription(drug_count: int = 2) -> int:
+    """Write an aggregated prescription with `drug_count` drugs inside it.
+
+    A review targets the aggregation, but the items it counts live on the
+    individual prescriptions underneath, so both halves are written: the agg row
+    that the endpoint is called with, and one internal prescription holding the
+    drugs. Ids come from the shared >= 100000 counter, so tests.conftest cleans
+    them up.
+    """
+    admission = test_counters["admission_number"]
+    id_agg = test_counters["id_prescription"]
+    id_internal = id_agg + 1
+
+    test_counters["id_prescription"] += 2
+    test_counters["admission_number"] += 1
+
+    date = datetime.now()
+
+    create_prescription(
+        id=id_agg, admissionNumber=admission, idPatient=1, agg=True, date=date
+    )
+    create_prescription(
+        id=id_internal, admissionNumber=admission, idPatient=1, date=date
+    )
+
+    for i in range(drug_count):
+        create_prescription_drug(
+            id=int(f"{id_internal}00{i + 1}"),
+            idPrescription=id_internal,
+            idDrug=3 + i,
+        )
+
+    return id_agg
+
+
+def _audits(id_prescription: int) -> list[PrescriptionAudit]:
+    """Every audit row written for a prescription, oldest first."""
+    return (
+        session.query(PrescriptionAudit)
+        .filter(PrescriptionAudit.idPrescription == id_prescription)
+        .order_by(PrescriptionAudit.id)
+        .all()
+    )
+
+
+def _review_type(id_prescription: int):
+    """The persisted review flag, read back outside the request session."""
+    return (
+        session.query(Prescription.reviewType)
+        .filter(Prescription.id == id_prescription)
+        .scalar()
+    )
+
+
+@pytest.fixture
+def agg_prescription() -> int:
+    """An aggregated prescription with two drugs, not yet reviewed."""
+    return _create_agg_prescription()
+
+
+def test_review_marks_the_prescription_as_reviewed(
+    client, analyst_headers, agg_prescription
+):
+    """Teste post /prescriptions/review - Deve marcar a prescrição agregada como revisada"""
+    response = client.post(
+        URL,
+        json={"idPrescription": agg_prescription, "reviewType": REVIEWED},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.get_json()["data"]
+    assert data["reviewed"] is True
+    assert data["reviewedBy"] == CALLER_NAME
+    # a timestamp the frontend shows straight away, so it must parse
+    assert datetime.fromisoformat(data["reviewedAt"])
+
+    assert _review_type(agg_prescription) == REVIEWED
+
+
+def test_undo_review_marks_the_prescription_as_pending(
+    client, analyst_headers, agg_prescription
+):
+    """Teste post /prescriptions/review - Deve permitir desfazer a revisão"""
+    client.post(
+        URL,
+        json={"idPrescription": agg_prescription, "reviewType": REVIEWED},
+        headers=analyst_headers,
+    )
+
+    response = client.post(
+        URL,
+        json={"idPrescription": agg_prescription, "reviewType": PENDING},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"]["reviewed"] is False
+    assert _review_type(agg_prescription) == PENDING
+
+
+def test_review_writes_a_revision_audit(client, analyst_headers, agg_prescription):
+    """Teste post /prescriptions/review - Deve registrar auditoria do tipo REVISION"""
+    client.post(
+        URL,
+        json={"idPrescription": agg_prescription, "reviewType": REVIEWED},
+        headers=analyst_headers,
+    )
+
+    audits = _audits(agg_prescription)
+    assert len(audits) == 1
+
+    audit = audits[0]
+    assert audit.auditType == PrescriptionAuditTypeEnum.REVISION.value
+    assert audit.agg is True
+    assert audit.idPrescription == agg_prescription
+
+
+def test_undo_review_writes_an_undo_revision_audit(
+    client, analyst_headers, agg_prescription
+):
+    """Teste post /prescriptions/review - Desfazer a revisão registra auditoria UNDO_REVISION"""
+    client.post(
+        URL,
+        json={"idPrescription": agg_prescription, "reviewType": REVIEWED},
+        headers=analyst_headers,
+    )
+    client.post(
+        URL,
+        json={"idPrescription": agg_prescription, "reviewType": PENDING},
+        headers=analyst_headers,
+    )
+
+    audit_types = [a.auditType for a in _audits(agg_prescription)]
+    assert audit_types == [
+        PrescriptionAuditTypeEnum.REVISION.value,
+        PrescriptionAuditTypeEnum.UNDO_REVISION.value,
+    ]
+
+
+def test_review_audit_counts_the_items_inside_the_aggregation(client, analyst_headers):
+    """Teste post /prescriptions/review - A auditoria conta os itens das prescrições agregadas"""
+    id_agg = _create_agg_prescription(drug_count=3)
+
+    client.post(
+        URL,
+        json={"idPrescription": id_agg, "reviewType": REVIEWED},
+        headers=analyst_headers,
+    )
+
+    assert _audits(id_agg)[0].totalItens == 3
+
+
+def test_review_audit_ignores_items_outside_the_counted_types(client, analyst_headers):
+    """Teste post /prescriptions/review - A auditoria não conta itens do tipo Materiais"""
+    id_agg = _create_agg_prescription(drug_count=2)
+    id_internal = id_agg + 1
+
+    # origem is rewritten by the insert trigger, so it is set with raw SQL
+    session.execute(
+        text("UPDATE demo.presmed SET origem = :source WHERE fkpresmed = :id"),
+        {"source": DrugTypeEnum.MATERIAL.value, "id": int(f"{id_internal}001")},
+    )
+    session_commit()
+
+    client.post(
+        URL,
+        json={"idPrescription": id_agg, "reviewType": REVIEWED},
+        headers=analyst_headers,
+    )
+
+    assert _audits(id_agg)[0].totalItens == 1
+
+
+def test_review_audit_records_the_reported_evaluation_time(
+    client, analyst_headers, agg_prescription
+):
+    """Teste post /prescriptions/review - A auditoria registra o tempo de avaliação informado"""
+    client.post(
+        URL,
+        json={
+            "idPrescription": agg_prescription,
+            "reviewType": REVIEWED,
+            "evaluationTime": 42,
+        },
+        headers=analyst_headers,
+    )
+
+    assert _audits(agg_prescription)[0].extra["evaluationTime"] == 42
+
+
+def test_review_audit_defaults_the_evaluation_time_to_zero(
+    client, analyst_headers, agg_prescription
+):
+    """Teste post /prescriptions/review - Sem tempo de avaliação informado a auditoria registra zero"""
+    client.post(
+        URL,
+        json={"idPrescription": agg_prescription, "reviewType": REVIEWED},
+        headers=analyst_headers,
+    )
+
+    extra = _audits(agg_prescription)[0].extra
+    assert extra["evaluationTime"] == 0
+    # no evaluation was started on this prescription, so there is no start date
+    assert extra["main_evaluationStartDate"] is None
+
+
+def test_review_audit_carries_the_evaluation_start_date(client, analyst_headers):
+    """Teste post /prescriptions/review - A auditoria copia a data de início da avaliação"""
+    id_agg = _create_agg_prescription()
+    start_date = "2024-01-02T03:04:05"
+
+    session.execute(
+        text(
+            "UPDATE demo.prescricao SET indicadores = CAST(:features AS json) "
+            "WHERE fkprescricao = :id"
+        ),
+        {
+            "features": json.dumps({"evaluation": {"startDate": start_date}}),
+            "id": id_agg,
+        },
+    )
+    session_commit()
+
+    client.post(
+        URL,
+        json={"idPrescription": id_agg, "reviewType": REVIEWED},
+        headers=analyst_headers,
+    )
+
+    assert _audits(id_agg)[0].extra["main_evaluationStartDate"] == start_date
+
+
+def test_review_rejects_an_individual_prescription(client, analyst_headers):
+    """Teste post /prescriptions/review - Não deve revisar prescrição individual [400 BAD REQUEST]"""
+    id_prescription = test_counters["id_prescription"]
+    test_counters["id_prescription"] += 1
+
+    create_prescription(
+        id=id_prescription,
+        admissionNumber=test_counters["admission_number"],
+        idPatient=1,
+    )
+    test_counters["admission_number"] += 1
+
+    response = client.post(
+        URL,
+        json={"idPrescription": id_prescription, "reviewType": REVIEWED},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    # tp_revisao defaults to 0, so an untouched prescription reads back as pending
+    assert _review_type(id_prescription) == PENDING
+    assert _audits(id_prescription) == []
+
+
+def test_review_rejects_a_missing_prescription(client, analyst_headers):
+    """Teste post /prescriptions/review - Prescrição inexistente deve retornar erro [400 BAD REQUEST]"""
+    response = client.post(
+        URL,
+        json={"idPrescription": MISSING_PRESCRIPTION, "reviewType": REVIEWED},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.parametrize("review_type", [2, -1, "reviewed", None])
+def test_review_rejects_an_unknown_review_type(
+    client, analyst_headers, agg_prescription, review_type
+):
+    """Teste post /prescriptions/review - Status de revisão fora do enum deve retornar erro [400 BAD REQUEST]"""
+    response = client.post(
+        URL,
+        json={"idPrescription": agg_prescription, "reviewType": review_type},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert _review_type(agg_prescription) == PENDING
+    assert _audits(agg_prescription) == []
+
+
+def test_review_requires_write_permission(client, viewer_headers, agg_prescription):
+    """Teste post /prescriptions/review - Usuário sem permissão de escrita deve receber [401 UNAUTHORIZED]"""
+    response = client.post(
+        URL,
+        json={"idPrescription": agg_prescription, "reviewType": REVIEWED},
+        headers=viewer_headers,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert _review_type(agg_prescription) == PENDING
+    assert _audits(agg_prescription) == []


### PR DESCRIPTION
Two features had no test coverage at all. This adds 31 integration tests across two new files; the suite goes from 1736 to 1767 passing.

## `POST /prescriptions/review` — `tests/integration/test_prescription_review.py`

Reviewing a patient is not the same act as checking a prescription: it is only offered on the aggregated prescription that stands for the admission, it is a toggle that can be taken back, and every flip has to append a `prescricao_audit` row because the review counters in the reports are built from that trail rather than from the flag itself. `prescription_check_service.review_prescription` was reached by no test — `test_prescription_view.py` only reads the `review` block back.

Covered:

- the toggle persists in both directions, and the response reports which way it went and who did it;
- each flip appends a `REVISION` / `UNDO_REVISION` audit row, in that order;
- the audit's `totalItens` counts the items inside the aggregation and skips types outside the counted set (`Materiais`);
- the audit's `extra` carries the reported evaluation time, defaults it to `0`, and copies `main_evaluationStartDate` off the prescription's `indicadores`;
- the refusals: an individual (non-agg) prescription, an unknown prescription, a `reviewType` outside the enum, and a caller without `WRITE_PRESCRIPTION` — each asserted to leave neither the flag nor an audit row behind.

## `GET /notes/get-user-last`, `/notes/get-user-last-list`, `/notes/single/<id>` — `tests/integration/test_notes_last.py`

The three read-only endpoints behind "what did a pharmacist last write about this admission?". The list has two entirely different sources depending on the `MULTI_CLINICAL_NOTES` schema feature — `demo.prescricao.evolucao` with it off, `demo.prescricao_evolucao` with it on — and the demo schema has it on, so the second path is exercised by taking the flag away for the length of a test and restoring it afterwards.

Covered:

- the newest note wins, and prescriptions carrying no note are passed over rather than answered with an empty note;
- an admission nobody has written about answers with `null` / `[]`, not an error;
- the list is capped at five, ordered newest first, and a note that was edited is ordered by its edit date (the `coalesce(updated_at, created_at)` ordering);
- the feature really does switch the source: a note stored one way is not served while the other way is configured;
- `single` returns the note's own fields, leaves the primary-care fields empty, cuts a text past `convert_notes`' 700k limit instead of shipping it, and refuses an unknown id;
- none of the three is readable without `READ_PRESCRIPTION`.

## Notes

- No production code changed — tests only.
- Both files clean up after themselves. The prescription ids and admission numbers come from the shared `>= 100000` counters that `tests/conftest.py` already wipes; the notes module adds an autouse fixture for `demo.prescricao_evolucao` and `demo.evolucao`, which the shared cleanup does not know about, so the suite stays re-runnable.
- Verified locally against a PostgreSQL instance loaded from the same `noharm-ai/database` SQL files CI uses: full suite green twice in a row, `ruff check` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AHHaYwek2LPiHoTYgFoy3b)_