### PR TITLE
test: cover clinical note authoring and batch interventions

### DIFF
--- a/tests/integration/test_intervention_multiple.py
+++ b/tests/integration/test_intervention_multiple.py
@@ -1,0 +1,361 @@
+"""Tests: PUT /intervention with idPrescriptionDrugList (batch interventions).
+
+``PUT /intervention`` serves two different code paths. With a single
+``idPrescriptionDrug`` it goes to ``intervention_service.save_intervention``,
+which creates or updates one intervention and is covered in test_intervention.py.
+With a non-empty ``idPrescriptionDrugList`` it goes instead to
+``intervention_service.add_multiple_interventions``, which creates one brand new
+intervention per prescribed drug in a single request -- what the pharmacist
+screen calls when several drugs are flagged for the same reason at once.
+
+The batch path is not a loop over the single path: it derives the economy type,
+the department and the RAM payload once for the whole request and applies them
+to every intervention it creates, and it never updates an existing record.
+
+What these tests pin down:
+
+* one intervention per prescribed drug, each pointing at its own presmed row,
+  carrying the shared admission number, reason list, error/cost flags and
+  observation, opened with status "s" and no prescription of its own;
+* the response carries exactly the interventions that were created;
+* the department is copied from the admission's most recent prescription;
+* the economy type follows the reason -- suspension, substitution and custom
+  economy each map to their own type, an ordinary reason to none -- and the
+  economy base date is filled in only when there is an economy type, from the
+  prescription the drug belongs to;
+* the RAM payload is stored only when a reason is flagged as RAM;
+* every created intervention gets a CREATE audit row recording the economy type;
+* a caller without WRITE_PRESCRIPTION writes nothing.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import InterventionAuditEnum, InterventionEconomyTypeEnum
+from models.prescription import Intervention, InterventionAudit
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_prescription import (
+    create_prescription,
+    create_prescription_drug,
+    test_counters,
+)
+from utils import status
+
+INTERVENTION_URL = "/intervention"
+
+# the demo user, who authenticates every request in this module
+AUTHOR_ID = 1
+
+# seed reasons carrying each economy flag (demo.motivointervencao)
+REASON_PLAIN = 5  # "Duplicidade medicamentosa" -- no economy
+REASON_SUSPENSION = 22  # "Suspensão da terapia"
+REASON_SUBSTITUTION = 23  # "Substituição"
+REASON_CUSTOM_ECONOMY = 1  # "Alta antecipada"
+
+# reserved id for the RAM reason this module creates; no seed reason has ram on
+REASON_RAM = 90001
+
+SEGMENT = 1  # the demo user is authorized on it (public.usuario_autorizacao)
+DEPARTMENT = 7
+
+
+@pytest.fixture(autouse=True)
+def clean_interventions():
+    """Drop the interventions this module writes -- tests.conftest does not know them."""
+    yield
+    session.execute(
+        text(
+            "DELETE FROM demo.intervencao_audit WHERE idintervencao IN "
+            "(SELECT idintervencao FROM demo.intervencao WHERE nratendimento >= 100000)"
+        )
+    )
+    session.execute(text("DELETE FROM demo.intervencao WHERE nratendimento >= 100000"))
+    session.execute(
+        text("DELETE FROM demo.motivointervencao WHERE idmotivointervencao >= 90000")
+    )
+    session_commit()
+
+
+@pytest.fixture
+def ram_reason():
+    """A reason flagged as RAM -- the seed data has none."""
+    session.execute(
+        text(
+            "INSERT INTO demo.motivointervencao "
+            "(idmotivointervencao, nome, ativo, ram) VALUES (:id, 'ZZTEST RAM', true, true)"
+        ),
+        {"id": REASON_RAM},
+    )
+    session_commit()
+
+    return REASON_RAM
+
+
+def _prescription_with_drugs(drug_count=2, date=None, id_department=DEPARTMENT):
+    """Create a prescription for a fresh admission and return (admission, date, drug ids)."""
+    id_prescription = test_counters["id_prescription"]
+    test_counters["id_prescription"] += 1
+    admission = test_counters["admission_number"]
+    test_counters["admission_number"] += 1
+
+    prescription_date = date or datetime.now()
+
+    create_prescription(
+        id=id_prescription,
+        admissionNumber=admission,
+        idPatient=1,
+        date=prescription_date,
+        idSegment=SEGMENT,
+        idDepartment=id_department,
+    )
+
+    id_prescription_drugs = []
+    for position in range(drug_count):
+        id_prescription_drug = int(f"{id_prescription}{position + 1:03d}")
+        create_prescription_drug(
+            id=id_prescription_drug,
+            idPrescription=id_prescription,
+            idDrug=3 + position,
+            idSegment=SEGMENT,
+        )
+        id_prescription_drugs.append(id_prescription_drug)
+
+    return admission, prescription_date, id_prescription_drugs
+
+
+def _payload(admission, id_prescription_drugs, reasons, **extra):
+    """Build a batch PUT /intervention body."""
+    body = {
+        "idPrescriptionDrugList": [str(i) for i in id_prescription_drugs],
+        "admissionNumber": admission,
+        "idInterventionReason": reasons,
+    }
+    body.update(extra)
+
+    return body
+
+
+def _interventions(admission) -> list:
+    """Every intervention stored for an admission, oldest id first."""
+    session.expire_all()
+    return (
+        session.query(Intervention)
+        .filter(Intervention.admissionNumber == admission)
+        .order_by(Intervention.idIntervention)
+        .all()
+    )
+
+
+def test_creates_one_intervention_per_prescribed_drug(client, analyst_headers):
+    """Teste put /intervention - Deve criar uma intervenção para cada medicamento da lista"""
+    admission, _, drugs = _prescription_with_drugs(drug_count=3)
+
+    response = client.put(
+        INTERVENTION_URL,
+        json=_payload(admission, drugs, [REASON_PLAIN]),
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    interventions = _interventions(admission)
+    assert len(interventions) == 3
+    assert sorted(i.id for i in interventions) == sorted(drugs)
+
+
+def test_created_interventions_carry_the_request_data(client, analyst_headers):
+    """Teste put /intervention - As intervenções criadas devem gravar motivo, erro, custo e observação enviados"""
+    admission, _, drugs = _prescription_with_drugs()
+
+    client.put(
+        INTERVENTION_URL,
+        json=_payload(
+            admission,
+            drugs,
+            [REASON_PLAIN],
+            error=True,
+            cost=True,
+            observation="dose acima do previsto",
+        ),
+        headers=analyst_headers,
+    )
+
+    for intervention in _interventions(admission):
+        assert intervention.admissionNumber == admission
+        assert intervention.idInterventionReason == [REASON_PLAIN]
+        assert intervention.error is True
+        assert intervention.cost is True
+        assert intervention.notes == "dose acima do previsto"
+        assert intervention.user == AUTHOR_ID
+        # a batch intervention always hangs off a presmed, never a prescription
+        assert intervention.idPrescription == 0
+        assert intervention.status == "s"
+        assert intervention.date.date() == datetime.today().date()
+
+
+def test_response_lists_the_created_interventions(client, analyst_headers):
+    """Teste put /intervention - A resposta deve trazer exatamente as intervenções criadas"""
+    admission, _, drugs = _prescription_with_drugs()
+
+    response = client.put(
+        INTERVENTION_URL,
+        json=_payload(admission, drugs, [REASON_PLAIN]),
+        headers=analyst_headers,
+    )
+
+    data = response.get_json()["data"]
+    created = {str(i.idIntervention) for i in _interventions(admission)}
+
+    assert {str(item["idIntervention"]) for item in data} == created
+
+
+def test_department_comes_from_the_most_recent_prescription(client, analyst_headers):
+    """Teste put /intervention - O setor deve vir da prescrição mais recente do atendimento"""
+    admission, _, drugs = _prescription_with_drugs(id_department=DEPARTMENT)
+
+    # a newer prescription on the same admission, in another department
+    newer_department = 8
+    id_newer = test_counters["id_prescription"]
+    test_counters["id_prescription"] += 1
+    create_prescription(
+        id=id_newer,
+        admissionNumber=admission,
+        idPatient=1,
+        date=datetime.now() + timedelta(hours=1),
+        idSegment=SEGMENT,
+        idDepartment=newer_department,
+    )
+
+    client.put(
+        INTERVENTION_URL,
+        json=_payload(admission, drugs, [REASON_PLAIN]),
+        headers=analyst_headers,
+    )
+
+    for intervention in _interventions(admission):
+        assert intervention.idDepartment == newer_department
+
+
+@pytest.mark.parametrize(
+    "reason,economy_type",
+    [
+        (REASON_SUSPENSION, InterventionEconomyTypeEnum.SUSPENSION.value),
+        (REASON_SUBSTITUTION, InterventionEconomyTypeEnum.SUBSTITUTION.value),
+        (REASON_CUSTOM_ECONOMY, InterventionEconomyTypeEnum.CUSTOM.value),
+    ],
+)
+def test_economy_type_follows_the_reason(client, analyst_headers, reason, economy_type):
+    """Teste put /intervention - O tipo de economia deve ser derivado do motivo enviado"""
+    admission, _, drugs = _prescription_with_drugs()
+
+    client.put(
+        INTERVENTION_URL,
+        json=_payload(admission, drugs, [reason]),
+        headers=analyst_headers,
+    )
+
+    for intervention in _interventions(admission):
+        assert intervention.economy_type == economy_type
+
+
+def test_an_ordinary_reason_has_no_economy_type(client, analyst_headers):
+    """Teste put /intervention - Um motivo sem economia não deve gerar tipo nem data base de economia"""
+    admission, _, drugs = _prescription_with_drugs()
+
+    client.put(
+        INTERVENTION_URL,
+        json=_payload(admission, drugs, [REASON_PLAIN]),
+        headers=analyst_headers,
+    )
+
+    for intervention in _interventions(admission):
+        assert intervention.economy_type is None
+        assert intervention.date_base_economy is None
+
+
+def test_economy_base_date_comes_from_the_drugs_prescription(client, analyst_headers):
+    """Teste put /intervention - A data base de economia deve ser a data da prescrição do medicamento"""
+    prescription_date = datetime.now() - timedelta(days=2)
+    admission, _, drugs = _prescription_with_drugs(date=prescription_date)
+
+    client.put(
+        INTERVENTION_URL,
+        json=_payload(admission, drugs, [REASON_SUSPENSION]),
+        headers=analyst_headers,
+    )
+
+    for intervention in _interventions(admission):
+        assert intervention.date_base_economy.date() == prescription_date.date()
+
+
+def test_ram_is_stored_only_for_a_ram_reason(client, analyst_headers, ram_reason):
+    """Teste put /intervention - O ramData deve ser gravado quando o motivo é marcado como RAM"""
+    admission, _, drugs = _prescription_with_drugs()
+    ram_data = {"severity": "grave", "causality": "provavel"}
+
+    client.put(
+        INTERVENTION_URL,
+        json=_payload(admission, drugs, [ram_reason], ramData=ram_data),
+        headers=analyst_headers,
+    )
+
+    for intervention in _interventions(admission):
+        assert intervention.ram == ram_data
+
+
+def test_ram_is_dropped_when_no_reason_is_flagged_as_ram(client, analyst_headers):
+    """Teste put /intervention - O ramData deve ser ignorado quando nenhum motivo é RAM"""
+    admission, _, drugs = _prescription_with_drugs()
+
+    client.put(
+        INTERVENTION_URL,
+        json=_payload(admission, drugs, [REASON_PLAIN], ramData={"severity": "grave"}),
+        headers=analyst_headers,
+    )
+
+    for intervention in _interventions(admission):
+        assert intervention.ram is None
+
+
+def test_every_created_intervention_is_audited(client, analyst_headers):
+    """Teste put /intervention - Cada intervenção criada deve gerar um registro de auditoria CREATE"""
+    admission, _, drugs = _prescription_with_drugs()
+
+    client.put(
+        INTERVENTION_URL,
+        json=_payload(admission, drugs, [REASON_SUSPENSION]),
+        headers=analyst_headers,
+    )
+
+    created = [i.idIntervention for i in _interventions(admission)]
+    audits = (
+        session.query(InterventionAudit)
+        .filter(InterventionAudit.idIntervention.in_(created))
+        .all()
+    )
+
+    assert len(audits) == len(created)
+    for audit in audits:
+        assert audit.auditType == InterventionAuditEnum.CREATE.value
+        assert audit.createdBy == AUTHOR_ID
+        assert audit.extra["status"] == "s"
+        assert audit.extra["update_responsible"] is False
+        assert (
+            audit.extra["economy_type"] == InterventionEconomyTypeEnum.SUSPENSION.value
+        )
+
+
+def test_batch_requires_write_prescription(client, viewer_headers):
+    """Teste put /intervention - Deve retornar erro [401 UNAUTHORIZED] para usuário sem WRITE_PRESCRIPTION"""
+    admission, _, drugs = _prescription_with_drugs()
+
+    response = client.put(
+        INTERVENTION_URL,
+        json=_payload(admission, drugs, [REASON_PLAIN]),
+        headers=viewer_headers,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert _interventions(admission) == []

--- a/tests/integration/test_notes_create.py
+++ b/tests/integration/test_notes_create.py
@@ -1,0 +1,441 @@
+"""Tests: POST /notes and POST /notes/<idNote> (clinical note authoring).
+
+The two endpoints that let a user *write* a clinical note, as opposed to the
+read endpoints covered in test_notes_last.py. Both live in
+``clinical_notes_service`` and both are gated twice: by the WRITE_PRESCRIPTION
+permission and by the schema's PRIMARYCARE feature, which the demo schema does
+not carry -- so the tests that need it switch it on for their duration.
+
+What these tests pin down:
+
+* ``POST /notes`` refuses to write anything unless PRIMARYCARE is on, and
+  refuses a caller without WRITE_PRESCRIPTION;
+* a created note takes its id from the schema's own ``evolucao`` sequence (a
+  fresh one per note), records the *author's* name as the prescriber rather
+  than anything the caller sent, and stores the primary-care form/template
+  payloads as they arrived;
+* the note's position is "Farmacêutica" by default, the caller's ``tplName``
+  when one is sent, and "Agendamento" for a scheduling note -- the scheduling
+  action wins over ``tplName``;
+* the date defaults to now when the body omits it and is honoured when sent;
+* ``POST /notes/<idNote>`` refuses an id that does not exist, replaces the text
+  and re-counts the allergy annotations embedded in it, and leaves the text
+  alone when the body does not carry one;
+* date and form on an edit are primary-care-only: with the feature off they are
+  ignored, with it on they are applied.
+"""
+
+import json
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from models.notes import ClinicalNotes
+from tests.conftest import session, session_commit
+from utils import status
+
+NOTES_URL = "/notes"
+
+PRIMARY_CARE = "PRIMARYCARE"
+
+# the demo user, who authenticates every request in this module
+AUTHOR_ID = 1
+AUTHOR_NAME = "Demonstração"
+
+# Reserved for this module. The seed data stops well below it and the shared
+# counter in tests.utils.utils_test_prescription hands out admission numbers from
+# 100000 upwards, one per prescription, so it cannot reach here. tests.conftest
+# never touches demo.evolucao, so clean_notes below wipes what this module writes.
+ADMISSION = 190000
+
+MISSING_NOTE = 999999999
+
+
+def _read_features() -> list:
+    """The feature list currently stored in the demo schema."""
+    row = session.execute(
+        text("SELECT valor FROM demo.memoria WHERE tipo = 'features'")
+    ).first()
+    return list(row[0]) if row else []
+
+
+def _write_features(features: list):
+    """Overwrite the demo schema feature list."""
+    session.execute(
+        text(
+            "UPDATE demo.memoria SET valor = CAST(:value AS json) WHERE tipo = 'features'"
+        ),
+        {"value": json.dumps(features)},
+    )
+    session_commit()
+
+
+@pytest.fixture
+def primary_care():
+    """Turn PRIMARYCARE on for the demo schema, as a primary-care client has it."""
+    original = _read_features()
+    _write_features(original + [PRIMARY_CARE])
+    yield
+    _write_features(original)
+
+
+@pytest.fixture(autouse=True)
+def clean_notes():
+    """Drop the notes this module writes -- tests.conftest does not know them."""
+    yield
+    session.execute(
+        text("DELETE FROM demo.evolucao WHERE nratendimento = :admission"),
+        {"admission": ADMISSION},
+    )
+    session_commit()
+
+
+def _notes() -> list:
+    """Every note written for the test admission, oldest id first."""
+    session.expire_all()
+    return (
+        session.query(ClinicalNotes)
+        .filter(ClinicalNotes.admissionNumber == ADMISSION)
+        .order_by(ClinicalNotes.id)
+        .all()
+    )
+
+
+def _create_note(text_value="nota", **extra) -> int:
+    """Write a note straight to the database and return its id.
+
+    Used by the edit tests, which need a note to exist without depending on the
+    create endpoint they are not exercising.
+    """
+    row = session.execute(
+        text(
+            "INSERT INTO demo.evolucao "
+            "(fkevolucao, nratendimento, texto, dtevolucao, prescritor, cargo, exame, formulario) "
+            "VALUES (NEXTVAL('demo.evolucao_fkevolucao_seq'), :admission, :note, :date, "
+            ":prescriber, :position, false, CAST(:form AS jsonb)) "
+            "RETURNING fkevolucao"
+        ),
+        {
+            "admission": ADMISSION,
+            "note": text_value,
+            "date": extra.get("date", datetime(2026, 1, 5, 9, 0)),
+            "prescriber": extra.get("prescriber", "Dr. Test"),
+            "position": extra.get("position", "Farmacêutica"),
+            "form": json.dumps(extra.get("form")) if extra.get("form") else None,
+        },
+    ).first()
+    session_commit()
+
+    return row[0]
+
+
+#
+# POST /notes -- create
+#
+
+
+def test_create_requires_the_primarycare_feature(client, analyst_headers):
+    """Teste post /notes - Deve recusar a criação quando a feature PRIMARYCARE está desligada"""
+    response = client.post(
+        NOTES_URL,
+        json={"admissionNumber": ADMISSION, "notes": "nota"},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert _notes() == []
+
+
+def test_create_requires_write_prescription(client, viewer_headers, primary_care):
+    """Teste post /notes - Deve retornar erro [401 UNAUTHORIZED] para usuário sem WRITE_PRESCRIPTION"""
+    response = client.post(
+        NOTES_URL,
+        json={"admissionNumber": ADMISSION, "notes": "nota"},
+        headers=viewer_headers,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert _notes() == []
+
+
+def test_create_persists_the_note(client, analyst_headers, primary_care):
+    """Teste post /notes - Deve gravar a evolução com o texto, o autor e o atendimento enviados"""
+    response = client.post(
+        NOTES_URL,
+        json={"admissionNumber": ADMISSION, "notes": "paciente estável"},
+        headers=analyst_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    notes = _notes()
+    assert len(notes) == 1
+
+    note = notes[0]
+    assert note.admissionNumber == ADMISSION
+    assert note.text == "paciente estável"
+    assert note.user == AUTHOR_ID
+    # the author is read from the database, not taken from the request body
+    assert note.prescriber == AUTHOR_NAME
+    # the created id is echoed back to the caller
+    assert response.get_json()["data"] == note.id
+
+
+def test_create_defaults_the_position_to_the_pharmacist_role(
+    client, analyst_headers, primary_care
+):
+    """Teste post /notes - Sem tplName o cargo deve ser 'Farmacêutica'"""
+    client.post(
+        NOTES_URL,
+        json={"admissionNumber": ADMISSION, "notes": "nota"},
+        headers=analyst_headers,
+    )
+
+    assert _notes()[0].position == "Farmacêutica"
+
+
+def test_create_uses_the_template_name_as_the_position(
+    client, analyst_headers, primary_care
+):
+    """Teste post /notes - O tplName enviado deve virar o cargo da evolução"""
+    client.post(
+        NOTES_URL,
+        json={
+            "admissionNumber": ADMISSION,
+            "notes": "nota",
+            "tplName": "Consulta Médica",
+        },
+        headers=analyst_headers,
+    )
+
+    assert _notes()[0].position == "Consulta Médica"
+
+
+def test_create_marks_a_scheduling_note(client, analyst_headers, primary_care):
+    """Teste post /notes - A ação 'schedule' deve prevalecer sobre o tplName e marcar o cargo como 'Agendamento'"""
+    client.post(
+        NOTES_URL,
+        json={
+            "admissionNumber": ADMISSION,
+            "notes": "retorno em 30 dias",
+            "action": "schedule",
+            "tplName": "Consulta Médica",
+        },
+        headers=analyst_headers,
+    )
+
+    assert _notes()[0].position == "Agendamento"
+
+
+def test_create_stores_the_form_and_template(client, analyst_headers, primary_care):
+    """Teste post /notes - Os campos formValues e template devem ser gravados como enviados"""
+    form = {"pressao": "120/80", "peso": 70}
+    template = [{"id": 1, "label": "Pressão"}]
+
+    client.post(
+        NOTES_URL,
+        json={
+            "admissionNumber": ADMISSION,
+            "notes": "nota",
+            "formValues": form,
+            "template": template,
+        },
+        headers=analyst_headers,
+    )
+
+    note = _notes()[0]
+    assert note.form == form
+    assert note.template == template
+
+
+def test_create_defaults_the_date_to_now(client, analyst_headers, primary_care):
+    """Teste post /notes - Sem data enviada a evolução deve ser datada de hoje"""
+    client.post(
+        NOTES_URL,
+        json={"admissionNumber": ADMISSION, "notes": "nota"},
+        headers=analyst_headers,
+    )
+
+    assert _notes()[0].date.date() == datetime.today().date()
+
+
+def test_create_honours_the_given_date(client, analyst_headers, primary_care):
+    """Teste post /notes - A data enviada deve ser usada no lugar da data de hoje"""
+    client.post(
+        NOTES_URL,
+        json={
+            "admissionNumber": ADMISSION,
+            "notes": "nota",
+            "date": "2026-02-03T14:25:00",
+        },
+        headers=analyst_headers,
+    )
+
+    assert _notes()[0].date == datetime(2026, 2, 3, 14, 25)
+
+
+def test_create_hands_out_a_new_id_for_every_note(
+    client, analyst_headers, primary_care
+):
+    """Teste post /notes - Cada evolução deve receber um id novo da sequência do schema"""
+    first = client.post(
+        NOTES_URL,
+        json={"admissionNumber": ADMISSION, "notes": "primeira"},
+        headers=analyst_headers,
+    ).get_json()["data"]
+    second = client.post(
+        NOTES_URL,
+        json={"admissionNumber": ADMISSION, "notes": "segunda"},
+        headers=analyst_headers,
+    ).get_json()["data"]
+
+    assert first != second
+    assert [n.id for n in _notes()] == sorted([first, second])
+
+
+#
+# POST /notes/<idNote> -- edit
+#
+
+
+def test_update_rejects_an_unknown_note(client, analyst_headers):
+    """Teste post /notes/<idNote> - Deve retornar erro [400 BAD REQUEST] para uma evolução inexistente"""
+    response = client.post(
+        f"{NOTES_URL}/{MISSING_NOTE}", json={"text": "nota"}, headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_update_requires_write_prescription(client, viewer_headers):
+    """Teste post /notes/<idNote> - Deve retornar erro [401 UNAUTHORIZED] para usuário sem WRITE_PRESCRIPTION"""
+    id_note = _create_note("texto original")
+
+    response = client.post(
+        f"{NOTES_URL}/{id_note}", json={"text": "novo texto"}, headers=viewer_headers
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert _notes()[0].text == "texto original"
+
+
+def test_update_replaces_the_text_and_stamps_the_author(client, analyst_headers):
+    """Teste post /notes/<idNote> - Deve gravar o novo texto e registrar quem editou"""
+    id_note = _create_note("texto original")
+
+    response = client.post(
+        f"{NOTES_URL}/{id_note}", json={"text": "novo texto"}, headers=analyst_headers
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    note = _notes()[0]
+    assert note.text == "novo texto"
+    assert note.user == AUTHOR_ID
+    assert note.update.date() == datetime.today().date()
+
+
+def test_update_counts_the_allergy_annotations(client, analyst_headers):
+    """Teste post /notes/<idNote> - O contador de alergias deve refletir as marcações do novo texto"""
+    id_note = _create_note("texto original")
+
+    client.post(
+        f"{NOTES_URL}/{id_note}",
+        json={
+            "text": (
+                'alergia a <span class="annotation-alergia">dipirona</span> e a '
+                '<span class="annotation-alergia">penicilina</span>'
+            )
+        },
+        headers=analyst_headers,
+    )
+
+    assert _notes()[0].allergy == 2
+
+
+def test_update_clears_the_allergy_count_when_the_annotations_go_away(
+    client, analyst_headers
+):
+    """Teste post /notes/<idNote> - Um texto sem marcações deve zerar o contador de alergias"""
+    id_note = _create_note('<span class="annotation-alergia">dipirona</span>')
+    client.post(
+        f"{NOTES_URL}/{id_note}",
+        json={"text": '<span class="annotation-alergia">dipirona</span>'},
+        headers=analyst_headers,
+    )
+    assert _notes()[0].allergy == 1
+
+    client.post(
+        f"{NOTES_URL}/{id_note}", json={"text": "sem alergias"}, headers=analyst_headers
+    )
+
+    assert _notes()[0].allergy == 0
+
+
+def test_update_keeps_the_text_when_it_is_not_sent(client, analyst_headers):
+    """Teste post /notes/<idNote> - Um corpo sem 'text' não deve apagar o texto da evolução"""
+    id_note = _create_note("texto original")
+
+    response = client.post(f"{NOTES_URL}/{id_note}", json={}, headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _notes()[0].text == "texto original"
+
+
+def test_update_ignores_the_date_and_form_without_primarycare(client, analyst_headers):
+    """Teste post /notes/<idNote> - Sem PRIMARYCARE a data e o formulário enviados devem ser ignorados"""
+    id_note = _create_note("texto original", form={"peso": 70})
+
+    client.post(
+        f"{NOTES_URL}/{id_note}",
+        json={
+            "text": "novo texto",
+            "date": "2026-02-03T14:25:00",
+            "form": {"peso": 80},
+        },
+        headers=analyst_headers,
+    )
+
+    note = _notes()[0]
+    assert note.text == "novo texto"
+    assert note.date == datetime(2026, 1, 5, 9, 0)
+    assert note.form == {"peso": 70}
+
+
+def test_update_applies_the_date_and_form_with_primarycare(
+    client, analyst_headers, primary_care
+):
+    """Teste post /notes/<idNote> - Com PRIMARYCARE a data e o formulário enviados devem ser gravados"""
+    id_note = _create_note("texto original", form={"peso": 70})
+
+    client.post(
+        f"{NOTES_URL}/{id_note}",
+        json={
+            "text": "novo texto",
+            "date": "2026-02-03T14:25:00",
+            "form": {"peso": 80},
+        },
+        headers=analyst_headers,
+    )
+
+    note = _notes()[0]
+    assert note.date == datetime(2026, 2, 3, 14, 25)
+    assert note.form == {"peso": 80}
+
+
+def test_update_keeps_the_date_and_form_when_they_are_null(
+    client, analyst_headers, primary_care
+):
+    """Teste post /notes/<idNote> - Com PRIMARYCARE, data e formulário nulos não devem sobrescrever os valores atuais"""
+    id_note = _create_note("texto original", form={"peso": 70})
+
+    client.post(
+        f"{NOTES_URL}/{id_note}",
+        json={"text": "novo texto", "date": None, "form": None},
+        headers=analyst_headers,
+    )
+
+    note = _notes()[0]
+    assert note.date == datetime(2026, 1, 5, 9, 0)
+    assert note.form == {"peso": 70}


### PR DESCRIPTION
Two features the suite did not reach at all. Both are integration tests, since both are thin service layers over the database and the interesting behaviour is what actually gets persisted.

## `POST /notes` and `POST /notes/<idNote>` — clinical note authoring

`tests/integration/test_notes_create.py` (19 tests)

The write side of clinical notes (`clinical_notes_service.create_clinical_notes` / `update_note_text`), as opposed to the read endpoints already covered in `test_notes_last.py`. Both are gated twice — by `WRITE_PRESCRIPTION` and by the schema's `PRIMARYCARE` feature, which the demo schema does not carry, so the tests that need it switch it on for their duration and put it back.

Pinned down:

- creation refuses to write anything with `PRIMARYCARE` off, and refuses a caller without `WRITE_PRESCRIPTION`;
- a created note takes its id from the schema's own `evolucao` sequence (a fresh one per note), records the *author's* name as prescriber rather than anything the caller sent, and stores the `formValues` / `template` payloads as they arrived;
- the position is `Farmacêutica` by default, the caller's `tplName` when one is sent, and `Agendamento` for a scheduling note — the scheduling action wins over `tplName`;
- the date defaults to now when omitted and is honoured when sent;
- an edit refuses an unknown id (400), replaces the text and re-counts the allergy annotations embedded in it, and leaves the text alone when the body carries none;
- date and form on an edit are primary-care-only: ignored with the feature off, applied with it on, and never overwritten by nulls.

## `PUT /intervention` with `idPrescriptionDrugList` — batch interventions

`tests/integration/test_intervention_multiple.py` (13 tests)

`PUT /intervention` serves two code paths. The single-`idPrescriptionDrug` path (`save_intervention`) is covered in `test_intervention.py`; the batch path (`add_multiple_interventions`) was not covered at all. It is not a loop over the single path — it derives the economy type, the department and the RAM payload once for the whole request and applies them to every intervention it creates, and it never updates an existing record.

Pinned down:

- one intervention per prescribed drug, each pointing at its own `presmed` row, carrying the shared admission number, reason list, error/cost flags and observation, opened with status `s` and no prescription of its own;
- the response carries exactly the interventions that were created;
- the department is copied from the admission's most recent prescription;
- the economy type follows the reason — suspension, substitution and custom economy each map to their own type, an ordinary reason to none — and the economy base date is filled in only when there is an economy type, from the prescription the drug belongs to;
- the RAM payload is stored only when a reason is flagged as RAM (the seed data has no such reason, so the test creates one and removes it again);
- every created intervention gets a `CREATE` audit row recording the economy type;
- a caller without `WRITE_PRESCRIPTION` writes nothing.

## Coverage

| module | before | after |
| --- | --- | --- |
| `services/clinical_notes_service.py` | 69% | 79% |
| `services/intervention_service.py` | 54% | 76% |

## Test isolation

Neither `demo.evolucao` nor `demo.intervencao` is touched by the session-scoped cleanup in `tests/conftest.py`, so each module wipes its own rows in an autouse fixture. The notes module writes to a reserved admission number (190000) that the shared prescription counter cannot reach; the intervention module deletes its interventions, their audit rows and the temporary RAM reason. Both files are re-runnable.

Full suite locally: **2040 passed** (2008 before), `ruff check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKMFkthJ9f2FHwWB2FVrJN)_