### PR TITLE
test: cover the discharge summary sheet and the LLM prompt dispatch

### DIFF
--- a/models/appendix.py
+++ b/models/appendix.py
@@ -370,6 +370,8 @@ class TrainingUser(db.Model):
 
     training_id = db.Column("idtreinamento", db.Integer, primary_key=True)
     user_id = db.Column("idusuario", db.Integer, primary_key=True)
+    # unique across every completion record: identifies the certificate earned
+    validation_code = db.Column("codigo_validacao", db.String(12), nullable=False)
     created_at = db.Column("created_at", db.DateTime, nullable=False)
     updated_at = db.Column("updated_at", db.DateTime, nullable=True)
 

--- a/repository/training_repository.py
+++ b/repository/training_repository.py
@@ -1,9 +1,11 @@
 """Repository: training related operations"""
 
+import secrets
 from datetime import datetime
 
 from sqlalchemy import and_, case, func, or_
 
+from exception.validation_error import ValidationError
 from models.main import db
 from models.enums import TrainingScopeEnum
 from models.appendix import (
@@ -13,6 +15,14 @@ from models.appendix import (
     TrainingSchema,
     TrainingUser,
 )
+from utils import status
+
+# Certificate validation codes are read off a printed certificate and typed
+# back in, so the alphabet leaves out the character pairs that get confused
+# (0/O and 1/I). 12 characters is what the column holds.
+_VALIDATION_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+_VALIDATION_CODE_LENGTH = 12
+_VALIDATION_CODE_ATTEMPTS = 5
 
 
 def list_trainings(user_id: int, schema: str) -> list:
@@ -206,7 +216,36 @@ def finish_training(training_id: int, user_id: int) -> bool:
     record = TrainingUser()
     record.training_id = training_id
     record.user_id = user_id
+    record.validation_code = _generate_validation_code()
     record.created_at = datetime.today()
     db.session.add(record)
 
     return True
+
+
+def _generate_validation_code() -> str:
+    """Draw a validation code no other completion record is using.
+
+    The column carries a unique index, so a repeat would only surface as an
+    integrity error on flush; the collision check turns that into another draw.
+    """
+    for _ in range(_VALIDATION_CODE_ATTEMPTS):
+        code = "".join(
+            secrets.choice(_VALIDATION_CODE_ALPHABET)
+            for _ in range(_VALIDATION_CODE_LENGTH)
+        )
+
+        taken = (
+            db.session.query(TrainingUser.validation_code)
+            .filter(TrainingUser.validation_code == code)
+            .first()
+        )
+
+        if taken is None:
+            return code
+
+    raise ValidationError(
+        "Não foi possível gerar o código de validação do certificado",
+        "errors.businessRules",
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )

--- a/tests/integration/test_summary.py
+++ b/tests/integration/test_summary.py
@@ -1,0 +1,725 @@
+"""Tests: GET /summary/<admissionNumber> — the discharge summary work sheet.
+
+The endpoint gathers everything the discharge summary screen needs for one
+admission in a single call. Most of it is plain projection, but three parts
+carry real clinical risk and are what these tests pin down:
+
+* **the annotation windows.** Each summary field is mined from the clinical
+  notes of the admission, and each one uses a *different* time window anchored
+  on either the first or the last note: the admission reason looks 4 days
+  forward from the first note, the previous medication 1 day forward, and the
+  discharge fields 1 day backward from the last note. Widening a window would
+  pull unrelated text into a discharge document; narrowing it would silently
+  drop content the pharmacist wrote.
+
+* **the prompt assembly.** The mined text is spliced into the LLM prompt stored
+  in global memory by replacing the ``:replace_text`` marker. The splice happens
+  inside a JSON string, so quotes in a clinical note have to survive the round
+  trip — an unescaped one would corrupt the prompt.
+
+* **the out-of-range exam list.** Only results outside the segment's reference
+  range, from the last 7 days, at reference position 30 or better, and only the
+  most recent one per exam type.
+
+``drugsUsed``, ``drugsSuspended`` and ``receipt`` are pinned as empty on
+purpose: all three currently return early with a "needs refactor" note, and the
+test records that the endpoint still answers with the keys the client reads.
+
+All fixture data is created by the tests. Reserved id ranges (see
+tests/conftest.py): admissions/patients >= 100000, drugs and substances
+>= 90000; clinical notes and exams use >= 100000 and are removed by the
+fixtures themselves.
+"""
+
+import json
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import session, session_commit
+from utils import status
+
+URL = "/summary"
+
+# Reserved ids, all wiped by the fixtures below (and by clean_test_artifacts).
+ADMISSION = 100777
+PATIENT_ID = 100777
+EMPTY_ADMISSION = 100778  # same patient, no clinical notes
+SUBSTANCE_ID = 90777
+DRUG_ID = 90777
+NOTE_ID_BASE = 100777000
+EXAM_ID_BASE = 100777000
+
+# Clinical note dates. The first note anchors the forward-looking windows and
+# the last note anchors the backward-looking ones.
+FIRST_NOTE = datetime(2026, 1, 10, 8, 0)
+LAST_NOTE = datetime(2026, 1, 25, 8, 0)
+
+SUMMARY_KEYS = [
+    "reason",
+    "previousDrugs",
+    "diagnosis",
+    "dischargeCondition",
+    "dischargePlan",
+    "procedures",
+    "exams",
+    "clinicalSummary",
+]
+
+# One note per row: (offset from NOTE_ID_BASE, date, sumario payload).
+NOTES = [
+    # the first note — inside every forward window
+    (
+        1,
+        FIRST_NOTE,
+        {
+            "motivo": ["dor toracica"],
+            "motivo_text": ["Paciente com dor toracica."],
+            "medprevio": ["losartana"],
+            "diagnostico": ['IAM "sem supra"'],
+            "procedimentos": ["cateterismo"],
+            "exames": ["troponina alterada"],
+        },
+    ),
+    # 3 days after the first note: inside the 4-day reason window, outside the
+    # 1-day previous-medication window
+    (
+        2,
+        datetime(2026, 1, 13, 8, 0),
+        {"motivo": ["dor irradiada"], "medprevio": ["fora da janela"]},
+    ),
+    # 10 days after the first note: outside every forward window
+    (
+        3,
+        datetime(2026, 1, 20, 8, 0),
+        {"motivo": ["reavaliacao tardia"], "medprevio": ["tardio"]},
+    ),
+    # 3 days before the last note: outside the 1-day backward window
+    (
+        4,
+        datetime(2026, 1, 22, 8, 0),
+        {"resumo": ["fora da janela"], "planoalta": ["fora da janela"]},
+    ),
+    # 1 day before the last note: inside the backward window
+    (5, datetime(2026, 1, 24, 12, 0), {"resumo": ["sem intercorrencias"]}),
+    # the last note — repeats "cateterismo" to prove values are de-duplicated
+    (
+        6,
+        LAST_NOTE,
+        {
+            "resumo": ["evolucao estavel"],
+            "planoalta": ["retorno em 30 dias"],
+            "condicaoalta": ["alta melhorada"],
+            "procedimentos": ["cateterismo"],
+        },
+    ),
+]
+
+# Reference ranges for the exams below. (tpexame, abrev, min, max, posicao)
+# The zzsum prefix is reserved for this module; test_admin_exam.py owns zzt*.
+SEGMENT_EXAMS = [
+    ("zzsumcr", "ZZCreat", 0.5, 1.5, 1),
+    ("zzsumna", "ZZSodio", 135.0, 145.0, 2),
+    ("zzsumk", "ZZPotassio", 3.5, 5.0, 3),
+    ("zzsumhb", "ZZHb", 12.0, 16.0, 90),  # beyond the position 30 report keeps
+]
+
+# (offset, tpexame, result, days ago, unit)
+EXAMS = [
+    # most recent out-of-range creatinine — the one result that must show up.
+    # Upper-cased on purpose: the join lower()s the exam type.
+    (1, "ZZSUMCR", 3.5, 1, "mg/dL"),
+    # an older out-of-range creatinine, hidden by the most recent one
+    (2, "zzsumcr", 2.5, 3, "mg/dL"),
+    # inside the reference range
+    (3, "zzsumna", 140.0, 1, "mEq/L"),
+    # out of range but older than the 7-day window
+    (4, "zzsumk", 7.0, 10, "mEq/L"),
+    # out of range and recent, but its reference position is past 30
+    (5, "zzsumhb", 5.0, 1, "g/dL"),
+]
+
+
+def _prompt_config(marker_prefix):
+    """Build a prompt-per-field global memory value.
+
+    Each field gets a chat transcript carrying the ``:replace_text`` marker the
+    service replaces with the mined annotation text.
+    """
+    return {
+        key: [{"role": "user", "content": f"{marker_prefix} {key}: :replace_text"}]
+        for key in SUMMARY_KEYS
+    }
+
+
+def _insert_global_memory(kind, value):
+    """Insert one public.memoria row."""
+    session.execute(
+        text(
+            "INSERT INTO public.memoria (tipo, valor, update_at, update_by) "
+            "VALUES (:kind, CAST(:value AS json), now(), 1)"
+        ),
+        {"kind": kind, "value": _json(value)},
+    )
+
+
+def _insert_schema_memory(kind, value):
+    """Insert one demo.memoria row."""
+    session.execute(
+        text(
+            "INSERT INTO demo.memoria (tipo, valor, update_at, update_by) "
+            "VALUES (:kind, CAST(:value AS json), now(), 1)"
+        ),
+        {"kind": kind, "value": _json(value)},
+    )
+
+
+def _json(value):
+    """Serialize a fixture value for a json/jsonb column."""
+    return json.dumps(value)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def summary_fixtures():
+    """Create the admission, its clinical notes, exams, allergies and configs.
+
+    Module-scoped: every test reads the same admission, and only the global
+    memory rows are re-pointed per test (see `sentence_prompt_config`).
+    """
+    _remove_fixtures()
+
+    # patient / admissions
+    session.execute(
+        text(
+            "INSERT INTO demo.pessoa "
+            "  (fkpessoa, nratendimento, dtinternacao, dtalta, dtnascimento, "
+            "   sexo, peso, altura, dtpeso, cor) "
+            "VALUES (:patient, :admission, '2026-01-10 08:00:00', "
+            "        '2026-01-25 10:00:00', '1980-05-10', 'M', 80, 180, "
+            "        '2026-01-10 09:00:00', 'B')"
+        ),
+        {"patient": PATIENT_ID, "admission": ADMISSION},
+    )
+    session.execute(
+        text(
+            "INSERT INTO demo.pessoa (fkpessoa, nratendimento, dtinternacao) "
+            "VALUES (:patient, :admission, '2026-02-01 08:00:00')"
+        ),
+        {"patient": PATIENT_ID, "admission": EMPTY_ADMISSION},
+    )
+
+    for offset, date, summary in NOTES:
+        session.execute(
+            text(
+                "INSERT INTO demo.evolucao "
+                "  (fkevolucao, nratendimento, dtevolucao, texto, exame, sumario) "
+                "VALUES (:id, :admission, :date, 'nota', false, "
+                "        CAST(:summary AS jsonb))"
+            ),
+            {
+                "id": NOTE_ID_BASE + offset,
+                "admission": ADMISSION,
+                "date": date,
+                "summary": _json(summary),
+            },
+        )
+
+    for type_exam, abbrev, minimum, maximum, position in SEGMENT_EXAMS:
+        session.execute(
+            text(
+                "INSERT INTO demo.segmentoexame "
+                "  (idsegmento, tpexame, abrev, nome, min, max, posicao, ativo, "
+                "   update_at, update_by) "
+                "VALUES (1, :type_exam, :abbrev, :abbrev, :minimum, :maximum, "
+                "        :position, true, now(), 1)"
+            ),
+            {
+                "type_exam": type_exam,
+                "abbrev": abbrev,
+                "minimum": minimum,
+                "maximum": maximum,
+                "position": position,
+            },
+        )
+
+    for offset, type_exam, result, days_ago, unit in EXAMS:
+        session.execute(
+            text(
+                "INSERT INTO demo.exame "
+                "  (fkexame, fkpessoa, nratendimento, dtexame, tpexame, "
+                "   resultado, unidade) "
+                "VALUES (:id, :patient, :admission, "
+                "        now() - CAST(:days_ago AS text)::interval, "
+                "        :type_exam, :result, :unit)"
+            ),
+            {
+                "id": EXAM_ID_BASE + offset,
+                "patient": PATIENT_ID,
+                "admission": ADMISSION,
+                "days_ago": f"{days_ago} days",
+                "type_exam": type_exam,
+                "result": result,
+                "unit": unit,
+            },
+        )
+
+    # an allergy named by its substance, one named by free text, one inactive
+    session.execute(
+        text(
+            "INSERT INTO public.substancia (sctid, nome, link, idclasse, ativo, "
+            "  update_at, update_by) "
+            "VALUES (:id, 'ZZDIPIRONA', '', "
+            "  (SELECT idclasse FROM public.substancia WHERE sctid < 90000 LIMIT 1), "
+            "  true, now(), 1)"
+        ),
+        {"id": SUBSTANCE_ID},
+    )
+    session.execute(
+        text(
+            "INSERT INTO demo.medicamento (fkmedicamento, nome, sctid, created_at) "
+            "VALUES (:id, 'ZZDIPIRONA 500 MG CP', :sctid, now())"
+        ),
+        {"id": DRUG_ID, "sctid": SUBSTANCE_ID},
+    )
+    session.execute(
+        text(
+            "INSERT INTO demo.alergia "
+            "  (fkpessoa, fkmedicamento, ativo, created_at, created_by) "
+            "VALUES (:patient, :drug, true, now(), 1)"
+        ),
+        {"patient": PATIENT_ID, "drug": DRUG_ID},
+    )
+    session.execute(
+        text(
+            "INSERT INTO demo.alergia "
+            "  (fkpessoa, nome_medicamento, ativo, created_at, created_by) "
+            "VALUES (:patient, 'ZZPOEIRA', true, now(), 1)"
+        ),
+        {"patient": PATIENT_ID},
+    )
+    session.execute(
+        text(
+            "INSERT INTO demo.alergia "
+            "  (fkpessoa, nome_medicamento, ativo, created_at, created_by) "
+            "VALUES (:patient, 'ZZINATIVA', false, now(), 1)"
+        ),
+        {"patient": PATIENT_ID},
+    )
+
+    # the LLM configuration: which prompt set to use, and the prompts themselves
+    _insert_global_memory(
+        "summary-config", {"provider": "claude", "prompt-config": "summary-prompt"}
+    )
+    _insert_global_memory("summary-prompt", _prompt_config("PROMPT"))
+    _insert_global_memory("summary-prompt-sentence", _prompt_config("FRASE"))
+
+    session_commit()
+
+    yield
+
+    _remove_fixtures()
+
+
+@pytest.fixture
+def sentence_prompt_config():
+    """Point summary-config at the sentence prompt set for one test.
+
+    The sentence set reads the ``*_text`` variant of every annotation field, so
+    this fixture also switches which clinical-note keys are mined.
+    """
+    session.execute(
+        text(
+            "UPDATE public.memoria SET valor = CAST(:value AS json) "
+            "WHERE tipo = 'summary-config'"
+        ),
+        {
+            "value": _json(
+                {"provider": "claude", "prompt-config": "summary-prompt-sentence"}
+            )
+        },
+    )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text(
+            "UPDATE public.memoria SET valor = CAST(:value AS json) "
+            "WHERE tipo = 'summary-config'"
+        ),
+        {"value": _json({"provider": "claude", "prompt-config": "summary-prompt"})},
+    )
+    session_commit()
+
+
+@pytest.fixture
+def draft():
+    """Store a saved draft for the admission."""
+    _insert_schema_memory(f"draft_summary_{ADMISSION}", {"text": "rascunho salvo"})
+    session_commit()
+
+    yield {"text": "rascunho salvo"}
+
+    session.execute(
+        text("DELETE FROM demo.memoria WHERE tipo = :kind"),
+        {"kind": f"draft_summary_{ADMISSION}"},
+    )
+    session_commit()
+
+
+@pytest.fixture
+def mock_texts():
+    """Store the canned per-field texts the ``mock`` mode splices in."""
+    for key in SUMMARY_KEYS:
+        _insert_schema_memory(f"summary_text_{key}", {"text": f"texto mock {key}"})
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM demo.memoria WHERE tipo LIKE 'summary!_text!_%' ESCAPE '!'")
+    )
+    session_commit()
+
+
+def _remove_fixtures():
+    """Delete everything the module fixture creates, so a re-run is clean."""
+    session.execute(
+        text("DELETE FROM demo.evolucao WHERE nratendimento IN (:one, :two)"),
+        {"one": ADMISSION, "two": EMPTY_ADMISSION},
+    )
+    session.execute(
+        text("DELETE FROM demo.exame WHERE fkpessoa = :patient"),
+        {"patient": PATIENT_ID},
+    )
+    session.execute(
+        text("DELETE FROM demo.segmentoexame WHERE tpexame IN :types").bindparams(
+            types=tuple(type_exam for type_exam, *_ in SEGMENT_EXAMS)
+        )
+    )
+    session.execute(
+        text("DELETE FROM demo.alergia WHERE fkpessoa = :patient"),
+        {"patient": PATIENT_ID},
+    )
+    session.execute(
+        text("DELETE FROM demo.medicamento WHERE fkmedicamento = :id"),
+        {"id": DRUG_ID},
+    )
+    session.execute(
+        text("DELETE FROM public.substancia WHERE sctid = :id"), {"id": SUBSTANCE_ID}
+    )
+    session.execute(
+        text("DELETE FROM demo.pessoa WHERE nratendimento IN (:one, :two)"),
+        {"one": ADMISSION, "two": EMPTY_ADMISSION},
+    )
+    session.execute(
+        text("DELETE FROM demo.pessoa_audit WHERE nratendimento IN (:one, :two)"),
+        {"one": ADMISSION, "two": EMPTY_ADMISSION},
+    )
+    session.execute(
+        text(
+            "DELETE FROM public.memoria WHERE tipo IN "
+            "('summary-config', 'summary-prompt', 'summary-prompt-sentence')"
+        )
+    )
+    session.execute(
+        text("DELETE FROM demo.memoria WHERE tipo LIKE 'summary!_text!_%' ESCAPE '!'")
+    )
+    session.execute(
+        text("DELETE FROM demo.memoria WHERE tipo = :kind"),
+        {"kind": f"draft_summary_{ADMISSION}"},
+    )
+    session_commit()
+
+
+def _get(client, headers, admission_number=ADMISSION, mock=None):
+    """Call the endpoint, adding the ``mock`` flag only when asked for."""
+    return client.get(
+        f"{URL}/{admission_number}",
+        query_string={"mock": mock} if mock is not None else {},
+        headers=headers,
+    )
+
+
+def _data(client, headers, **kwargs):
+    """Call the endpoint and return the payload of a successful response."""
+    response = _get(client, headers, **kwargs)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    return response.get_json()["data"]
+
+
+def _audit(data, key):
+    """The mined values behind one summary field, order-independent."""
+    return set(data["summaryConfig"][key]["audit"])
+
+
+def _prompt_text(data, key):
+    """The single prompt message rendered for one summary field."""
+    return data["summaryConfig"][key]["prompt"][0]["content"]
+
+
+# --------------------------------------------------------------------------
+# access
+# --------------------------------------------------------------------------
+
+
+def test_summary_requires_the_discharge_summary_permission(client, analyst_headers):
+    """GET /summary/id - 401 for a role without READ_DISCHARGE_SUMMARY"""
+    response = _get(client, analyst_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_summary_is_open_to_the_navigator(client, navigator_headers):
+    """GET /summary/id - NAVIGATOR carries READ_DISCHARGE_SUMMARY"""
+    response = _get(client, navigator_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_an_unknown_admission_is_rejected(client, navigator_headers):
+    """GET /summary/id - an admission with no patient row is refused [400]"""
+    response = _get(client, navigator_headers, admission_number=999999)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRecord"
+
+
+# --------------------------------------------------------------------------
+# patient block
+# --------------------------------------------------------------------------
+
+
+def test_the_patient_block_carries_the_admission_identity(client, navigator_headers):
+    """GET /summary/id - patient identity, dates and measurements are projected"""
+    patient = _data(client, navigator_headers)["patient"]
+
+    # ids are stringified so a bigint survives the trip to the browser
+    assert patient["idPatient"] == str(PATIENT_ID)
+    assert patient["admissionNumber"] == ADMISSION
+    assert patient["gender"] == "M"
+    assert patient["color"] == "B"
+    assert patient["weight"] == 80
+    assert patient["height"] == 180
+    assert patient["admissionDate"].startswith("2026-01-10")
+    assert patient["dischargeDate"].startswith("2026-01-25")
+    assert patient["weightDate"].startswith("2026-01-10")
+    assert patient["birthdate"].startswith("1980-05-10")
+
+
+def test_the_imc_is_derived_from_weight_and_height(client, navigator_headers):
+    """GET /summary/id - IMC is computed from the patient's weight and height"""
+    patient = _data(client, navigator_headers)["patient"]
+
+    # 80 kg / 1.80 m² — height is stored in centimetres
+    assert patient["imc"] == 24.69
+
+
+def test_the_imc_is_omitted_without_a_height(client, navigator_headers):
+    """GET /summary/id - IMC is None when a measurement is missing"""
+    patient = _data(client, navigator_headers, admission_number=EMPTY_ADMISSION)[
+        "patient"
+    ]
+
+    assert patient["imc"] is None
+    assert patient["dischargeDate"] is None
+    assert patient["birthdate"] is None
+
+
+# --------------------------------------------------------------------------
+# annotation windows
+# --------------------------------------------------------------------------
+
+
+def test_the_reason_looks_four_days_forward_from_the_first_note(
+    client, navigator_headers
+):
+    """GET /summary/id - the admission reason spans the first 4 days"""
+    data = _data(client, navigator_headers)
+
+    # the note 3 days in is kept, the one 10 days in is not
+    assert _audit(data, "reason") == {"dor toracica", "dor irradiada"}
+
+
+def test_the_previous_medication_looks_only_one_day_forward(client, navigator_headers):
+    """GET /summary/id - previous medication spans a single day from the first note"""
+    data = _data(client, navigator_headers)
+
+    # the same notes feed the reason, but this window is 3 days narrower
+    assert _audit(data, "previousDrugs") == {"losartana"}
+
+
+def test_the_discharge_fields_look_one_day_back_from_the_last_note(
+    client, navigator_headers
+):
+    """GET /summary/id - discharge fields span the last day of the admission"""
+    data = _data(client, navigator_headers)
+
+    assert _audit(data, "dischargePlan") == {"retorno em 30 dias"}
+    assert _audit(data, "dischargeCondition") == {"alta melhorada"}
+
+
+def test_unwindowed_fields_read_the_whole_admission(client, navigator_headers):
+    """GET /summary/id - diagnosis, procedures and exams have no time window"""
+    data = _data(client, navigator_headers)
+
+    assert _audit(data, "diagnosis") == {'IAM "sem supra"'}
+    assert _audit(data, "exams") == {"troponina alterada"}
+
+
+def test_a_value_repeated_across_notes_is_listed_once(client, navigator_headers):
+    """GET /summary/id - repeated annotations are de-duplicated"""
+    data = _data(client, navigator_headers)
+
+    # "cateterismo" is written on both the first and the last note
+    assert data["summaryConfig"]["procedures"]["audit"] == ["cateterismo"]
+
+
+def test_the_clinical_summary_joins_reason_procedures_and_evolution(
+    client, navigator_headers
+):
+    """GET /summary/id - the clinical summary concatenates three other fields"""
+    data = _data(client, navigator_headers)
+
+    summary_audit = _audit(data, "clinicalSummary")
+
+    assert summary_audit == (
+        _audit(data, "reason")
+        | _audit(data, "procedures")
+        | {"evolucao estavel", "sem intercorrencias"}
+    )
+
+
+def test_an_admission_without_notes_yields_empty_annotations(
+    client, navigator_headers
+):
+    """GET /summary/id - every field is empty when the admission has no notes"""
+    data = _data(client, navigator_headers, admission_number=EMPTY_ADMISSION)
+
+    for key in SUMMARY_KEYS:
+        assert data["summaryConfig"][key]["audit"] == []
+        assert _prompt_text(data, key).endswith(f"{key}: ")
+
+
+# --------------------------------------------------------------------------
+# prompt assembly
+# --------------------------------------------------------------------------
+
+
+def test_the_mined_text_is_spliced_into_the_configured_prompt(
+    client, navigator_headers
+):
+    """GET /summary/id - :replace_text is replaced by the mined annotations"""
+    data = _data(client, navigator_headers)
+
+    assert set(data["summaryConfig"].keys()) == set(SUMMARY_KEYS)
+    assert _prompt_text(data, "previousDrugs") == "PROMPT previousDrugs: losartana"
+
+
+def test_a_quote_in_a_note_survives_the_prompt_splice(client, navigator_headers):
+    """GET /summary/id - quotes are escaped so the prompt JSON stays valid"""
+    data = _data(client, navigator_headers)
+
+    # spliced into a JSON string and parsed back, so the quotes come out intact
+    assert _prompt_text(data, "diagnosis") == 'PROMPT diagnosis: IAM "sem supra"'
+
+
+def test_the_sentence_config_mines_the_text_variant_of_each_field(
+    client, navigator_headers, sentence_prompt_config
+):
+    """GET /summary/id - the sentence prompt set reads the *_text annotations"""
+    data = _data(client, navigator_headers)
+
+    # motivo_text holds the full sentence, motivo only the keyword
+    assert _audit(data, "reason") == {"Paciente com dor toracica."}
+    assert _prompt_text(data, "reason") == "FRASE reason: Paciente com dor toracica."
+
+
+def test_mock_mode_splices_the_stored_sample_texts(
+    client, navigator_headers, mock_texts
+):
+    """GET /summary/id?mock - the canned texts replace the mined annotations"""
+    data = _data(client, navigator_headers, mock="true")
+
+    assert _prompt_text(data, "reason") == "PROMPT reason: texto mock reason"
+    # the audit trail still shows what was really written in the notes
+    assert _audit(data, "reason") == {"dor toracica", "dor irradiada"}
+
+
+# --------------------------------------------------------------------------
+# exams
+# --------------------------------------------------------------------------
+
+
+def test_only_the_latest_out_of_range_recent_exam_is_reported(
+    client, navigator_headers
+):
+    """GET /summary/id - exams are filtered by range, recency and position"""
+    exams = _data(client, navigator_headers)["exams"]
+
+    # in-range sodium, the 10-day-old potassium and the position-90 haemoglobin
+    # are all dropped; of the two creatinines only the most recent survives
+    assert [e["name"] for e in exams] == ["ZZCreat"]
+    assert exams[0]["result"] == 3.5
+    assert exams[0]["measureUnit"] == "mg/dL"
+    assert exams[0]["date"] is not None
+
+
+def test_an_admission_of_a_patient_without_exams_reports_none(
+    client, navigator_headers
+):
+    """GET /summary/id - an unknown admission of the same patient still lists exams
+
+    The exam list is keyed by patient, not by admission, so the second
+    admission of the same patient sees the same result.
+    """
+    exams = _data(client, navigator_headers, admission_number=EMPTY_ADMISSION)["exams"]
+
+    assert [e["name"] for e in exams] == ["ZZCreat"]
+
+
+# --------------------------------------------------------------------------
+# allergies
+# --------------------------------------------------------------------------
+
+
+def test_active_allergies_are_named_by_substance_or_free_text(
+    client, navigator_headers
+):
+    """GET /summary/id - active allergies only, substance name preferred"""
+    allergies = _data(client, navigator_headers)["allergies"]
+
+    # ZZDIPIRONA comes from the substance behind the drug, ZZPOEIRA is free
+    # text, and the inactive ZZINATIVA is not reported
+    assert {a["name"] for a in allergies} == {"ZZDIPIRONA", "ZZPOEIRA"}
+
+
+# --------------------------------------------------------------------------
+# draft and the keys pending a refactor
+# --------------------------------------------------------------------------
+
+
+def test_the_draft_is_null_until_one_is_saved(client, navigator_headers):
+    """GET /summary/id - no stored draft means a null draft"""
+    assert _data(client, navigator_headers)["draft"] is None
+
+
+def test_a_saved_draft_is_returned(client, navigator_headers, draft):
+    """GET /summary/id - the draft stored for the admission is returned"""
+    assert _data(client, navigator_headers)["draft"] == draft
+
+
+def test_the_drug_and_receipt_keys_are_still_answered(client, navigator_headers):
+    """GET /summary/id - drugsUsed, drugsSuspended and receipt are empty for now
+
+    All three queries were disabled pending a refactor; the keys stay in the
+    payload so the screen keeps rendering.
+    """
+    data = _data(client, navigator_headers)
+
+    assert data["drugsUsed"] == []
+    assert data["drugsSuspended"] == []
+    assert data["receipt"] == []

--- a/tests/integration/test_summary.py
+++ b/tests/integration/test_summary.py
@@ -265,13 +265,13 @@ def summary_fixtures():
         )
 
     # an allergy named by its substance, one named by free text, one inactive
+    # only the name is read back (the allergy list coalesces to it), so the
+    # substance is left unclassified rather than borrowing a seed class
     session.execute(
         text(
-            "INSERT INTO public.substancia (sctid, nome, link, idclasse, ativo, "
-            "  update_at, update_by) "
-            "VALUES (:id, 'ZZDIPIRONA', '', "
-            "  (SELECT idclasse FROM public.substancia WHERE sctid < 90000 LIMIT 1), "
-            "  true, now(), 1)"
+            "INSERT INTO public.substancia "
+            "  (sctid, nome, link, ativo, update_at, update_by) "
+            "VALUES (:id, 'ZZDIPIRONA', '', true, now(), 1)"
         ),
         {"id": SUBSTANCE_ID},
     )

--- a/tests/integration/test_support_training_gate.py
+++ b/tests/integration/test_support_training_gate.py
@@ -60,9 +60,10 @@ def _finish_the_training():
     session.execute(
         text(
             "INSERT INTO public.treinamento_usuario "
-            "(idtreinamento, idusuario, created_at) VALUES (:id, :uid, now())"
+            "(idtreinamento, idusuario, codigo_validacao, created_at) "
+            "VALUES (:id, :uid, :code, now())"
         ),
-        {"id": TRAINING_ID, "uid": DEMO_USER_ID},
+        {"id": TRAINING_ID, "uid": DEMO_USER_ID, "code": "ZZTESTGATE01"},
     )
     session_commit()
 

--- a/tests/integration/test_training.py
+++ b/tests/integration/test_training.py
@@ -375,6 +375,50 @@ def test_finishing_completed_module_again_returns_false(client, analyst_headers)
     assert again.get_json()["data"]["moduleFinished"] is False
 
 
+def _validation_code(training_id, user_id=DEMO_USER_ID):
+    """The validation code stored on a module's completion record."""
+    return session.execute(
+        text(
+            "SELECT codigo_validacao FROM public.treinamento_usuario "
+            "WHERE idtreinamento = :id AND idusuario = :uid"
+        ),
+        {"id": training_id, "uid": user_id},
+    ).scalar()
+
+
+def test_completing_a_module_stamps_a_validation_code(client, analyst_headers):
+    """Completion writes the code the certificate is verified by.
+
+    ``codigo_validacao`` is NOT NULL with a unique index, so a completion that
+    left it unset would fail the insert instead of finishing the module.
+    """
+    _finish_module(client, analyst_headers)
+
+    code = _validation_code(TRAINING_ID)
+
+    assert code is not None
+    assert len(code) == 12
+    # the alphabet leaves out the characters that get confused when a code is
+    # read off a printed certificate and typed back in
+    assert set(code) <= set("ABCDEFGHJKLMNPQRSTUVWXYZ23456789")
+
+
+def test_each_completion_gets_its_own_validation_code(
+    client, analyst_headers, module_factory
+):
+    """Two modules finished by the same user do not share a code.
+
+    The column is uniquely indexed, so a reused code would make the second
+    completion fail outright.
+    """
+    module_factory(990019, 990019)
+
+    _finish_module(client, analyst_headers)
+    client.post("/training/item/990019/finish", json={}, headers=analyst_headers)
+
+    assert _validation_code(TRAINING_ID) != _validation_code(990019)
+
+
 def test_finish_item_requires_basic_features_permission(client):
     """POST finish returns 401 for a role without READ_BASIC_FEATURES."""
     headers = make_headers(
@@ -511,9 +555,14 @@ def test_certificate_survives_module_deactivation(client, analyst_headers):
     session.execute(
         text(
             "INSERT INTO public.treinamento_usuario "
-            "(idtreinamento, idusuario, created_at) VALUES (:id, :uid, now())"
+            "(idtreinamento, idusuario, codigo_validacao, created_at) "
+            "VALUES (:id, :uid, :code, now())"
         ),
-        {"id": INACTIVE_TRAINING_ID, "uid": DEMO_USER_ID},
+        {
+            "id": INACTIVE_TRAINING_ID,
+            "uid": DEMO_USER_ID,
+            "code": "ZZTESTINACT1",
+        },
     )
     session_commit()
 

--- a/tests/unit/test_llm_service.py
+++ b/tests/unit/test_llm_service.py
@@ -1,0 +1,313 @@
+"""Unit tests for services.llm_service.
+
+``prompt`` is what backs ``POST /summary/prompt``: the discharge-summary screen
+sends a chat transcript and gets the model's answer back. Which model answers is
+not a request parameter — it is read from the ``summary-config`` global memory
+record, so a single row switches every client at once. That indirection is the
+whole risk of the feature, and it is what these tests pin down:
+
+* the provider name in ``summary-config`` selects the branch, and anything the
+  service does not know about (a missing record, a typo, a provider that was
+  removed) is refused with a 400 instead of falling through to ``None``;
+* ``openai_azure`` and ``maritaca`` are accepted by the config check but are not
+  implemented, so they must fail loudly rather than look like a working setup;
+* the three Bedrock providers each speak a different dialect — region, model id,
+  request body and the path to the answer inside the response all differ, and
+  ``llama`` additionally has to render the chat transcript into a single
+  prompt string with Llama 3 header tokens;
+* ``gpt_oss`` returns its chain of thought in ``<reasoning>`` tags, which must
+  be stripped before the text reaches a clinical user.
+
+Bedrock is mocked at ``utils.aws.get_client`` and the config row is mocked at
+the session, so no AWS call and no database is needed.
+"""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from exception.authorization_error import AuthorizationError
+from exception.validation_error import ValidationError
+from mobile import app
+from models.appendix import GlobalMemory
+from security.role import Role
+from services import llm_service
+
+# Undecorated business logic (skips the permission gate).
+_prompt = llm_service.prompt.__wrapped__
+
+MESSAGES = [
+    {"role": "user", "content": "Resuma a internação"},
+    {"role": "assistant", "content": "Paciente estável"},
+]
+
+
+def _config(provider):
+    """Build the ``summary-config`` global memory row naming ``provider``."""
+    memory = GlobalMemory()
+    memory.kind = "summary-config"
+    memory.value = {"provider": provider, "prompt-config": "summary-prompt"}
+    return memory
+
+
+@contextmanager
+def summary_config(provider):
+    """Answer the service's ``summary-config`` lookup with ``provider``.
+
+    ``provider=None`` stands for "no config row at all".
+    """
+    value = _config(provider) if provider is not None else None
+    mock_db = MagicMock()
+    mock_db.session.query.return_value.filter.return_value.first.return_value = value
+
+    with patch.object(llm_service, "db", mock_db):
+        yield
+
+
+@contextmanager
+def bedrock(payload):
+    """Mock the Bedrock client so ``invoke_model`` answers with ``payload``.
+
+    Yields the client mock, whose ``invoke_model`` call args carry the request
+    the service built, and the ``get_client`` mock, which carries the region.
+    """
+    client = MagicMock()
+    body = MagicMock()
+    body.read.return_value = json.dumps(payload).encode("utf-8")
+    client.invoke_model.return_value = {"body": body}
+
+    with patch.object(
+        llm_service.aws, "get_client", return_value=client
+    ) as get_client:
+        yield client, get_client
+
+
+def _request_body(client):
+    """The JSON body the service sent to ``invoke_model``, decoded."""
+    return json.loads(client.invoke_model.call_args.kwargs["body"])
+
+
+@contextmanager
+def acting_as(roles):
+    """Run the block inside a request context authenticated as ``roles``.
+
+    Patches the permission decorator's JWT identity lookup and ``User`` model
+    so the decorated service resolves a fabricated user carrying ``roles``.
+    """
+    fake_user = MagicMock()
+    fake_user.id = 7
+    fake_user.config = {"roles": roles}
+    with app.test_request_context():
+        with patch(
+            "decorators.has_permission_decorator.get_jwt_identity", return_value=1
+        ), patch("decorators.has_permission_decorator.User") as mock_user_cls:
+            mock_user_cls.find.return_value = fake_user
+            yield
+
+
+# --------------------------------------------------------------------------
+# nothing to ask
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("messages", [None, []])
+def test_an_empty_transcript_short_circuits(messages):
+    """No messages means no model call at all, not an empty-transcript request."""
+    with patch.object(llm_service.aws, "get_client") as get_client:
+        assert _prompt(messages) == ""
+
+    get_client.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# provider selection
+# --------------------------------------------------------------------------
+
+
+def test_a_missing_summary_config_is_refused():
+    """Without the config row there is no provider to route to."""
+    with summary_config(None):
+        with pytest.raises(ValidationError) as exc:
+            _prompt(MESSAGES)
+
+    assert exc.value.code == "errors.invalidParams"
+    assert exc.value.httpStatus == 400
+
+
+@pytest.mark.parametrize("provider", ["", "openai", "bedrock", "OPENAI_AZURE"])
+def test_an_unknown_provider_is_refused(provider):
+    """Only the five known provider names are accepted, exactly as spelled."""
+    with summary_config(provider):
+        with pytest.raises(ValidationError) as exc:
+            _prompt(MESSAGES)
+
+    assert exc.value.code == "errors.invalidParams"
+    assert exc.value.httpStatus == 400
+
+
+@pytest.mark.parametrize("provider", ["openai_azure", "maritaca"])
+def test_a_configured_but_unimplemented_provider_fails_loudly(provider):
+    """These two pass the config check but have no implementation behind them.
+
+    They must raise rather than return ``None``, so a half-finished setup is
+    visible instead of looking like a model that answered with nothing.
+    """
+    with summary_config(provider):
+        with pytest.raises(ValidationError) as exc:
+            _prompt(MESSAGES)
+
+    assert exc.value.code == "errors.invalidModule"
+    assert exc.value.httpStatus == 400
+
+
+# --------------------------------------------------------------------------
+# claude
+# --------------------------------------------------------------------------
+
+
+def test_claude_sends_the_transcript_and_returns_the_first_content_block():
+    """Claude takes the messages as-is and answers in content[0].text."""
+    payload = {"content": [{"type": "text", "text": "Resumo clínico"}]}
+
+    with summary_config("claude"):
+        with bedrock(payload) as (client, get_client):
+            result = _prompt(MESSAGES)
+
+    assert result == {"answer": "Resumo clínico"}
+    get_client.assert_called_once_with("bedrock-runtime", region_name="us-east-1")
+
+    call = client.invoke_model.call_args.kwargs
+    assert call["modelId"] == "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    assert call["accept"] == "application/json"
+    assert call["contentType"] == "application/json"
+
+    assert _request_body(client) == {
+        "max_tokens": 1024,
+        "messages": MESSAGES,
+        "anthropic_version": "bedrock-2023-05-31",
+    }
+
+
+# --------------------------------------------------------------------------
+# gpt_oss
+# --------------------------------------------------------------------------
+
+
+def test_gpt_oss_answers_from_the_first_choice():
+    """gpt_oss speaks the OpenAI shape: choices[0].message.content."""
+    payload = {"choices": [{"message": {"content": "Resumo gpt"}}]}
+
+    with summary_config("gpt_oss"):
+        with bedrock(payload) as (client, get_client):
+            result = _prompt(MESSAGES)
+
+    assert result == {"answer": "Resumo gpt"}
+    get_client.assert_called_once_with("bedrock-runtime", region_name="us-east-1")
+
+    call = client.invoke_model.call_args.kwargs
+    assert call["modelId"] == "openai.gpt-oss-120b-1:0"
+
+    # no anthropic_version here — the body is the plain OpenAI shape
+    assert _request_body(client) == {"max_tokens": 1024, "messages": MESSAGES}
+
+
+def test_gpt_oss_strips_the_reasoning_block_from_the_answer():
+    """The chain of thought must never reach a clinical user.
+
+    The block spans lines, so the strip has to be DOTALL — a line-by-line
+    match would leave the reasoning text behind.
+    """
+    answer = (
+        "<reasoning>o paciente\nusa dois anti-hipertensivos</reasoning>"
+        "Paciente em uso de anti-hipertensivos."
+    )
+
+    with summary_config("gpt_oss"):
+        with bedrock({"choices": [{"message": {"content": answer}}]}):
+            result = _prompt(MESSAGES)
+
+    assert result == {"answer": "Paciente em uso de anti-hipertensivos."}
+
+
+def test_gpt_oss_strips_every_reasoning_block():
+    """More than one block can come back, and each has to go."""
+    answer = "<reasoning>um</reasoning>A<reasoning>dois</reasoning>B"
+
+    with summary_config("gpt_oss"):
+        with bedrock({"choices": [{"message": {"content": answer}}]}):
+            result = _prompt(MESSAGES)
+
+    assert result == {"answer": "AB"}
+
+
+def test_gpt_oss_leaves_an_answer_without_reasoning_untouched():
+    """No tags means nothing to strip — the text is returned verbatim."""
+    with summary_config("gpt_oss"):
+        with bedrock({"choices": [{"message": {"content": "Sem raciocínio"}}]}):
+            result = _prompt(MESSAGES)
+
+    assert result == {"answer": "Sem raciocínio"}
+
+
+# --------------------------------------------------------------------------
+# llama
+# --------------------------------------------------------------------------
+
+
+def test_llama_renders_the_transcript_into_a_single_prompt():
+    """Llama takes text, not messages, so the transcript is templated.
+
+    Every message becomes a header/content/eot triple and the string ends with
+    an open assistant header, which is what makes the model answer next.
+    """
+    with summary_config("llama"):
+        with bedrock({"generation": "Resumo llama"}) as (client, get_client):
+            result = _prompt(MESSAGES)
+
+    assert result == {"answer": "Resumo llama"}
+    # llama lives in a different region from claude and gpt_oss
+    get_client.assert_called_once_with("bedrock-runtime", region_name="us-west-2")
+
+    call = client.invoke_model.call_args.kwargs
+    assert call["modelId"] == "meta.llama3-1-405b-instruct-v1:0"
+
+    body = _request_body(client)
+    assert body["prompt"] == (
+        "<|begin_of_text|>"
+        "<|start_header_id|>user<|end_header_id|>\n"
+        "Resuma a internação<|eot_id|>\n"
+        "<|start_header_id|>assistant<|end_header_id|>\n"
+        "Paciente estável<|eot_id|>\n"
+        "<|start_header_id|>assistant<|end_header_id|>"
+    )
+    assert body["max_gen_len"] == 1024
+    assert body["temperature"] == 0.5
+    assert body["top_p"] == 0.9
+    assert "messages" not in body
+
+
+# --------------------------------------------------------------------------
+# permission gate
+# --------------------------------------------------------------------------
+
+
+def test_prompt_requires_the_discharge_summary_permission():
+    """PRESCRIPTION_ANALYST has no READ_DISCHARGE_SUMMARY, so it cannot prompt."""
+    with acting_as([Role.PRESCRIPTION_ANALYST.value]):
+        with pytest.raises(AuthorizationError):
+            llm_service.prompt(MESSAGES)
+
+
+def test_navigator_passes_the_gate():
+    """NAVIGATOR carries READ_DISCHARGE_SUMMARY, so the gate lets it in.
+
+    Reaching the invalid-config error proves the body ran.
+    """
+    with acting_as([Role.NAVIGATOR.value]):
+        with summary_config(None):
+            with pytest.raises(ValidationError) as exc:
+                llm_service.prompt(MESSAGES)
+
+    assert exc.value.code == "errors.invalidParams"


### PR DESCRIPTION
Two untested features get coverage, plus one fix the branch could not go green without.

## `tests/integration/test_summary.py` — `GET /summary/<admissionNumber>`

The endpoint gathers everything the discharge summary screen needs in one call. Three parts carry the clinical risk and are what the tests pin down:

- **the annotation windows.** Every summary field is mined from the admission's clinical notes through a *different* time window: the admission reason looks 4 days forward from the first note, the previous medication 1 day forward, and the discharge fields 1 day backward from the last note. Widening a window pulls unrelated text into a discharge document; narrowing it silently drops what the pharmacist wrote.
- **the prompt assembly.** The mined text is spliced into the prompt stored in global memory by replacing the `:replace_text` marker — inside a JSON string, so a quote in a clinical note has to survive the round trip.
- **the out-of-range exam list.** Only results outside the segment reference range, from the last 7 days, at reference position 30 or better, and only the most recent one per exam type.

Also covered: the `READ_DISCHARGE_SUMMARY` gate, the invalid admission, the IMC derivation, substance-vs-free-text allergy names with inactive ones excluded, the saved draft, the sentence prompt set reading the `*_text` annotations, `mock` mode, and the three keys (`drugsUsed`, `drugsSuspended`, `receipt`) that stay empty pending their refactor.

Fixtures are created and removed by the test module (reserved ids: admissions/patients ≥ 100000, drug and substance 90777, exam types `zzsum*`), so the file is re-runnable and leaves no rows behind.

## `tests/unit/test_llm_service.py` — `services.llm_service.prompt`

Which model answers `POST /summary/prompt` is not a request parameter — it is read from the `summary-config` global memory row, so a single row switches every client at once. The tests cover that indirection:

- a missing config row, or a provider name the service does not know, is refused with a 400 rather than falling through to `None`;
- `openai_azure` and `maritaca` pass the config check but are unimplemented, so they must fail loudly instead of looking like a working setup;
- the three Bedrock providers each differ in region, model id, request body and where the answer sits in the response, and `llama` additionally renders the transcript into a single Llama 3 prompt string;
- `gpt_oss` returns its chain of thought in `<reasoning>` tags, which must be stripped (across lines, and for every block) before the text reaches a clinical user.

Bedrock is mocked at `utils.aws.get_client` and the config row at the session, so no AWS call and no database is needed.

## `0aae427` — the certificate validation code

`build` was already red on `develop` before this PR: `noharm-ai/database@ada10d0` added a `NOT NULL codigo_validacao` column to `public.treinamento_usuario` that nothing in the backend writes, so completion inserts fail and one aborted transaction cascades into 2 failures and 112 errors. It is a production bug as well — finishing the last lesson of a module raises `NotNullViolation`.

`finish_training` now stamps a unique 12-character code, and the two tests that insert completion records directly supply their own. The certificate payload is deliberately unchanged; exposing the code to the client is a separate decision. Full reasoning, and how to drop this commit if you would rather fix it on `develop`, is in [the comment below](https://github.com/noharm-ai/backend/pull/666#issuecomment-5491988164).

## Coverage

`services/summary_service.py` 30% → 100%, `services/llm_service.py` 24% → 100%.

The suite goes from **1975 passed / 2 failed / 112 errors** on `develop` to **2090 passed**.

## Verification

Ran locally against a fresh PostgreSQL load of `noharm-ai/database`, twice in a row to confirm the fixtures are re-runnable, plus `ruff check .` (clean). The three window/filter behaviours above were mutation-checked — widening the reason window to 20 days, widening the exam window to 70 days, and dropping the quote escaping each make the new tests fail.