### PR TITLE
test: cover prescription history report and unit conversion save

### DIFF
--- a/tests/integration/test_names.py
+++ b/tests/integration/test_names.py
@@ -35,10 +35,12 @@ from tests.conftest import session, session_commit
 # Any patient id works: nothing about the lookup touches the local patient row.
 PATIENT_ID = 1
 
-# HS256 keys, long enough not to trip PyJWT's short-key warning.
-GETNAME_SECRET = "zztest-getname-secret-0123456789abcdef"
-CLIENT_SECRET = "zztest-client-secret-0123456789abcdef"
-WRONG_SECRET = "zztest-wrong-secret-0123456789abcdef"
+# HS256 keys, long enough not to trip PyJWT's short-key warning. They are
+# literals invented for this file, never a real credential — the gitleaks
+# annotations keep the secret scan from reading them as one.
+GETNAME_SECRET = "zztest-getname-secret-0123456789abcdef"  # gitleaks:allow
+CLIENT_SECRET = "zztest-client-secret-0123456789abcdef"  # gitleaks:allow
+WRONG_SECRET = "zztest-wrong-secret-0123456789abcdef"  # gitleaks:allow
 
 
 @pytest.fixture

--- a/tests/integration/test_reports_prescription_history.py
+++ b/tests/integration/test_reports_prescription_history.py
@@ -1,0 +1,411 @@
+"""Integration tests for ``GET /reports/prescription/history``.
+
+The prescription-history report is the timeline a pharmacist opens to answer
+"what happened to this prescription, when, and who did it". Nothing in the
+suite touched it — neither
+``services/reports/reports_prescription_history_service.py`` nor the two
+queries behind it in
+``repository/reports/reports_prescription_history_repository.py``.
+
+The timeline is assembled from two very different sources, and every rule that
+decides what ends up in it is exercised here:
+
+* three synthetic ``custom`` events that exist only in this report — origin
+  creation (type 1, taken from ``prescricao.dtcriacao_origem``), arrival
+  (type 2) and processing (type 3), both derived from the earliest matching
+  ``presmed_audit`` row. All three are suppressed for aggregated
+  prescriptions, where the report shows the audit trail alone;
+* the arrival event only looks at items the report counts as prescribed
+  content, so a ``Materiais`` line that reached the backend first must not
+  move the arrival date;
+* every ``prescricao_audit`` row becomes an event whose ``responsible`` is
+  resolved through an outer join — an audit written by an id with no
+  ``usuario`` row still renders, with no responsible.
+
+The merged list is returned sorted by ``createdAt``, interleaving both
+sources.
+
+Prescriptions come from ``test_counters`` (ids >= 100000) and their items from
+the ``>= 100000001`` range, so the session-scoped ``clean_test_artifacts``
+fixture removes them — including the audit rows, which are deleted by
+prescription/item id.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import (
+    DrugTypeEnum,
+    PrescriptionAuditTypeEnum,
+    PrescriptionDrugAuditTypeEnum,
+)
+from models.prescription import PrescriptionAudit, PrescriptionDrugAudit
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_prescription import (
+    create_prescription,
+    create_prescription_drug,
+    test_counters,
+)
+from utils import status
+
+URL = "/reports/prescription/history"
+
+# the user behind every fixture in tests.conftest.get_access
+CALLER_ID = 1
+CALLER_NAME = "Demonstração"
+
+# an id with no demo.usuario row, to drive the outer join's null side
+UNKNOWN_USER_ID = 987654
+
+UNKNOWN_PRESCRIPTION = 999999999
+
+# event types the service assigns to the synthetic entries
+ORIGIN_EVENT = 1
+ARRIVAL_EVENT = 2
+PROCESS_EVENT = 3
+
+# a fixed base date keeps the expected ordering readable
+BASE_DATE = datetime(2024, 3, 11, 8, 0, 0)
+
+
+def _next_prescription_ids():
+    """Reserve a prescription id + admission number no other test uses."""
+    id_prescription = test_counters["id_prescription"]
+    admission_number = test_counters["admission_number"]
+    test_counters["id_prescription"] += 1
+    test_counters["admission_number"] += 1
+
+    return id_prescription, admission_number
+
+
+def _create_prescription(agg: bool = None, origin_created_at: datetime = None):
+    """Create a prescription in the reserved id range, optionally aggregated."""
+    id_prescription, admission_number = _next_prescription_ids()
+
+    prescription = create_prescription(
+        id=id_prescription,
+        admissionNumber=admission_number,
+        idPatient=id_prescription,
+        date=BASE_DATE,
+        expire=BASE_DATE + timedelta(days=1),
+        agg=agg,
+    )
+
+    if origin_created_at is not None:
+        prescription.origin_created_at = origin_created_at
+        session_commit()
+
+    return prescription
+
+
+def _create_item(prescription, order: int, source: str = DrugTypeEnum.DRUG.value):
+    """Add one item to ``prescription``; ids stay in the >= 100000001 range.
+
+    ``presmed`` carries a BEFORE INSERT trigger that normalises ``origem``
+    through the ``map-origin-*`` entries in ``memoria``, and the seed has no
+    mapping for ``Materiais`` — anything unmapped lands as ``Medicamentos``.
+    The source is therefore written back afterwards (the trigger does not fire
+    on UPDATE), which is what the report reads.
+    """
+    id_item = int(f"{prescription.id}{order:03d}")
+
+    create_prescription_drug(
+        id=id_item,
+        idPrescription=prescription.id,
+        idDrug=3,
+        source=source,
+    )
+
+    session.execute(
+        text("UPDATE demo.presmed SET origem = :source WHERE fkpresmed = :id"),
+        {"source": source, "id": id_item},
+    )
+    session_commit()
+
+    return id_item
+
+
+def _audit_item(id_item: int, audit_type: PrescriptionDrugAuditTypeEnum, created_at):
+    """Write a presmed_audit row for one prescription item."""
+    audit = PrescriptionDrugAudit()
+    audit.auditType = audit_type.value
+    audit.idPrescriptionDrug = id_item
+    audit.createdAt = created_at
+    audit.createdBy = CALLER_ID
+
+    session.add(audit)
+    session_commit()
+
+    return audit
+
+
+def _audit_prescription(
+    prescription,
+    audit_type: PrescriptionAuditTypeEnum,
+    created_at,
+    created_by: int = CALLER_ID,
+    extra=None,
+):
+    """Write a prescricao_audit row for the whole prescription."""
+    audit = PrescriptionAudit()
+    audit.auditType = audit_type.value
+    audit.admissionNumber = prescription.admissionNumber
+    audit.idPrescription = prescription.id
+    audit.prescriptionDate = prescription.date
+    audit.idDepartment = prescription.idDepartment
+    audit.idSegment = prescription.idSegment
+    audit.totalItens = 1
+    audit.agg = prescription.agg
+    audit.bed = prescription.bed
+    audit.extra = extra
+    audit.createdAt = created_at
+    audit.createdBy = created_by
+
+    session.add(audit)
+    session_commit()
+
+    return audit
+
+
+def _get_history(client, headers, id_prescription):
+    """Call the endpoint and return the raw response."""
+    return client.get(f"{URL}?idPrescription={id_prescription}", headers=headers)
+
+
+def _custom_events(data):
+    """The synthetic entries, keyed by their event type."""
+    return {e["type"]: e for e in data if e["source"] == "custom"}
+
+
+def test_timeline_merges_custom_events_with_the_audit_trail(client, analyst_headers):
+    """The timeline mixes the three synthetic events with prescricao_audit rows [200]."""
+    origin_date = BASE_DATE
+    arrival_date = BASE_DATE + timedelta(minutes=5)
+    process_date = BASE_DATE + timedelta(minutes=10)
+    check_date = BASE_DATE + timedelta(minutes=20)
+
+    prescription = _create_prescription(origin_created_at=origin_date)
+    id_item = _create_item(prescription, 1)
+
+    _audit_item(id_item, PrescriptionDrugAuditTypeEnum.UPSERT, arrival_date)
+    _audit_item(id_item, PrescriptionDrugAuditTypeEnum.PROCESSED, process_date)
+    _audit_prescription(prescription, PrescriptionAuditTypeEnum.CHECK, check_date)
+
+    response = _get_history(client, analyst_headers, prescription.id)
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.get_json()["data"]
+
+    assert [e["source"] for e in data] == [
+        "custom",
+        "custom",
+        "custom",
+        "PrescriptionAudit",
+    ]
+    assert [e["type"] for e in data] == [
+        ORIGIN_EVENT,
+        ARRIVAL_EVENT,
+        PROCESS_EVENT,
+        PrescriptionAuditTypeEnum.CHECK.value,
+    ]
+    assert [e["createdAt"] for e in data] == [
+        origin_date.isoformat(),
+        arrival_date.isoformat(),
+        process_date.isoformat(),
+        check_date.isoformat(),
+    ]
+
+    # every entry reports the prescription it belongs to, as a string
+    assert {e["idPrescription"] for e in data} == {str(prescription.id)}
+
+    events = _custom_events(data)
+    assert events[ORIGIN_EVENT]["responsible"] == "Sistema origem"
+    # arrival and processing are machine events with no author
+    assert events[ARRIVAL_EVENT]["responsible"] is None
+    assert events[PROCESS_EVENT]["responsible"] is None
+    assert data[3]["responsible"] == CALLER_NAME
+
+
+def test_events_are_returned_sorted_by_date(client, analyst_headers):
+    """Audit rows written out of order are still returned oldest first [200]."""
+    prescription = _create_prescription()
+
+    late = BASE_DATE + timedelta(hours=3)
+    early = BASE_DATE + timedelta(hours=1)
+    middle = BASE_DATE + timedelta(hours=2)
+
+    _audit_prescription(prescription, PrescriptionAuditTypeEnum.CHECK, late)
+    _audit_prescription(prescription, PrescriptionAuditTypeEnum.UNCHECK, early)
+    _audit_prescription(prescription, PrescriptionAuditTypeEnum.REVISION, middle)
+
+    data = _get_history(client, analyst_headers, prescription.id).get_json()["data"]
+
+    assert [e["createdAt"] for e in data] == [
+        early.isoformat(),
+        middle.isoformat(),
+        late.isoformat(),
+    ]
+
+
+def test_arrival_date_ignores_material_items(client, analyst_headers):
+    """A Materiais line audited first must not become the arrival date [200]."""
+    material_date = BASE_DATE + timedelta(minutes=1)
+    drug_date = BASE_DATE + timedelta(minutes=30)
+
+    prescription = _create_prescription()
+    id_material = _create_item(prescription, 1, source=DrugTypeEnum.MATERIAL.value)
+    id_drug = _create_item(prescription, 2, source=DrugTypeEnum.DRUG.value)
+
+    _audit_item(id_material, PrescriptionDrugAuditTypeEnum.UPSERT, material_date)
+    _audit_item(id_drug, PrescriptionDrugAuditTypeEnum.UPSERT, drug_date)
+
+    data = _get_history(client, analyst_headers, prescription.id).get_json()["data"]
+
+    events = _custom_events(data)
+    assert events[ARRIVAL_EVENT]["createdAt"] == drug_date.isoformat()
+
+
+def test_arrival_date_is_the_earliest_upsert(client, analyst_headers):
+    """With several items the arrival date is the first one the backend saw [200]."""
+    first = BASE_DATE + timedelta(minutes=2)
+    second = BASE_DATE + timedelta(minutes=40)
+
+    prescription = _create_prescription()
+    id_solution = _create_item(prescription, 1, source=DrugTypeEnum.SOLUTION.value)
+    id_diet = _create_item(prescription, 2, source=DrugTypeEnum.DIET.value)
+
+    _audit_item(id_diet, PrescriptionDrugAuditTypeEnum.UPSERT, second)
+    _audit_item(id_solution, PrescriptionDrugAuditTypeEnum.UPSERT, first)
+
+    data = _get_history(client, analyst_headers, prescription.id).get_json()["data"]
+
+    events = _custom_events(data)
+    assert events[ARRIVAL_EVENT]["createdAt"] == first.isoformat()
+
+
+def test_prescription_without_origin_date_has_no_origin_event(client, analyst_headers):
+    """dtcriacao_origem is optional; without it the origin event is skipped [200]."""
+    prescription = _create_prescription()
+    id_item = _create_item(prescription, 1)
+    _audit_item(
+        id_item,
+        PrescriptionDrugAuditTypeEnum.UPSERT,
+        BASE_DATE + timedelta(minutes=5),
+    )
+
+    data = _get_history(client, analyst_headers, prescription.id).get_json()["data"]
+
+    events = _custom_events(data)
+    assert ORIGIN_EVENT not in events
+    assert ARRIVAL_EVENT in events
+
+
+def test_items_never_processed_have_no_process_event(client, analyst_headers):
+    """Only a PROCESSED audit row produces the processing event [200]."""
+    prescription = _create_prescription()
+    id_item = _create_item(prescription, 1)
+    _audit_item(
+        id_item,
+        PrescriptionDrugAuditTypeEnum.UPSERT,
+        BASE_DATE + timedelta(minutes=5),
+    )
+
+    data = _get_history(client, analyst_headers, prescription.id).get_json()["data"]
+
+    assert PROCESS_EVENT not in _custom_events(data)
+
+
+def test_aggregated_prescription_hides_the_custom_events(client, analyst_headers):
+    """An aggregated prescription shows the audit trail only [200]."""
+    prescription = _create_prescription(
+        agg=True, origin_created_at=BASE_DATE - timedelta(hours=1)
+    )
+    id_item = _create_item(prescription, 1)
+
+    _audit_item(
+        id_item, PrescriptionDrugAuditTypeEnum.UPSERT, BASE_DATE + timedelta(minutes=5)
+    )
+    _audit_item(
+        id_item,
+        PrescriptionDrugAuditTypeEnum.PROCESSED,
+        BASE_DATE + timedelta(minutes=6),
+    )
+    _audit_prescription(
+        prescription,
+        PrescriptionAuditTypeEnum.CREATE_AGG,
+        BASE_DATE + timedelta(minutes=7),
+    )
+
+    data = _get_history(client, analyst_headers, prescription.id).get_json()["data"]
+
+    assert _custom_events(data) == {}
+    assert [e["type"] for e in data] == [PrescriptionAuditTypeEnum.CREATE_AGG.value]
+
+
+def test_audit_written_by_an_unknown_user_has_no_responsible(client, analyst_headers):
+    """The user join is optional, so an orphan audit row still renders [200]."""
+    prescription = _create_prescription()
+    _audit_prescription(
+        prescription,
+        PrescriptionAuditTypeEnum.CHECK,
+        BASE_DATE + timedelta(minutes=5),
+        created_by=UNKNOWN_USER_ID,
+    )
+
+    data = _get_history(client, analyst_headers, prescription.id).get_json()["data"]
+
+    assert len(data) == 1
+    assert data[0]["responsible"] is None
+
+
+def test_audit_extra_payload_is_returned(client, analyst_headers):
+    """The audit's extra column is handed to the client untouched [200]."""
+    extra = {"idProtocol": 7, "reason": "teste"}
+
+    prescription = _create_prescription()
+    _audit_prescription(
+        prescription,
+        PrescriptionAuditTypeEnum.REVISION,
+        BASE_DATE + timedelta(minutes=5),
+        extra=extra,
+    )
+
+    data = _get_history(client, analyst_headers, prescription.id).get_json()["data"]
+
+    assert data[0]["extra"] == extra
+
+
+def test_prescription_without_history_returns_an_empty_timeline(
+    client, analyst_headers
+):
+    """A prescription nobody touched has nothing to show, but is not an error [200]."""
+    prescription = _create_prescription()
+
+    response = _get_history(client, analyst_headers, prescription.id)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == []
+
+
+@pytest.mark.parametrize(
+    "query",
+    ["", f"?idPrescription={UNKNOWN_PRESCRIPTION}"],
+    ids=["missing id", "unknown id"],
+)
+def test_history_requires_an_existing_prescription(client, analyst_headers, query):
+    """Without a prescription to report on, the request is refused [400]."""
+    response = client.get(f"{URL}{query}", headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRecord"
+
+
+def test_role_without_read_reports_is_refused(client, user_manager_headers):
+    """USER_MANAGER holds no READ_REPORTS, so the timeline is out of reach [401]."""
+    prescription = _create_prescription()
+
+    response = _get_history(client, user_manager_headers, prescription.id)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/integration/test_unit_conversion_save.py
+++ b/tests/integration/test_unit_conversion_save.py
@@ -1,0 +1,392 @@
+"""Integration tests for the write half of the drug unit-conversion feature.
+
+``GET /drugs/unit-conversion/<drug>`` is covered by
+``tests/unit/test_unit_conversion_service.py``, but the two endpoints that
+actually change data had no coverage at all:
+
+* ``POST /drugs/unit-conversion/<drug>`` — the curator screen that fixes a
+  drug's conversion factors. It is deceptively wide: the payload names no
+  segment, yet the save is applied to *every* segment, creating the
+  ``medatributos`` row from the substance reference where one is missing,
+  pinning each row's default measure unit and upserting one
+  ``unidadeconverte`` row per segment/unit pair. The default unit comes from
+  the substance and falls back to ``un``; when that unit has no
+  ``unidademedida`` row yet, the save creates it.
+* ``POST /drugs/process-scores/<drug>`` — hands the drug to the score Lambda.
+
+Both AWS calls are stubbed: the save path must *not* reach Lambda (it passes
+``skip_lambda``), and the score path is asserted on the payload it sends,
+which is the part the backend decides.
+
+Each test saves against its own drug, so the module has no internal ordering.
+Fixtures use the reserved ``>= 90000`` id range (90400 block) so the
+session-scoped ``clean_test_artifacts`` fixture removes them. Measure units
+are not in that range, so this module removes the ones it created itself.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import text
+
+from models.appendix import MeasureUnit, MeasureUnitConvert
+from models.enums import DefaultMeasureUnitEnum
+from models.main import DrugAttributes
+from models.segment import Segment
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_unit_conversion import (
+    create_test_drug,
+    create_test_substance,
+)
+from utils import status
+
+SAVE_URL = "/drugs/unit-conversion"
+SCORES_URL = "/drugs/process-scores"
+
+# Ids reserved for this module (90400 block, distinct from other modules').
+_SCTID_WITH_DEFAULT = 90401
+_SCTID_WITHOUT_DEFAULT = 90402
+
+_DRUG_SEGMENTS = 90401  # asserts the conversions reach every segment
+_DRUG_ATTRIBUTES = 90402  # asserts medatributos is created on the fly
+_DRUG_MEASURE_UNIT = 90403  # asserts the default unit row is created
+_DRUG_RESAVED = 90404  # saved twice, asserts the upsert
+_DRUG_WITHOUT_DEFAULT = 90405  # substance names no unit, so ``un`` is used
+_DRUG_NO_LAMBDA = 90406  # asserts the save stays local
+_DRUG_SCORES = 90407  # target of the score endpoint
+_DRUG_REJECTED = 90408  # receives the payloads that must be refused
+_UNKNOWN_DRUG = 90499
+
+# A default measure unit absent from the seed, so the save has to create it.
+_TEST_MEASURE_UNIT = "ZZTESTUN"
+
+# an existing seed unit, used as the converted-from unit
+_SEED_MEASURE_UNIT = "1"
+
+# the demo user behind the config_manager_headers fixture
+CALLER_ID = 1
+CALLER_SCHEMA = "demo"
+
+_DRUGS_WITH_DEFAULT = [
+    (_DRUG_SEGMENTS, "ZZTest Medicamento Segmentos"),
+    (_DRUG_ATTRIBUTES, "ZZTest Medicamento Atributos UC"),
+    (_DRUG_MEASURE_UNIT, "ZZTest Medicamento Unidade"),
+    (_DRUG_RESAVED, "ZZTest Medicamento Refeito"),
+    (_DRUG_NO_LAMBDA, "ZZTest Medicamento Sem Lambda"),
+    (_DRUG_SCORES, "ZZTest Medicamento Escores"),
+    (_DRUG_REJECTED, "ZZTest Medicamento Recusado"),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_unit_conversion_data(clean_test_artifacts):  # noqa: ARG001
+    """Create the substances and drugs for this module, after the global cleanup.
+
+    ``unidademedida`` rows fall outside the ``>= 90000`` window the shared
+    cleanup wipes, so whatever the save creates is removed here on teardown —
+    identified by diffing against the units present before the tests ran.
+    """
+    create_test_substance(
+        _SCTID_WITH_DEFAULT, "ZZTest Substância Unidade", _TEST_MEASURE_UNIT
+    )
+    create_test_substance(_SCTID_WITHOUT_DEFAULT, "ZZTest Substância Sem Unidade", None)
+
+    for id_drug, name in _DRUGS_WITH_DEFAULT:
+        create_test_drug(id_drug, name, _SCTID_WITH_DEFAULT)
+
+    create_test_drug(
+        _DRUG_WITHOUT_DEFAULT, "ZZTest Medicamento Sem Unidade", _SCTID_WITHOUT_DEFAULT
+    )
+
+    preexisting_units = _measure_unit_ids()
+
+    yield
+
+    created_units = _measure_unit_ids() - preexisting_units
+    if created_units:
+        session.execute(
+            text("DELETE FROM demo.unidademedida WHERE fkunidademedida = ANY(:ids)"),
+            {"ids": list(created_units)},
+        )
+        session_commit()
+
+
+def _measure_unit_ids() -> set:
+    """Every measure unit id currently configured in the demo schema."""
+    session_commit()
+
+    return {row.id for row in session.query(MeasureUnit).all()}
+
+
+def _segments() -> list:
+    """All segments the save is expected to touch."""
+    return session.query(Segment).order_by(Segment.id).all()
+
+
+def _save(client, headers, id_drug, conversion_list):
+    """POST a conversion list, with Lambda stubbed so nothing leaves the process."""
+    with patch("services.unit_conversion_service.aws.get_client") as get_client:
+        response = client.post(
+            f"{SAVE_URL}/{id_drug}",
+            data=json.dumps({"conversion_list": conversion_list}),
+            headers=headers,
+        )
+
+    return response, get_client
+
+
+def _conversions(id_drug: int) -> dict:
+    """Saved factors for a drug, keyed by (segment, measure unit)."""
+    session_commit()  # see the rows the request committed
+
+    rows = (
+        session.query(MeasureUnitConvert)
+        .filter(MeasureUnitConvert.idDrug == id_drug)
+        .all()
+    )
+
+    return {(r.idSegment, r.idMeasureUnit): r.factor for r in rows}
+
+
+def _attributes(id_drug: int) -> dict:
+    """Saved medatributos rows for a drug, keyed by segment."""
+    session_commit()
+
+    rows = session.query(DrugAttributes).filter(DrugAttributes.idDrug == id_drug).all()
+
+    return {r.idSegment: r for r in rows}
+
+
+def test_save_applies_the_conversions_to_every_segment(client, config_manager_headers):
+    """One payload, no segment in it, and every segment ends up converted [200]."""
+    response, _ = _save(
+        client,
+        config_manager_headers,
+        _DRUG_SEGMENTS,
+        [
+            {"id_measure_unit": _TEST_MEASURE_UNIT, "factor": 1},
+            {"id_measure_unit": _SEED_MEASURE_UNIT, "factor": 0.5},
+        ],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    segments = _segments()
+    assert response.get_json()["data"]["updated"] == [s.description for s in segments]
+
+    saved = _conversions(_DRUG_SEGMENTS)
+    assert set(saved) == {
+        (segment.id, unit)
+        for segment in segments
+        for unit in (_TEST_MEASURE_UNIT, _SEED_MEASURE_UNIT)
+    }
+    for segment in segments:
+        assert saved[(segment.id, _TEST_MEASURE_UNIT)] == 1
+        assert saved[(segment.id, _SEED_MEASURE_UNIT)] == 0.5
+
+
+def test_save_creates_the_drug_attributes_it_needs(client, config_manager_headers):
+    """The drug has no medatributos row anywhere; the save creates one per segment [200]."""
+    assert _attributes(_DRUG_ATTRIBUTES) == {}
+
+    _save(
+        client,
+        config_manager_headers,
+        _DRUG_ATTRIBUTES,
+        [{"id_measure_unit": _SEED_MEASURE_UNIT, "factor": 1}],
+    )
+
+    attributes = _attributes(_DRUG_ATTRIBUTES)
+
+    assert set(attributes) == {s.id for s in _segments()}
+    for record in attributes.values():
+        # the substance's unit becomes the segment's default measure unit
+        assert record.idMeasureUnit == _TEST_MEASURE_UNIT
+        assert record.user == CALLER_ID
+
+
+def test_save_creates_the_missing_default_measure_unit(client, config_manager_headers):
+    """A substance may name a unit the schema does not configure yet [200]."""
+    session.execute(
+        text("DELETE FROM demo.unidademedida WHERE fkunidademedida = :id"),
+        {"id": _TEST_MEASURE_UNIT},
+    )
+    session_commit()
+
+    _save(
+        client,
+        config_manager_headers,
+        _DRUG_MEASURE_UNIT,
+        [{"id_measure_unit": _SEED_MEASURE_UNIT, "factor": 1}],
+    )
+    session_commit()
+
+    unit = (
+        session.query(MeasureUnit).filter(MeasureUnit.id == _TEST_MEASURE_UNIT).first()
+    )
+
+    assert unit is not None
+    assert unit.description == _TEST_MEASURE_UNIT
+    assert unit.measureunit_nh == _TEST_MEASURE_UNIT
+
+
+def test_resaving_updates_the_factor_instead_of_duplicating(
+    client, config_manager_headers
+):
+    """The upsert is keyed by segment/drug/unit, so a second save overwrites [200]."""
+    _save(
+        client,
+        config_manager_headers,
+        _DRUG_RESAVED,
+        [{"id_measure_unit": _SEED_MEASURE_UNIT, "factor": 2}],
+    )
+
+    first = _conversions(_DRUG_RESAVED)
+    assert set(first.values()) == {2}
+
+    response, _ = _save(
+        client,
+        config_manager_headers,
+        _DRUG_RESAVED,
+        [{"id_measure_unit": _SEED_MEASURE_UNIT, "factor": 7.5}],
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    second = _conversions(_DRUG_RESAVED)
+    assert set(second) == set(first)
+    assert set(second.values()) == {7.5}
+
+
+def test_substance_without_default_unit_falls_back_to_un(
+    client, config_manager_headers
+):
+    """No curated unit on the substance means the generic ``un`` is used [200]."""
+    response, _ = _save(
+        client,
+        config_manager_headers,
+        _DRUG_WITHOUT_DEFAULT,
+        [{"id_measure_unit": _SEED_MEASURE_UNIT, "factor": 3}],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    fallback = DefaultMeasureUnitEnum.UN.value
+    attributes = _attributes(_DRUG_WITHOUT_DEFAULT)
+    assert attributes
+    for record in attributes.values():
+        assert record.idMeasureUnit == fallback
+
+    assert session.query(MeasureUnit).filter(MeasureUnit.id == fallback).first()
+
+
+def test_save_does_not_invoke_the_score_lambda(client, config_manager_headers):
+    """Scores are generated by a separate call, so the save must stay local [200]."""
+    response, get_client = _save(
+        client,
+        config_manager_headers,
+        _DRUG_NO_LAMBDA,
+        [{"id_measure_unit": _SEED_MEASURE_UNIT, "factor": 4}],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    get_client.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "conversion_list",
+    [[], [{"id_measure_unit": _SEED_MEASURE_UNIT, "factor": 0}]],
+    ids=["empty list", "zero factor"],
+)
+def test_save_rejects_a_conversion_list_it_cannot_apply(
+    client, config_manager_headers, conversion_list
+):
+    """A missing list or a zero factor would silently break dose conversion [400]."""
+    response, _ = _save(client, config_manager_headers, _DRUG_REJECTED, conversion_list)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidParams"
+    assert _conversions(_DRUG_REJECTED) == {}
+
+
+def test_save_rejects_a_non_numeric_factor(client, config_manager_headers):
+    """The factor is typed, so a text value never reaches the service [400]."""
+    response, _ = _save(
+        client,
+        config_manager_headers,
+        _DRUG_REJECTED,
+        [{"id_measure_unit": _SEED_MEASURE_UNIT, "factor": "muito"}],
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["validations"]
+    assert _conversions(_DRUG_REJECTED) == {}
+
+
+def test_save_rejects_an_unknown_drug(client, config_manager_headers):
+    """There is no drug to build the attributes from, so nothing is written [400]."""
+    response, _ = _save(
+        client,
+        config_manager_headers,
+        _UNKNOWN_DRUG,
+        [{"id_measure_unit": _SEED_MEASURE_UNIT, "factor": 1}],
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRecord"
+    assert _conversions(_UNKNOWN_DRUG) == {}
+    assert _attributes(_UNKNOWN_DRUG) == {}
+
+
+def test_role_without_write_drug_attributes_cannot_save(client, analyst_headers):
+    """PRESCRIPTION_ANALYST may read conversions but never write them [401]."""
+    response, _ = _save(
+        client,
+        analyst_headers,
+        _DRUG_REJECTED,
+        [{"id_measure_unit": _SEED_MEASURE_UNIT, "factor": 1}],
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert _conversions(_DRUG_REJECTED) == {}
+
+
+def test_process_scores_hands_the_drug_to_the_lambda(client, config_manager_headers):
+    """The score request carries the caller's schema and user, not just the drug [200]."""
+    lambda_client = MagicMock()
+    lambda_client.invoke.return_value = {
+        "ResponseMetadata": {"RequestId": "zztest-request-id"},
+        "StatusCode": 202,
+    }
+
+    with patch(
+        "services.unit_conversion_service.aws.get_client", return_value=lambda_client
+    ):
+        response = client.post(
+            f"{SCORES_URL}/{_DRUG_SCORES}", headers=config_manager_headers
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == {
+        "request_id": "zztest-request-id",
+        "status_code": 202,
+    }
+
+    payload = json.loads(lambda_client.invoke.call_args.kwargs["Payload"])
+    assert payload == {
+        "command": "lambda_scores.process_drug_scores",
+        "schema": CALLER_SCHEMA,
+        "id_user": CALLER_ID,
+        "id_drug": _DRUG_SCORES,
+    }
+    # fire and forget: the caller polls the scores, it does not wait here
+    assert lambda_client.invoke.call_args.kwargs["InvocationType"] == "Event"
+
+
+def test_process_scores_requires_write_drug_attributes(client, analyst_headers):
+    """Regenerating scores is a curation action, closed to the analyst role [401]."""
+    with patch("services.unit_conversion_service.aws.get_client") as get_client:
+        response = client.post(f"{SCORES_URL}/{_DRUG_SCORES}", headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    get_client.assert_not_called()


### PR DESCRIPTION
Adds integration coverage for two features that had none. No production code changes — tests only.

## 1. `GET /reports/prescription/history`

The timeline a pharmacist opens to see what happened to a prescription. Neither `services/reports/reports_prescription_history_service.py` nor the two queries in `repository/reports/reports_prescription_history_repository.py` were exercised by any test.

`tests/integration/test_reports_prescription_history.py` pins:

- the three synthetic `custom` events — origin creation (from `prescricao.dtcriacao_origem`), arrival and processing (from the earliest matching `presmed_audit` rows);
- that all three are suppressed for aggregated prescriptions, which show the audit trail alone;
- that the arrival date only counts items the report treats as prescribed content — a `Materiais` line that arrived first must not move it;
- that the arrival date is the earliest `UPSERT`, and that the processing event only appears when a `PROCESSED` row exists;
- that a `prescricao_audit` row written by an id with no `usuario` row still renders, with no responsible (the join is outer);
- that `extra` is passed through untouched, that the merged list is sorted by date, and the 400/401 paths.

Coverage: service 31% → **100%**, repository 33% → **100%**.

## 2. `POST /drugs/unit-conversion/<drug>` and `POST /drugs/process-scores/<drug>`

The read side of unit conversion is covered by `tests/unit/test_unit_conversion_service.py`; the two endpoints that change data were not. The save is deceptively wide — the payload names no segment, yet it writes to every one of them.

`tests/integration/test_unit_conversion_save.py` pins:

- the conversions being applied to every segment, and the response listing them;
- `medatributos` being created from the substance reference where the drug has no row;
- the default measure unit being taken from the substance, and the `unidademedida` row being created when the schema does not have that unit yet;
- the fallback to `un` when the substance names no default unit;
- the upsert on re-save (factor overwritten, no duplicate row);
- the refused payloads: empty list, zero factor, non-numeric factor, unknown drug — with nothing written in each case;
- the permission gate (`PRESCRIPTION_ANALYST` cannot save or regenerate scores);
- that the save never reaches Lambda, while `process-scores` sends the expected `Event` payload with the caller's schema and user.

Coverage: `services/unit_conversion_service.py` 49% → **91%** (the remainder is the `wait_for_lambda` branch of `save_conversions`, which has no caller today).

## Test hygiene

Both modules clean up after themselves. Ids use the reserved ranges the session-scoped `clean_test_artifacts` fixture wipes (`>= 90000` for drugs/substances, `>= 100000` for prescriptions); `unidademedida` rows fall outside those ranges, so the unit-conversion module removes the ones the save created by diffing against the units present before the module ran. Each test targets its own drug, so the module has no internal ordering.

One thing worth noting for reviewers: `presmed` has a `BEFORE INSERT` trigger that normalises `origem` through the `map-origin-*` entries in `memoria`, and the seed has no mapping for `Materiais` — anything unmapped lands as `Medicamentos`. The history tests write the source back with an `UPDATE` after insert (the trigger does not fire on `UPDATE`), which is documented inline.

## Verification

Full suite run locally against a PostgreSQL loaded from `noharm-ai/database` with the same SQL files CI uses: **1895 passed** (1869 before, +26). `ruff check .` clean; both new files are `ruff format` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_012aounHgxMPaoZmScdtHU2z)_