### PR TITLE
test: cover the drug-attributes report and the support KB search

### DIFF
--- a/tests/integration/test_reports_drug_attributes.py
+++ b/tests/integration/test_reports_drug_attributes.py
@@ -1,0 +1,207 @@
+"""Tests: GET /reports/drug-attributes/history and /reports/antimicrobial/history
+
+The report lists every prescribed drug flagged with a given attribute for one
+admission. Three things carry the business risk and are pinned down here:
+
+* the ``attribute`` query param is mapped to a column name that is interpolated
+  straight into the SQL, so only the keys of ``VALID_ATTRIBUTES`` may pass and
+  each key must select the column it claims to;
+* the report widens the search to the patient's two previous admissions, so a
+  readmitted patient keeps the history of what was already given;
+* ``/reports/antimicrobial/history`` is the legacy alias kept for clients that
+  have not migrated, and must stay equivalent to ``attribute=antimicro``.
+
+Seed data used (demo schema, medatributos on segment 1):
+
+* admission 5 / patient 5 — prescription 8 (presmed 10, ENALAPRIL, antimicro)
+  and prescription 20 (presmed 30, ENALAPRIL, antimicro; presmed 42, BISACODIL,
+  controlados).
+"""
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import session, session_commit
+from utils import status
+
+URL = "/reports/drug-attributes/history"
+LEGACY_URL = "/reports/antimicrobial/history"
+
+# seed admission/patient carrying the flagged prescription drugs
+ADMISSION = 5
+PATIENT_ID = 5
+
+# seed presmed ids reachable from ADMISSION
+ANTIMICRO_DRUGS = {"10", "30"}  # ENALAPRIL, on prescriptions 8 and 20
+CONTROLLED_DRUG = "42"  # BISACODIL, on prescription 20
+
+# a later admission for the same patient, created by one test to exercise the
+# previous-admission lookup. Ids >= 100000 are wiped by the session-scoped
+# clean_test_artifacts fixture in tests/conftest.py.
+LATER_ADMISSION = 100005
+
+
+def _get(client, headers, admission_number=ADMISSION, attribute=None, url=URL):
+    """Call the report, omitting `attribute` when it is None."""
+    params = {}
+    if admission_number is not None:
+        params["admissionNumber"] = admission_number
+    if attribute is not None:
+        params["attribute"] = attribute
+
+    return client.get(url, query_string=params, headers=headers)
+
+
+def _drug_ids(response):
+    """Return the idPrescriptionDrug values of a successful response."""
+    return {row["idPrescriptionDrug"] for row in response.get_json()["data"]}
+
+
+@pytest.fixture
+def later_admission():
+    """Register a second, more recent admission for the seed patient."""
+    session.execute(
+        text(
+            "INSERT INTO demo.pessoa (fkpessoa, nratendimento, dtinternacao) "
+            "VALUES (:patient, :admission, '2024-01-05 00:00:00')"
+        ),
+        {"patient": PATIENT_ID, "admission": LATER_ADMISSION},
+    )
+    session_commit()
+
+    yield LATER_ADMISSION
+
+    session.execute(
+        text("DELETE FROM demo.pessoa WHERE nratendimento = :admission"),
+        {"admission": LATER_ADMISSION},
+    )
+    session.execute(
+        text("DELETE FROM demo.pessoa_audit WHERE nratendimento = :admission"),
+        {"admission": LATER_ADMISSION},
+    )
+    session_commit()
+
+
+def test_history_requires_read_reports(client, navigator_headers):
+    """GET /reports/drug-attributes/history - 401 without READ_REPORTS"""
+    response = _get(client, navigator_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_history_requires_admission_number(client, analyst_headers):
+    """GET /reports/drug-attributes/history - 400 when admissionNumber is missing"""
+    response = _get(client, analyst_headers, admission_number=None)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidParams"
+
+
+def test_history_rejects_unknown_attribute(client, analyst_headers):
+    """GET /reports/drug-attributes/history - 400 for an attribute outside the allowlist"""
+    response = _get(client, analyst_headers, attribute="naopadronizado")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    body = response.get_json()
+    assert body["code"] == "errors.invalidParams"
+    # the message lists the accepted keys so the caller can fix the request
+    assert "notdefault" in body["message"]
+
+
+def test_history_rejects_sql_injection_attempt(client, analyst_headers):
+    """GET /reports/drug-attributes/history - a crafted attribute never reaches the SQL"""
+    response = _get(client, analyst_headers, attribute="antimicro OR TRUE --")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidParams"
+
+
+def test_history_defaults_to_antimicro(client, analyst_headers):
+    """GET /reports/drug-attributes/history - omitting attribute reports antimicrobials"""
+    response = _get(client, analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _drug_ids(response) == ANTIMICRO_DRUGS
+
+
+def test_history_returns_prescription_details(client, analyst_headers):
+    """GET /reports/drug-attributes/history - each row carries the prescription context"""
+    response = _get(client, analyst_headers, attribute="antimicro")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    rows = {row["idPrescriptionDrug"]: row for row in response.get_json()["data"]}
+    row = rows["10"]
+
+    assert row["idPrescription"] == "8"
+    assert row["admissionNumber"] == ADMISSION
+    assert row["prescriptionDate"].startswith("2020-12-31")
+    assert row["drug"] == "ENALAPRIL 20 mg CP"
+    assert row["dose"] == 20
+    assert row["measureUnit"] == "mg"
+    assert row["frequency"] == "12h/12h"
+    assert row["route"] == "VO"
+    # nothing was suspended on the seed prescription
+    assert row["suspensionDate"] is None
+
+
+def test_history_selects_the_column_of_the_requested_attribute(
+    client, analyst_headers
+):
+    """GET /reports/drug-attributes/history - 'controlled' reads the controlados column"""
+    response = _get(client, analyst_headers, attribute="controlled")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    ids = _drug_ids(response)
+    assert ids == {CONTROLLED_DRUG}
+    # the antimicrobials must not leak into a different attribute's report
+    assert not ids & ANTIMICRO_DRUGS
+
+
+def test_history_is_empty_when_no_drug_carries_the_attribute(client, analyst_headers):
+    """GET /reports/drug-attributes/history - an unused attribute returns an empty list"""
+    response = _get(client, analyst_headers, attribute="chemo")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == []
+
+
+def test_history_is_empty_for_an_unknown_admission(client, analyst_headers):
+    """GET /reports/drug-attributes/history - an admission with no prescriptions is empty"""
+    response = _get(client, analyst_headers, admission_number=987654)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == []
+
+
+def test_history_includes_previous_admissions_of_the_patient(
+    client, analyst_headers, later_admission
+):
+    """GET /reports/drug-attributes/history - a readmission keeps the earlier history"""
+    response = _get(client, analyst_headers, admission_number=later_admission)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    rows = response.get_json()["data"]
+    assert {row["idPrescriptionDrug"] for row in rows} == ANTIMICRO_DRUGS
+    # the rows belong to the previous admission, not to the one asked for
+    assert {row["admissionNumber"] for row in rows} == {ADMISSION}
+
+
+def test_legacy_route_matches_the_antimicro_report(client, analyst_headers):
+    """GET /reports/antimicrobial/history - the legacy alias still reports antimicrobials"""
+    legacy = _get(client, analyst_headers, url=LEGACY_URL)
+    current = _get(client, analyst_headers, attribute="antimicro")
+
+    assert legacy.status_code == status.HTTP_200_OK
+    assert _drug_ids(legacy) == _drug_ids(current) == ANTIMICRO_DRUGS
+
+
+def test_legacy_route_requires_admission_number(client, analyst_headers):
+    """GET /reports/antimicrobial/history - 400 when admissionNumber is missing"""
+    response = _get(client, analyst_headers, admission_number=None, url=LEGACY_URL)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidParams"

--- a/tests/integration/test_support_related_kb.py
+++ b/tests/integration/test_support_related_kb.py
@@ -1,0 +1,196 @@
+"""Tests: POST /support/related-articles
+
+The endpoint suggests knowledge-base articles for a support question. It reads
+the vector-index configuration from the global memory (``public.memoria``, kind
+``user-kb``), narrows the search to the three closest matches and collapses the
+vector hits into a de-duplicated article list.
+
+The retrieval itself talks to Bedrock and to an S3 vector index, neither of
+which is reachable from a test, so ``vector_search_service.search`` is replaced
+by a stub. That keeps two production-relevant things assertable: the *config*
+handed to the search (a wrong bucket or an unbounded ``max_results`` is a real
+incident) and how vector hits are folded into articles — the same article is
+indexed as many chunks, so duplicates are the normal case rather than the
+exception.
+
+``vector_search_service.search`` itself is covered by
+``tests/unit/test_vector_search_service.py``.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import GlobalMemoryEnum
+from services import support_service
+from tests.conftest import session, session_commit
+from utils import status
+
+URL = "/support/related-articles"
+
+SEARCH_CONFIG = {
+    "vector_bucket": "kb-vectors",
+    "vector_index": "articles",
+    "vector_region": "us-east-1",
+    "embedding_model": "amazon.titan-embed-text-v2:0",
+    "embedding_region": "sa-east-1",
+    "max_results": 10,
+}
+
+
+def _vector(distance, article_id=None, article_name=None):
+    """Build a vector hit as the search service returns it.
+
+    Omitting ``article_id`` yields a hit whose metadata does not point at an
+    article — content indexed from another source.
+    """
+    metadata = {}
+    if article_id is not None:
+        metadata["article_id"] = article_id
+    if article_name is not None:
+        metadata["article_name"] = article_name
+
+    return {"key": f"chunk-{distance}", "distance": distance, "metadata": metadata}
+
+
+@pytest.fixture(autouse=True)
+def kb_config():
+    """Install the user-kb search configuration in the global memory."""
+    session.execute(
+        text(
+            "INSERT INTO public.memoria (tipo, valor, update_at, update_by) "
+            "VALUES (:kind, CAST(:value AS json), now(), 1)"
+        ),
+        {"kind": GlobalMemoryEnum.USER_KB.value, "value": json.dumps(SEARCH_CONFIG)},
+    )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM public.memoria WHERE tipo = :kind"),
+        {"kind": GlobalMemoryEnum.USER_KB.value},
+    )
+    session_commit()
+
+
+@pytest.fixture
+def search_mock():
+    """Replace the vector search with a stub returning no hit by default."""
+    with patch.object(
+        support_service.vector_search_service, "search", return_value=[]
+    ) as mock:
+        yield mock
+
+
+def test_related_articles_requires_a_question(client, analyst_headers, search_mock):
+    """POST /support/related-articles - 400 when the question is empty"""
+    response = client.post(URL, json={"question": ""}, headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+    search_mock.assert_not_called()
+
+
+def test_related_articles_requires_the_question_field(
+    client, analyst_headers, search_mock
+):
+    """POST /support/related-articles - 400 when the question field is absent"""
+    response = client.post(URL, json={}, headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    search_mock.assert_not_called()
+
+
+def test_related_articles_searches_with_the_stored_config(
+    client, analyst_headers, search_mock
+):
+    """POST /support/related-articles - the search uses the user-kb config, capped at 3"""
+    response = client.post(
+        URL, json={"question": "como emito o relatório?"}, headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    search_mock.assert_called_once()
+    kwargs = search_mock.call_args.kwargs
+    assert kwargs["query"] == "como emito o relatório?"
+
+    config = kwargs["config"]
+    assert config.vector_bucket == SEARCH_CONFIG["vector_bucket"]
+    assert config.vector_index == SEARCH_CONFIG["vector_index"]
+    assert config.embedding_model == SEARCH_CONFIG["embedding_model"]
+    # the stored config allows 10 results; the endpoint narrows it to 3
+    assert config.max_results == 3
+
+
+def test_related_articles_returns_the_matched_articles(
+    client, analyst_headers, search_mock
+):
+    """POST /support/related-articles - each matched article is returned with its name"""
+    search_mock.return_value = [
+        _vector(0.1, article_id="12", article_name="Emitir relatório"),
+        _vector(0.4, article_id="34", article_name="Configurar segmento"),
+    ]
+
+    response = client.post(
+        URL, json={"question": "relatório"}, headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == [
+        {"id": "12", "name": "Emitir relatório"},
+        {"id": "34", "name": "Configurar segmento"},
+    ]
+
+
+def test_related_articles_deduplicates_chunks_of_the_same_article(
+    client, analyst_headers, search_mock
+):
+    """POST /support/related-articles - several chunks of one article yield one entry"""
+    search_mock.return_value = [
+        _vector(0.1, article_id="12", article_name="Emitir relatório"),
+        _vector(0.2, article_id="12", article_name="Emitir relatório"),
+        _vector(0.3, article_id="34", article_name="Configurar segmento"),
+    ]
+
+    response = client.post(
+        URL, json={"question": "relatório"}, headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == [
+        {"id": "12", "name": "Emitir relatório"},
+        {"id": "34", "name": "Configurar segmento"},
+    ]
+
+
+def test_related_articles_ignores_hits_without_an_article(
+    client, analyst_headers, search_mock
+):
+    """POST /support/related-articles - hits whose metadata has no article are dropped"""
+    search_mock.return_value = [
+        _vector(0.1),
+        _vector(0.2, article_id="12", article_name="Emitir relatório"),
+    ]
+
+    response = client.post(
+        URL, json={"question": "relatório"}, headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == [{"id": "12", "name": "Emitir relatório"}]
+
+
+def test_related_articles_is_empty_when_nothing_matches(
+    client, analyst_headers, search_mock
+):
+    """POST /support/related-articles - no vector hit means no suggestion"""
+    response = client.post(
+        URL, json={"question": "assunto inexistente"}, headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == []

--- a/tests/unit/test_vector_search_service.py
+++ b/tests/unit/test_vector_search_service.py
@@ -1,0 +1,143 @@
+"""Unit tests for services.vector_search_service.
+
+``search`` is the retrieval half of the support knowledge base: it turns a
+question into an embedding with Bedrock, queries an S3 vector index with it and
+returns the matches ordered by distance. Both AWS boundaries are mocked, so the
+tests pin down the contract that the callers depend on:
+
+* each client is created for the region its own config field names — embeddings
+  and the vector index may live in different regions;
+* the question is sent to the configured embedding model and the resulting
+  vector is what gets queried, with ``max_results`` as ``topK``;
+* results come back sorted by ascending distance (closest first), which is what
+  ``support_service.get_related_kb`` relies on when it keeps the top articles.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services import vector_search_service
+from services.vector_search_service import SearchConfig
+
+CONFIG_FIELDS = {
+    "vector_bucket": "kb-vectors",
+    "vector_index": "articles",
+    "vector_region": "us-east-1",
+    "embedding_model": "amazon.titan-embed-text-v2:0",
+    "embedding_region": "sa-east-1",
+}
+
+EMBEDDING = [0.1, 0.2, 0.3]
+
+
+def _vector(distance, article_id):
+    """Build a vector match as the s3vectors API returns it."""
+    return {
+        "key": f"article-{article_id}",
+        "distance": distance,
+        "metadata": {"article_id": article_id, "article_name": f"Article {article_id}"},
+    }
+
+
+@pytest.fixture
+def aws_clients():
+    """Replace utils.aws.get_client with per-service mocks.
+
+    Yields ``(get_client, bedrock, s3vectors)``; the bedrock mock already
+    answers ``invoke_model`` with EMBEDDING.
+    """
+    bedrock = MagicMock()
+    body = MagicMock()
+    body.read.return_value = json.dumps({"embedding": EMBEDDING}).encode("utf-8")
+    bedrock.invoke_model.return_value = {"body": body}
+
+    s3vectors = MagicMock()
+    s3vectors.query_vectors.return_value = {"vectors": []}
+
+    clients = {"bedrock-runtime": bedrock, "s3vectors": s3vectors}
+
+    with patch.object(
+        vector_search_service.aws,
+        "get_client",
+        side_effect=lambda service_name, region_name=None: clients[service_name],
+    ) as get_client:
+        yield get_client, bedrock, s3vectors
+
+
+def test_search_config_defaults_to_five_results():
+    """SearchConfig.max_results defaults to 5 when the stored config omits it"""
+    config = SearchConfig(**CONFIG_FIELDS)
+
+    assert config.max_results == 5
+
+
+def test_search_config_rejects_incomplete_config():
+    """SearchConfig refuses a config missing a mandatory field"""
+    incomplete = {k: v for k, v in CONFIG_FIELDS.items() if k != "vector_bucket"}
+
+    with pytest.raises(ValueError):
+        SearchConfig(**incomplete)
+
+
+def test_search_builds_each_client_in_its_own_region(aws_clients):
+    """search creates the bedrock and s3vectors clients in the configured regions"""
+    get_client, _, _ = aws_clients
+
+    vector_search_service.search(query="como faço x?", config=SearchConfig(**CONFIG_FIELDS))
+
+    get_client.assert_any_call("bedrock-runtime", region_name="sa-east-1")
+    get_client.assert_any_call("s3vectors", region_name="us-east-1")
+
+
+def test_search_embeds_the_query_with_the_configured_model(aws_clients):
+    """search sends the raw question to the configured embedding model"""
+    _, bedrock, _ = aws_clients
+
+    vector_search_service.search(query="como faço x?", config=SearchConfig(**CONFIG_FIELDS))
+
+    bedrock.invoke_model.assert_called_once()
+    kwargs = bedrock.invoke_model.call_args.kwargs
+    assert kwargs["modelId"] == CONFIG_FIELDS["embedding_model"]
+    assert json.loads(kwargs["body"]) == {"inputText": "como faço x?"}
+
+
+def test_search_queries_the_index_with_the_generated_embedding(aws_clients):
+    """search queries the vector index with the embedding and the configured topK"""
+    _, _, s3vectors = aws_clients
+    config = SearchConfig(**CONFIG_FIELDS, max_results=3)
+
+    vector_search_service.search(query="como faço x?", config=config)
+
+    s3vectors.query_vectors.assert_called_once_with(
+        vectorBucketName=CONFIG_FIELDS["vector_bucket"],
+        indexName=CONFIG_FIELDS["vector_index"],
+        queryVector={"float32": EMBEDDING},
+        topK=3,
+        returnDistance=True,
+        returnMetadata=True,
+    )
+
+
+def test_search_returns_matches_closest_first(aws_clients):
+    """search orders the matches by ascending distance"""
+    _, _, s3vectors = aws_clients
+    s3vectors.query_vectors.return_value = {
+        "vectors": [_vector(0.9, "c"), _vector(0.1, "a"), _vector(0.5, "b")]
+    }
+
+    results = vector_search_service.search(
+        query="como faço x?", config=SearchConfig(**CONFIG_FIELDS)
+    )
+
+    assert [v["metadata"]["article_id"] for v in results] == ["a", "b", "c"]
+
+
+def test_search_returns_an_empty_list_when_the_index_has_no_match(aws_clients):
+    """search returns an empty list when the index answers with no vector"""
+    results = vector_search_service.search(
+        query="como faço x?", config=SearchConfig(**CONFIG_FIELDS)
+    )
+
+    assert results == []


### PR DESCRIPTION
Adds coverage for two features that had none. No production code changes — tests only.

## 1. `GET /reports/drug-attributes/history`

The report a pharmacist opens to see every drug of one admission flagged with a given attribute (antimicrobials, controlled substances, chemo, …). `services/reports/reports_drug_attributes_service.py` was at 33% — the whole `get_history` body was unexercised, including the `/reports/antimicrobial/history` legacy alias that clients still call.

`tests/integration/test_reports_drug_attributes.py` pins:

- the `VALID_ATTRIBUTES` allowlist. The chosen key is mapped to a column name that is **interpolated straight into the SQL**, so the gate matters: an unknown key is refused (with the accepted keys named in the message), a raw column name (`naopadronizado`) is refused because it is not a key, and a crafted `antimicro OR TRUE --` never reaches the query;
- that each key selects the column it claims to — `controlled` returns the `controlados` row and none of the `antimicro` ones;
- the default (`attribute` omitted ⇒ antimicrobials) and the full row payload: prescription id, dates, dose, measure unit, frequency, route, suspension date;
- the widening to the patient's two previous admissions — a readmission still reports what was given before, and the rows come back carrying the *earlier* admission number;
- the empty cases (an attribute no drug carries, an unknown admission) and the 400/401 paths;
- that the legacy alias stays equivalent to `attribute=antimicro`, and rejects a missing `admissionNumber` the same way.

Coverage: **33% → 100%**.

## 2. The support knowledge-base search

`POST /support/related-articles` suggests KB articles for a support question: it reads the vector-index config from `public.memoria` (kind `user-kb`), embeds the question with Bedrock, queries an S3 vector index and folds the hits into an article list. `services/vector_search_service.py` was at 58% and `support_service.get_related_kb` was untested.

`tests/unit/test_vector_search_service.py` mocks both AWS boundaries and pins the contract its caller depends on:

- each client is built for the region its own config field names (embeddings and the index may live in different regions);
- the question reaches the configured embedding model, and the vector that comes back is what gets queried, with `max_results` as `topK`;
- results are ordered closest-first by distance;
- `SearchConfig` defaults `max_results` to 5 and refuses an incomplete stored config.

`tests/integration/test_support_related_kb.py` replaces the search with a stub — Bedrock and the vector index are unreachable from a test — and covers the parts that carry production risk:

- the config handed to the search comes from the `user-kb` global memory, with `max_results` narrowed to 3 regardless of what is stored (the stored config says 10);
- several chunks of the same article collapse into one entry — the same article is indexed as many chunks, so duplicates are the normal case;
- hits whose metadata names no article are dropped rather than emitted with a null id;
- the empty result and the 400 on a missing or empty question, which must not reach the search at all.

Coverage: `vector_search_service` **58% → 100%**, `support_service` 64% → 73%.

## Test hygiene

Both integration modules clean up after themselves. The readmission test inserts a `demo.pessoa` row in the `>= 100000` range the session-scoped `clean_test_artifacts` fixture wipes, and removes it in its own fixture; the KB module inserts and removes its `public.memoria` row. No test depends on another's ordering.

## Verification

Full suite run locally against PostgreSQL loaded from `noharm-ai/database` with the same SQL files CI uses: **1940 passed** (1914 before, +26). `ruff check .` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJss7x7K8zLo826yX6T5BR)_