### PR TITLE
test: cover the api_endpoint boundary and the prescalc pipeline

### DIFF
--- a/tests/unit/test_api_endpoint_decorator.py
+++ b/tests/unit/test_api_endpoint_decorator.py
@@ -1,0 +1,516 @@
+"""Unit tests for the ``api_endpoint`` decorator.
+
+Every route in the application is wrapped in ``@api_endpoint()``, which owns:
+
+* authentication — ``verify_jwt_in_request`` plus resolving the ``User``;
+* the request schema — ``dbSession.setSchema(user_context.schema)``, the
+  multi-tenancy switch;
+* the transaction — commit on success, rollback on every failure, and running
+  the post-commit callbacks only after a successful commit;
+* the response envelope — ``{"status", "data"}`` on success, ``{"status",
+  "message", "code"}`` on failure, each with its HTTP status;
+* the authorization backstop — a handler that never went through
+  ``@has_permission`` is refused rather than served.
+
+These are unit tests: ``db``, ``dbSession``, ``User`` and the JWT helpers are
+replaced with mocks so each branch can be driven directly, and the decorated
+function is a locally defined handler rather than a real route. The
+``ValidationError`` → HTTP mapping and the schema switch are behaviour clients
+depend on, so they are asserted explicitly.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import g
+from flask_jwt_extended.exceptions import NoAuthorizationError
+from jwt.exceptions import ExpiredSignatureError
+from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
+
+from config import Config
+from decorators import api_endpoint_decorator
+from decorators.api_endpoint_decorator import api_endpoint
+from exception.authorization_error import AuthorizationError
+from exception.validation_error import ValidationError
+from models.enums import NoHarmENV
+from mobile import app
+from utils import post_commit, status
+
+
+class _Model(BaseModel):
+    """Minimal pydantic model, used to produce a real PydanticValidationError."""
+
+    quantity: int
+
+
+def _pydantic_error():
+    """Return a genuine PydanticValidationError instead of a fabricated one."""
+    try:
+        _Model(quantity="not-a-number")
+    except PydanticValidationError as e:
+        return e
+    raise AssertionError("expected pydantic to reject the payload")
+
+
+def _user(id=42, schema="demo"):
+    """Build the user the decorator resolves from the JWT identity."""
+    user = MagicMock()
+    user.id = id
+    user.schema = schema
+    return user
+
+
+def _run(handler, *, user=None, path="/some/endpoint", method="GET", data=None):
+    """Invoke a decorated handler with the decorator's collaborators mocked.
+
+    Returns ``(result, mocks)`` where ``mocks`` exposes ``db``, ``db_session``
+    (the ``dbSession`` schema switcher) and ``logger`` for assertions.
+    """
+    mock_db = MagicMock()
+    mock_db_session = MagicMock()
+    user = _user() if user is None else user
+
+    with app.test_request_context(path=path, method=method, data=data):
+        # every handler under test is expected to have passed the permission
+        # gate; the tests that exercise the backstop clear this explicitly
+        g.permission_test_count = 1
+
+        with patch.object(api_endpoint_decorator, "db", mock_db), patch.object(
+            api_endpoint_decorator, "dbSession", mock_db_session
+        ), patch.object(
+            api_endpoint_decorator, "verify_jwt_in_request"
+        ), patch.object(
+            api_endpoint_decorator, "get_jwt_identity", return_value=1
+        ), patch.object(
+            api_endpoint_decorator, "User"
+        ) as mock_user_cls, patch.object(
+            api_endpoint_decorator.logger, "backend_logger"
+        ) as mock_logger:
+            mock_user_cls.find.return_value = user
+            result = handler()
+
+    return result, MagicMock(db=mock_db, db_session=mock_db_session, logger=mock_logger)
+
+
+# --------------------------------------------------------------------------
+# success path
+# --------------------------------------------------------------------------
+
+
+def test_success_wraps_the_result_in_the_standard_envelope():
+    """A handler's return value is nested under ``data`` with a 200."""
+
+    @api_endpoint()
+    def handler():
+        return {"id": 7}
+
+    result, _ = _run(handler)
+
+    assert result == ({"status": "success", "data": {"id": 7}}, status.HTTP_200_OK)
+
+
+def test_success_commits_and_releases_the_session():
+    """The transaction is committed, then the session is closed and removed."""
+
+    @api_endpoint()
+    def handler():
+        return None
+
+    _, mocks = _run(handler)
+
+    mocks.db.session.commit.assert_called_once()
+    mocks.db.session.close.assert_called_once()
+    mocks.db.session.remove.assert_called_once()
+    mocks.db.session.rollback.assert_not_called()
+
+
+def test_success_sets_the_request_schema():
+    """Multi-tenancy hinges on this: the user's schema drives every query."""
+
+    @api_endpoint()
+    def handler():
+        return None
+
+    _, mocks = _run(handler, user=_user(schema="hospital_x"))
+
+    mocks.db_session.setSchema.assert_called_once_with("hospital_x")
+
+
+def test_the_user_context_is_injected_only_when_the_handler_asks_for_it():
+    """Handlers opt in by declaring ``user_context``; others are called bare."""
+    user = _user(id=99)
+    seen = {}
+
+    @api_endpoint()
+    def wants_context(user_context=None):
+        seen["user_context"] = user_context
+        return None
+
+    _run(wants_context, user=user)
+    assert seen["user_context"] is user
+
+    @api_endpoint()
+    def takes_no_context(**kwargs):
+        seen["kwargs"] = kwargs
+        return None
+
+    _run(takes_no_context, user=user)
+    assert seen["kwargs"] == {}
+
+
+def test_falsy_results_are_still_reported_as_success():
+    """An empty list is a valid payload, not an error."""
+
+    @api_endpoint()
+    def handler():
+        return []
+
+    result, _ = _run(handler)
+
+    assert result == ({"status": "success", "data": []}, status.HTTP_200_OK)
+
+
+# --------------------------------------------------------------------------
+# post-commit callbacks
+# --------------------------------------------------------------------------
+
+
+def test_post_commit_callbacks_run_after_a_successful_commit():
+    """Callbacks registered by the handler fire once the commit lands."""
+    calls = []
+
+    @api_endpoint()
+    def handler():
+        post_commit.on_commit(lambda: calls.append("dispatched"))
+        return None
+
+    _run(handler)
+
+    assert calls == ["dispatched"]
+
+
+def test_post_commit_callbacks_do_not_run_when_the_handler_fails():
+    """On the rollback path the registered side effects must be abandoned."""
+    calls = []
+
+    @api_endpoint()
+    def handler():
+        post_commit.on_commit(lambda: calls.append("dispatched"))
+        raise ValidationError("nope", "errors.businessRules", 400)
+
+    _run(handler)
+
+    assert calls == []
+
+
+# --------------------------------------------------------------------------
+# authorization backstop
+# --------------------------------------------------------------------------
+
+
+def test_a_handler_that_skipped_the_permission_gate_is_refused():
+    """A route whose service is missing ``@has_permission`` returns 401.
+
+    ``permission_test_count`` is bumped by the permission decorator; zero means
+    no permission was ever checked, which is treated as a programming error and
+    refused rather than served.
+    """
+    mock_db = MagicMock()
+
+    @api_endpoint()
+    def handler():
+        return {"leaked": True}
+
+    with app.test_request_context():
+        # deliberately not setting g.permission_test_count
+        with patch.object(api_endpoint_decorator, "db", mock_db), patch.object(
+            api_endpoint_decorator, "dbSession"
+        ), patch.object(api_endpoint_decorator, "verify_jwt_in_request"), patch.object(
+            api_endpoint_decorator, "get_jwt_identity", return_value=1
+        ), patch.object(api_endpoint_decorator, "User") as mock_user_cls, patch.object(
+            api_endpoint_decorator.logger, "backend_logger"
+        ):
+            mock_user_cls.find.return_value = _user()
+            body, http_status = handler()
+
+    assert http_status == status.HTTP_401_UNAUTHORIZED
+    assert body["code"] == "error.authorizationError"
+    # the handler ran, so its work must be rolled back rather than committed
+    mock_db.session.commit.assert_not_called()
+    mock_db.session.rollback.assert_called_once()
+
+
+def test_an_authorization_error_from_the_service_becomes_a_401():
+    """``@has_permission`` raising propagates as the 401 envelope."""
+
+    @api_endpoint()
+    def handler():
+        raise AuthorizationError()
+
+    (body, http_status), mocks = _run(handler)
+
+    assert http_status == status.HTTP_401_UNAUTHORIZED
+    assert body == {
+        "status": "error",
+        "message": "Usuário não autorizado neste recurso",
+        "code": "error.authorizationError",
+    }
+    mocks.db.session.rollback.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# admin endpoints
+# --------------------------------------------------------------------------
+
+
+def test_admin_endpoints_are_blocked_in_production():
+    """``is_admin`` routes are support tooling and must not exist in prod.
+
+    The check runs before ``verify_jwt_in_request``, so no valid token can
+    reach the handler.
+    """
+    called = []
+
+    @api_endpoint(is_admin=True)
+    def handler():
+        called.append(True)
+        return None
+
+    with app.test_request_context():
+        with patch.object(Config, "ENV", NoHarmENV.PRODUCTION.value), patch.object(
+            api_endpoint_decorator, "db"
+        ), patch.object(
+            api_endpoint_decorator, "verify_jwt_in_request"
+        ) as mock_verify, patch.object(
+            api_endpoint_decorator.logger, "backend_logger"
+        ):
+            body, http_status = handler()
+
+    assert http_status == status.HTTP_401_UNAUTHORIZED
+    assert body["code"] == "error.authorizationError"
+    assert called == []
+    mock_verify.assert_not_called()
+
+
+def test_admin_endpoints_are_allowed_outside_production():
+    """The same route is served normally in the non-production environments."""
+
+    @api_endpoint(is_admin=True)
+    def handler():
+        return "ok"
+
+    result, _ = _run(handler)
+
+    assert result == ({"status": "success", "data": "ok"}, status.HTTP_200_OK)
+
+
+# --------------------------------------------------------------------------
+# error mapping
+# --------------------------------------------------------------------------
+
+
+def test_a_validation_error_keeps_its_code_and_http_status():
+    """Business errors are surfaced verbatim so the UI can translate them."""
+
+    @api_endpoint()
+    def handler():
+        raise ValidationError(
+            "Prescrição inexistente",
+            "errors.invalidPrescription",
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    (body, http_status), mocks = _run(handler)
+
+    assert http_status == status.HTTP_400_BAD_REQUEST
+    assert body == {
+        "status": "error",
+        "message": "Prescrição inexistente",
+        "code": "errors.invalidPrescription",
+    }
+    mocks.db.session.rollback.assert_called_once()
+    mocks.db.session.commit.assert_not_called()
+
+
+def test_a_validation_error_can_carry_a_non_400_status():
+    """The status comes from the exception, not from a fixed mapping."""
+
+    @api_endpoint()
+    def handler():
+        raise ValidationError(
+            "Registro em uso", "errors.businessRules", status.HTTP_409_CONFLICT
+        )
+
+    (_, http_status), _ = _run(handler)
+
+    assert http_status == status.HTTP_409_CONFLICT
+
+
+def test_a_pydantic_error_returns_the_field_validations():
+    """Request-model failures return 400 plus the per-field detail."""
+
+    @api_endpoint()
+    def handler():
+        raise _pydantic_error()
+
+    (body, http_status), mocks = _run(handler)
+
+    assert http_status == status.HTTP_400_BAD_REQUEST
+    assert body["status"] == "error"
+    assert body["message"] == "Parâmetros inválidos"
+    assert [v["loc"] for v in body["validations"]] == [("quantity",)]
+    mocks.db.session.rollback.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [NoAuthorizationError("missing token"), ExpiredSignatureError("expired")],
+    ids=["flask_jwt_extended", "pyjwt"],
+)
+def test_jwt_failures_report_an_expired_login(error):
+    """Both JWT exception families map to the same 401 the client acts on."""
+
+    @api_endpoint()
+    def handler():
+        return None
+
+    mock_db = MagicMock()
+    with app.test_request_context():
+        g.permission_test_count = 1
+        with patch.object(api_endpoint_decorator, "db", mock_db), patch.object(
+            api_endpoint_decorator, "dbSession"
+        ), patch.object(
+            api_endpoint_decorator, "verify_jwt_in_request", side_effect=error
+        ), patch.object(api_endpoint_decorator.logger, "backend_logger"):
+            body, http_status = handler()
+
+    assert http_status == status.HTTP_401_UNAUTHORIZED
+    assert body == {
+        "status": "error",
+        "message": "Login expirado",
+        "code": "error.authorizationError",
+    }
+    mock_db.session.rollback.assert_called_once()
+
+
+def test_an_unexpected_exception_does_not_leak_its_message():
+    """Internal failures return a generic 500; the detail only goes to the log."""
+
+    @api_endpoint()
+    def handler():
+        raise RuntimeError("connection to db-primary.internal refused")
+
+    (body, http_status), mocks = _run(handler)
+
+    assert http_status == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert body == {"status": "error", "message": "Ocorreu um erro inesperado"}
+    assert "db-primary.internal" not in json.dumps(body)
+    mocks.db.session.rollback.assert_called_once()
+    mocks.logger.exception.assert_called_once_with(
+        "connection to db-primary.internal refused"
+    )
+
+
+def test_an_unexpected_exception_logs_the_query_string():
+    """GET filters are needed to reproduce timeouts, so they are logged too."""
+
+    @api_endpoint()
+    def handler():
+        raise RuntimeError("timeout")
+
+    _, mocks = _run(handler, path="/prescriptions?idSegment=1&status=s")
+
+    logged = [call.args for call in mocks.logger.error.call_args_list]
+    assert any("idSegment=1&status=s" in str(args) for args in logged)
+
+
+# --------------------------------------------------------------------------
+# download responses
+# --------------------------------------------------------------------------
+
+
+def test_download_headers_are_applied_to_a_raw_response():
+    """File downloads bypass the envelope and carry the given headers."""
+    headers = {
+        "Content-Type": "text/csv",
+        "Content-Disposition": "attachment; filename=report.csv",
+    }
+
+    @api_endpoint(download_headers=headers)
+    def handler():
+        return "id;name\n1;Fulano Beltrano\n"
+
+    response, _ = _run(handler)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.headers["Content-Type"] == "text/csv"
+    assert response.headers["Content-Disposition"] == "attachment; filename=report.csv"
+    # the payload is the handler's own return value, not the success envelope
+    assert response.get_data(as_text=True) == "id;name\n1;Fulano Beltrano\n"
+
+
+def test_a_failing_download_endpoint_still_returns_the_error_envelope():
+    """``download_headers`` only applies to the success path."""
+
+    @api_endpoint(download_headers={"Content-Type": "text/csv"})
+    def handler():
+        raise ValidationError(
+            "Sem dados", "errors.businessRules", status.HTTP_400_BAD_REQUEST
+        )
+
+    (body, http_status), _ = _run(handler)
+
+    assert http_status == status.HTTP_400_BAD_REQUEST
+    assert body["code"] == "errors.businessRules"
+
+
+# --------------------------------------------------------------------------
+# request logging
+# --------------------------------------------------------------------------
+
+
+def test_every_request_logs_a_completion_event():
+    """The ``finally`` block reports the request regardless of the outcome."""
+
+    @api_endpoint()
+    def handler():
+        return None
+
+    _, mocks = _run(handler, path="/some/endpoint", method="GET")
+
+    events = [json.loads(call.args[0]) for call in mocks.logger.warning.call_args_list]
+    complete = [e for e in events if e.get("event") == "request_complete"]
+
+    assert len(complete) == 1
+    assert complete[0]["path"] == "/some/endpoint"
+    assert complete[0]["method"] == "GET"
+    assert complete[0]["schema"] == "demo"
+    assert complete[0]["user"] == 42
+    assert complete[0]["duration_ms"] >= 0
+
+
+def test_a_request_that_failed_before_authentication_logs_an_undefined_user():
+    """With no resolved user the log must not blow up on the missing context."""
+
+    @api_endpoint()
+    def handler():
+        return None
+
+    with app.test_request_context(path="/some/endpoint"):
+        g.permission_test_count = 1
+        with patch.object(api_endpoint_decorator, "db"), patch.object(
+            api_endpoint_decorator, "dbSession"
+        ), patch.object(
+            api_endpoint_decorator,
+            "verify_jwt_in_request",
+            side_effect=NoAuthorizationError("missing token"),
+        ), patch.object(api_endpoint_decorator.logger, "backend_logger") as mock_logger:
+            handler()
+
+    events = [json.loads(call.args[0]) for call in mock_logger.warning.call_args_list]
+    complete = [e for e in events if e.get("event") == "request_complete"]
+
+    assert complete[0]["schema"] == "undefined"
+    assert complete[0]["user"] == "undefined"

--- a/tests/unit/test_post_commit.py
+++ b/tests/unit/test_post_commit.py
@@ -1,0 +1,192 @@
+"""Unit tests for the post-commit callback registry.
+
+Some work must only happen once the request transaction is durably committed —
+dispatching an async event that references rows the worker will read back, for
+instance. ``utils.post_commit`` is the registry for that: services call
+``on_commit(callback)`` during the request, and the two transaction owners
+(``api_endpoint`` and ``execute_with_static_context``) call
+``run_post_commit_callbacks()`` immediately after a successful commit.
+
+The registry lives on Flask's ``g``, so it is request-scoped: a rollback
+discards the request context and the callbacks simply never run. These tests
+pin that contract down, plus the guarantee that a callback blowing up cannot
+turn an already-committed transaction into a failed request.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from flask import g
+
+from mobile import app
+from utils import post_commit
+
+
+@pytest.fixture
+def request_context():
+    """Run each test inside its own request context (its own ``g``)."""
+    with app.test_request_context():
+        yield
+
+
+# --------------------------------------------------------------------------
+# registration
+# --------------------------------------------------------------------------
+
+
+def test_run_without_any_callback_is_a_noop(request_context):
+    """A request that registered nothing must not fail on the run call."""
+    post_commit.run_post_commit_callbacks()
+
+
+def test_on_commit_creates_the_registry_on_first_use(request_context):
+    """``g`` starts clean; the first ``on_commit`` seeds the list."""
+    assert not hasattr(g, "post_commit_callbacks")
+
+    def callback():
+        pass
+
+    post_commit.on_commit(callback)
+
+    assert g.post_commit_callbacks == [callback]
+
+
+def test_callbacks_run_in_registration_order(request_context):
+    """Order matters: services may register dependent side effects."""
+    calls = []
+
+    post_commit.on_commit(lambda: calls.append("first"))
+    post_commit.on_commit(lambda: calls.append("second"))
+    post_commit.on_commit(lambda: calls.append("third"))
+
+    post_commit.run_post_commit_callbacks()
+
+    assert calls == ["first", "second", "third"]
+
+
+def test_the_same_callback_registered_twice_runs_twice(request_context):
+    """No de-duplication: two registrations mean two side effects."""
+    calls = []
+
+    def callback():
+        calls.append(1)
+
+    post_commit.on_commit(callback)
+    post_commit.on_commit(callback)
+
+    post_commit.run_post_commit_callbacks()
+
+    assert calls == [1, 1]
+
+
+# --------------------------------------------------------------------------
+# draining
+# --------------------------------------------------------------------------
+
+
+def test_the_registry_is_drained_after_running(request_context):
+    """Callbacks fire exactly once, even if the run is called again."""
+    calls = []
+    post_commit.on_commit(lambda: calls.append(1))
+
+    post_commit.run_post_commit_callbacks()
+    post_commit.run_post_commit_callbacks()
+
+    assert calls == [1]
+    assert g.post_commit_callbacks == []
+
+
+def test_a_callback_registering_another_one_defers_it(request_context):
+    """The registry is swapped out before the run, so a nested registration
+    lands in the next batch instead of extending the current one."""
+    calls = []
+
+    def outer():
+        calls.append("outer")
+        post_commit.on_commit(lambda: calls.append("nested"))
+
+    post_commit.on_commit(outer)
+    post_commit.run_post_commit_callbacks()
+
+    # the nested callback did not run in this pass, but is queued
+    assert calls == ["outer"]
+    assert len(g.post_commit_callbacks) == 1
+
+    post_commit.run_post_commit_callbacks()
+
+    assert calls == ["outer", "nested"]
+
+
+# --------------------------------------------------------------------------
+# failure isolation — the transaction is already committed
+# --------------------------------------------------------------------------
+
+
+def test_a_failing_callback_does_not_propagate(request_context):
+    """The commit already happened, so a callback error cannot fail the request."""
+
+    def boom():
+        raise RuntimeError("sqs unavailable")
+
+    post_commit.on_commit(boom)
+
+    with patch.object(post_commit.logger, "backend_logger") as mock_logger:
+        post_commit.run_post_commit_callbacks()
+
+    mock_logger.exception.assert_called_once_with("post-commit callback failed")
+
+
+def test_a_failing_callback_does_not_stop_the_remaining_ones(request_context):
+    """Each callback is independent: one failure must not swallow the others."""
+    calls = []
+
+    def boom():
+        raise RuntimeError("sqs unavailable")
+
+    post_commit.on_commit(lambda: calls.append("before"))
+    post_commit.on_commit(boom)
+    post_commit.on_commit(lambda: calls.append("after"))
+
+    with patch.object(post_commit.logger, "backend_logger"):
+        post_commit.run_post_commit_callbacks()
+
+    assert calls == ["before", "after"]
+
+
+def test_a_failing_callback_is_still_drained(request_context):
+    """A failed callback is not retried on the next run."""
+
+    def boom():
+        raise RuntimeError("sqs unavailable")
+
+    post_commit.on_commit(boom)
+
+    with patch.object(post_commit.logger, "backend_logger") as mock_logger:
+        post_commit.run_post_commit_callbacks()
+        post_commit.run_post_commit_callbacks()
+
+    assert mock_logger.exception.call_count == 1
+
+
+# --------------------------------------------------------------------------
+# request scoping
+# --------------------------------------------------------------------------
+
+
+def test_callbacks_do_not_leak_between_requests():
+    """``g`` is per-request, so an unrun callback dies with its request.
+
+    This is what makes the rollback path safe: the transaction owner only calls
+    the runner after a successful commit, and anything registered during a
+    failed request is discarded with the context.
+    """
+    calls = []
+
+    with app.test_request_context():
+        post_commit.on_commit(lambda: calls.append("abandoned"))
+        # request ends without the runner ever being called (rollback path)
+
+    with app.test_request_context():
+        post_commit.run_post_commit_callbacks()
+
+    assert calls == []

--- a/tests/unit/test_prescription_agg_service.py
+++ b/tests/unit/test_prescription_agg_service.py
@@ -1,0 +1,1376 @@
+"""Unit tests for the prescription-aggregation (prescalc) service.
+
+NoHarm's work queue is built on *aggregated prescriptions* — one synthetic
+"prescription-day" row per admission/segment/date that rolls up every
+individual prescription the hospital sent for that day. ``prescalc`` is the
+pipeline that keeps those rows in sync, and it is entered two ways:
+
+* ``create_agg_prescription_by_prescription`` — one individual prescription
+  arrived (the classic flow);
+* ``create_agg_prescription_by_date`` — an admission/date pair changed (the
+  CPOE flow, where items carry their own validity period).
+
+Both share the delicate parts: an advisory lock that serializes concurrent runs
+for the same admission, an idempotency check so an already-processed
+prescription is not recomputed, the ``gen_agg_id`` derivation, the score
+variation against the previous day, and — most consequential clinically —
+deciding whether a pharmacist's *check* survives the recalculation or has to be
+withdrawn because the item list changed underneath it.
+
+These are unit tests. ``db`` is replaced with a fake session (``query()`` walks
+a queue of rows, ``add()`` is recorded) and every collaborating service and
+repository is patched, so each branch can be driven directly without the
+regulation/CPOE fixtures the integration suite would need. Real SQLAlchemy
+model instances are used as the rows, so the services' attribute writes are
+exercised for real.
+"""
+
+import json
+from contextlib import ExitStack, contextmanager
+from datetime import date, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from exception.validation_error import ValidationError
+from models.enums import (
+    DrugTypeEnum,
+    PatientConciliationStatusEnum,
+    PrescriptionAuditTypeEnum,
+    PrescriptionDrugAuditTypeEnum,
+)
+from models.main import User
+from models.prescription import Patient, Prescription, PrescriptionAudit
+from services import prescription_agg_service
+from utils import prescriptionutils
+
+# Undecorated business logic (skips the permission gate).
+_create_by_prescription = (
+    prescription_agg_service.create_agg_prescription_by_prescription.__wrapped__
+)
+_create_by_date = prescription_agg_service.create_agg_prescription_by_date.__wrapped__
+
+SCHEMA = "demo"
+ADMISSION = 100001
+
+
+# --------------------------------------------------------------------------
+# fakes
+# --------------------------------------------------------------------------
+
+
+class _FakeQuery:
+    """Query stub: any filter/order chain resolves to the next queued row."""
+
+    def __init__(self, queue):
+        self._queue = queue
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._queue.pop(0) if self._queue else None
+
+
+def _fake_db(rows=()):
+    """Build a fake ``db``: ``query().…first()`` pops ``rows`` in order.
+
+    ``session.added`` records everything handed to ``session.add`` so tests can
+    assert on the inserted agg prescriptions and audit rows.
+    """
+    fake_db = MagicMock()
+    fake_db.session.added = []
+    fake_db.session.add.side_effect = fake_db.session.added.append
+
+    queue = list(rows)
+    fake_db.session.query.side_effect = lambda *a, **k: _FakeQuery(queue)
+    fake_db.session.row_queue = queue
+
+    return fake_db
+
+
+def _user(id=1, schema=SCHEMA):
+    """Build the ``user_context`` the service passes down to the view layer."""
+    user = User()
+    user.id = id
+    user.schema = schema
+    return user
+
+
+def _prescription(
+    *,
+    id=100100,
+    admission_number=ADMISSION,
+    id_patient=55,
+    id_segment=1,
+    p_date=None,
+    status=0,
+    concilia=None,
+    features=None,
+    id_department=7,
+):
+    """Build an individual Prescription row in a known state."""
+    prescription = Prescription()
+    prescription.id = id
+    prescription.admissionNumber = admission_number
+    prescription.idPatient = id_patient
+    prescription.idSegment = id_segment
+    prescription.idHospital = 1
+    prescription.idDepartment = id_department
+    prescription.date = p_date if p_date is not None else datetime(2026, 3, 10, 8, 0)
+    prescription.status = status
+    prescription.concilia = concilia
+    prescription.features = features
+    prescription.bed = "101-A"
+    prescription.record = "REC-1"
+    prescription.specialty = "Clínica Médica"
+    prescription.insurance = "SUS"
+    return prescription
+
+
+def _features(**overrides):
+    """Build the feature payload ``prescriptionutils.getFeatures`` returns."""
+    features = {
+        "drugIDs": [11, 22],
+        "departmentList": [7],
+        "globalScore": 40,
+        "totalItens": 3,
+    }
+    features.update(overrides)
+    return features
+
+
+DEFAULT_VARIATION = {
+    "variation": 100,
+    "currentGlobalScore": 40,
+    "previousGlobalScore": 0,
+}
+
+
+@contextmanager
+def prescalc_env(
+    *,
+    rows=(),
+    features=None,
+    lock_acquired=True,
+    processed_status="NEW_PRESCRIPTION",
+    is_cpoe=False,
+    out_patient=False,
+    drug_count=1,
+    last_check_data=None,
+    has_feature=False,
+    outpatient_processed_status="PENDING",
+    internal_prescription_ids=(100100,),
+):
+    """Patch every prescalc collaborator and yield the mocks under test.
+
+    Only the service's own decision logic is left real: the fake ``db``, the
+    repository lookups, the view/feature helpers and the check service are all
+    controlled from here so each branch can be reached deterministically.
+    """
+    fake_db = _fake_db(rows)
+    features = _features() if features is None else features
+    mocks = SimpleNamespace(db=fake_db)
+
+    module = prescription_agg_service
+    with ExitStack() as stack:
+        p = stack.enter_context
+
+        p(patch.object(module, "db", fake_db))
+        p(patch.object(module, "_set_schema"))
+        mocks.logger = p(patch.object(module.logger, "backend_logger"))
+
+        mocks.acquire_lock = p(
+            patch.object(
+                module.prescalc_repository,
+                "acquire_admission_lock",
+                return_value=lock_acquired,
+            )
+        )
+        mocks.get_processed_status = p(
+            patch.object(
+                module.prescalc_repository,
+                "get_processed_status",
+                return_value=processed_status,
+            )
+        )
+        mocks.get_processed_outpatient_status = p(
+            patch.object(
+                module.prescalc_repository,
+                "get_processed_outpatient_status",
+                return_value=outpatient_processed_status,
+            )
+        )
+        mocks.get_last_check_data = p(
+            patch.object(
+                module.prescalc_repository,
+                "get_last_check_data",
+                return_value=last_check_data,
+            )
+        )
+
+        mocks.is_cpoe = p(
+            patch.object(module.segment_service, "is_cpoe", return_value=is_cpoe)
+        )
+        mocks.has_feature_nouser = p(
+            patch.object(
+                module.memory_service, "has_feature_nouser", return_value=out_patient
+            )
+        )
+        mocks.has_feature = p(
+            patch.object(
+                module.feature_service, "has_feature", return_value=has_feature
+            )
+        )
+        mocks.static_get_prescription = p(
+            patch.object(
+                module.prescription_view_service,
+                "static_get_prescription",
+                return_value={"data": "irrelevant"},
+            )
+        )
+        mocks.get_features = p(
+            patch.object(
+                module.prescriptionutils, "getFeatures", return_value=features
+            )
+        )
+        mocks.get_internal_prescription_ids = p(
+            patch.object(
+                module.prescriptionutils,
+                "get_internal_prescription_ids",
+                return_value=list(internal_prescription_ids),
+            )
+        )
+        mocks.count_drugs = p(
+            patch.object(
+                module.prescription_drug_service,
+                "count_drugs_by_prescription",
+                return_value=drug_count,
+            )
+        )
+        mocks.audit_check = p(
+            patch.object(module.prescription_check_service, "audit_check")
+        )
+        mocks.check_prescription = p(
+            patch.object(module.prescription_check_service, "check_prescription")
+        )
+
+        mocks.score_variation = p(
+            patch.object(
+                module, "_get_score_variation", return_value=dict(DEFAULT_VARIATION)
+            )
+        )
+        mocks.log_processed_date = p(patch.object(module, "_log_processed_date"))
+        mocks.update_conciliation = p(
+            patch.object(module, "_update_patient_conciliation_status")
+        )
+
+        yield mocks
+
+
+def _logged_events(mock_logger):
+    """Collect the JSON log payloads the service emitted."""
+    events = []
+    for call in mock_logger.warning.call_args_list:
+        if not call.args:
+            continue
+        try:
+            events.append(json.loads(call.args[0]))
+        except (TypeError, ValueError):
+            continue
+    return events
+
+
+def _added(mocks, model):
+    """Return the rows of ``model`` handed to ``session.add``."""
+    return [row for row in mocks.db.session.added if isinstance(row, model)]
+
+
+# --------------------------------------------------------------------------
+# create_agg_prescription_by_prescription — guards
+# --------------------------------------------------------------------------
+
+
+def test_by_prescription_unknown_id_is_rejected():
+    """An id with no matching prescription raises a 400 ValidationError."""
+    with prescalc_env(rows=[None]):
+        with pytest.raises(ValidationError) as exc:
+            _create_by_prescription(
+                schema=SCHEMA, id_prescription=404, user_context=_user()
+            )
+
+    assert exc.value.code == "errors.invalidPrescription"
+    assert exc.value.httpStatus == 400
+
+
+def test_by_prescription_without_a_segment_is_skipped():
+    """A prescription the integration has not segmented yet cannot be rolled up."""
+    prescription = _prescription(id_segment=None)
+
+    with prescalc_env(rows=[prescription]) as mocks:
+        result = _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    assert result is None
+    # bailing out before the lock keeps the admission free for the real flow
+    mocks.acquire_lock.assert_not_called()
+
+
+def test_by_prescription_rejects_a_cpoe_segment():
+    """CPOE admissions must go through the by-date entry point instead."""
+    prescription = _prescription()
+
+    with prescalc_env(rows=[prescription], is_cpoe=True):
+        with pytest.raises(ValidationError) as exc:
+            _create_by_prescription(
+                schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+            )
+
+    assert exc.value.code == "errors.businessRules"
+
+
+def test_by_prescription_allows_a_conciliation_on_a_cpoe_segment():
+    """Conciliations are the documented exception to the CPOE rule."""
+    prescription = _prescription(concilia="s")
+
+    with prescalc_env(rows=[prescription], is_cpoe=True) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    assert prescription.features == _features()
+    mocks.acquire_lock.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# create_agg_prescription_by_prescription — concurrency and idempotency
+# --------------------------------------------------------------------------
+
+
+def test_by_prescription_skips_when_the_admission_lock_is_held():
+    """A concurrent prescalc run for the same admission wins; this one skips.
+
+    Items stay unmarked, so the next prescalc event reprocesses them as
+    NEW_ITENS — nothing is lost by giving up here.
+    """
+    prescription = _prescription()
+
+    with prescalc_env(rows=[prescription], lock_acquired=False) as mocks:
+        result = _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    assert result is None
+    mocks.static_get_prescription.assert_not_called()
+    mocks.log_processed_date.assert_not_called()
+
+    events = _logged_events(mocks.logger)
+    assert [e["event"] for e in events] == ["prescalc_lock_timeout"]
+    assert events[0]["admission_number"] == ADMISSION
+    assert events[0]["id_prescription"] == prescription.id
+
+
+def test_by_prescription_locks_on_the_admission_copied_before_the_call():
+    """The lock key is read off the row first: a timeout expires the instance."""
+    prescription = _prescription()
+
+    with prescalc_env(rows=[prescription], lock_acquired=False) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    mocks.acquire_lock.assert_called_once_with(
+        schema=SCHEMA, admission_number=ADMISSION
+    )
+
+
+def test_by_prescription_skips_an_already_processed_prescription():
+    """Idempotency: processed items with computed features are not redone."""
+    prescription = _prescription(features=_features())
+
+    with prescalc_env(
+        rows=[prescription], processed_status="PROCESSED"
+    ) as mocks:
+        result = _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    assert result is None
+    mocks.static_get_prescription.assert_not_called()
+    assert [e["message"] for e in _logged_events(mocks.logger)] == [
+        "Prescrição já foi processada"
+    ]
+
+
+def test_by_prescription_force_reprocesses_an_already_processed_prescription():
+    """``force`` is the support escape hatch for a bad earlier calculation."""
+    prescription = _prescription(features=_features())
+
+    with prescalc_env(
+        rows=[prescription, None], processed_status="PROCESSED"
+    ) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA,
+            id_prescription=prescription.id,
+            user_context=_user(),
+            force=True,
+        )
+
+    assert mocks.static_get_prescription.called
+    mocks.log_processed_date.assert_called_once()
+
+
+def test_by_prescription_reprocesses_when_features_were_never_computed():
+    """A PROCESSED row with no features is a failed run, so it is redone."""
+    prescription = _prescription(features=None)
+
+    with prescalc_env(
+        rows=[prescription, None], processed_status="PROCESSED"
+    ) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    assert mocks.static_get_prescription.called
+
+
+# --------------------------------------------------------------------------
+# create_agg_prescription_by_prescription — conciliation short-circuit
+# --------------------------------------------------------------------------
+
+
+def test_by_prescription_conciliation_updates_itself_and_stops():
+    """A conciliation carries its own features and never joins an agg row."""
+    prescription = _prescription(concilia="s")
+
+    with prescalc_env(rows=[prescription]) as mocks:
+        result = _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    assert result is None
+    assert prescription.features == _features()
+    assert prescription.aggDrugs == [11, 22]
+    assert prescription.aggDeps == [prescription.idDepartment]
+
+    # no agg prescription and no audit row were created
+    assert mocks.db.session.added == []
+    mocks.log_processed_date.assert_not_called()
+    mocks.db.session.flush.assert_called_once()
+
+
+def test_by_prescription_marks_the_conciliation_on_the_patient():
+    """The patient's conciliation status is advanced for a conciliation row."""
+    prescription = _prescription(concilia="s")
+
+    with prescalc_env(rows=[prescription]) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    mocks.update_conciliation.assert_called_once_with(
+        admission_number=ADMISSION, is_concilia=True
+    )
+
+
+# --------------------------------------------------------------------------
+# create_agg_prescription_by_prescription — building the agg prescription
+# --------------------------------------------------------------------------
+
+
+def test_by_prescription_creates_the_agg_prescription_with_the_derived_id():
+    """A missing agg row is inserted under the id ``gen_agg_id`` derives."""
+    prescription = _prescription(p_date=datetime(2026, 3, 10, 8, 0))
+    expected_id = prescriptionutils.gen_agg_id(
+        prescription.admissionNumber, prescription.idSegment, prescription.date
+    )
+
+    with prescalc_env(rows=[prescription, None]) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    agg = _added(mocks, Prescription)[0]
+    assert agg.id == expected_id
+    assert agg.admissionNumber == ADMISSION
+    assert agg.idPatient == prescription.idPatient
+    assert agg.date == prescription.date
+    assert agg.agg is True
+    assert agg.prescriber == "Prescrição Agregada"
+    # the header fields are mirrored from the individual prescription
+    assert agg.idSegment == prescription.idSegment
+    assert agg.idDepartment == prescription.idDepartment
+    assert agg.bed == prescription.bed
+    assert agg.record == prescription.record
+    assert agg.specialty == prescription.specialty
+    assert agg.insurance == prescription.insurance
+
+
+def test_by_prescription_audits_a_newly_created_agg_prescription():
+    """The insert is recorded as a CREATE_AGG audit event."""
+    prescription = _prescription()
+
+    with prescalc_env(rows=[prescription, None]) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    audits = _added(mocks, PrescriptionAudit)
+    assert len(audits) == 1
+    assert audits[0].auditType == PrescriptionAuditTypeEnum.CREATE_AGG.value
+    assert audits[0].admissionNumber == ADMISSION
+    assert audits[0].createdBy == 0
+
+
+def test_by_prescription_reuses_an_existing_agg_prescription():
+    """A second prescription for the same day updates the existing row."""
+    prescription = _prescription()
+    existing_agg = _prescription(id=999, status=0)
+
+    with prescalc_env(rows=[prescription, existing_agg]) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    # nothing inserted: neither a prescription nor a CREATE_AGG audit
+    assert mocks.db.session.added == []
+    assert existing_agg.features["scoreVariation"] == DEFAULT_VARIATION
+
+
+def test_by_prescription_stores_the_features_and_score_variation():
+    """The agg row carries the rolled-up features plus the day-over-day delta."""
+    prescription = _prescription()
+    features = _features(drugIDs=[3, 4], departmentList=[7, 9])
+
+    with prescalc_env(rows=[prescription, None], features=features) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    agg = _added(mocks, Prescription)[0]
+    assert agg.features["scoreVariation"] == DEFAULT_VARIATION
+    assert agg.aggDrugs == [3, 4]
+    assert agg.aggDeps == [7, 9]
+
+    # intervals are resolved against the agg date for this flow
+    _, kwargs = mocks.get_features.call_args
+    assert kwargs["agg_date"] == agg.date
+    assert kwargs["intervals_for_agg_date"] is True
+
+
+def test_by_prescription_marks_the_items_as_processed():
+    """The run ends by stamping PROCESSED on the prescription's items."""
+    prescription = _prescription()
+
+    with prescalc_env(rows=[prescription, None]) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    mocks.log_processed_date.assert_called_once_with(
+        id_prescription_array=[prescription.id], schema=SCHEMA
+    )
+
+
+# --------------------------------------------------------------------------
+# create_agg_prescription_by_prescription — which day the items land on
+# --------------------------------------------------------------------------
+
+
+def test_new_items_on_a_recent_prescription_land_on_today():
+    """Items added to yesterday's prescription belong to today's work queue."""
+    yesterday = datetime.today() - timedelta(days=1)
+    prescription = _prescription(p_date=yesterday)
+
+    with prescalc_env(rows=[prescription, None], processed_status="NEW_ITENS") as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    agg = _added(mocks, Prescription)[0]
+    assert agg.date == datetime.today().date()
+
+
+def test_new_items_on_an_older_prescription_keep_the_original_date():
+    """A backfill for an old prescription must not pollute today's queue."""
+    prescription = _prescription(p_date=datetime.today() - timedelta(days=5))
+
+    with prescalc_env(rows=[prescription, None], processed_status="NEW_ITENS") as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    agg = _added(mocks, Prescription)[0]
+    assert agg.date == prescription.date
+
+
+def test_a_new_prescription_always_keeps_its_own_date():
+    """The today-shift only applies to NEW_ITENS, not to a first calculation."""
+    prescription = _prescription(p_date=datetime.today() - timedelta(days=1))
+
+    with prescalc_env(
+        rows=[prescription, None], processed_status="NEW_PRESCRIPTION"
+    ) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    agg = _added(mocks, Prescription)[0]
+    assert agg.date == prescription.date
+
+
+def test_primary_care_aggregates_per_admission_instead_of_per_day():
+    """Outpatient tenants keep one agg row per admission, keyed by its number."""
+    prescription = _prescription(p_date=datetime(2026, 3, 10, 8, 0))
+
+    with prescalc_env(rows=[prescription, None], out_patient=True) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    agg = _added(mocks, Prescription)[0]
+    assert agg.id == ADMISSION
+    # the timestamp is truncated to a plain date for this flow
+    assert agg.date == date(2026, 3, 10)
+
+
+# --------------------------------------------------------------------------
+# create_agg_prescription_by_prescription — the pharmacist's check
+# --------------------------------------------------------------------------
+
+
+def test_a_changed_item_count_withdraws_the_check_from_both_rows():
+    """New items invalidate the review, so both checks are withdrawn.
+
+    This is the clinically important branch: a pharmacist checked the
+    prescription, then items changed, so the check must not stand.
+    """
+    prescription = _prescription(status="s")
+    existing_agg = _prescription(id=999, status="s")
+    last_check = SimpleNamespace(PrescriptionAudit=SimpleNamespace(totalItens=2))
+
+    with prescalc_env(
+        rows=[prescription, existing_agg],
+        drug_count=5,
+        last_check_data=last_check,
+    ) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    assert existing_agg.status == 0
+    assert prescription.status == 0
+    assert prescription.user is None
+
+    audited = [call.kwargs["prescription"] for call in mocks.audit_check.call_args_list]
+    assert audited == [existing_agg, prescription]
+    # the audit is attributed to the prescalc service user, not a person
+    assert all(call.kwargs["user"].id == 0 for call in mocks.audit_check.call_args_list)
+    assert mocks.audit_check.call_args_list[0].kwargs["extra"]["prescalc"] is True
+
+
+def test_an_unchanged_item_count_keeps_the_existing_check():
+    """Recalculating the same items must not undo a pharmacist's review."""
+    prescription = _prescription(status="s")
+    existing_agg = _prescription(id=999, status="s")
+    last_check = SimpleNamespace(PrescriptionAudit=SimpleNamespace(totalItens=3))
+
+    with prescalc_env(
+        rows=[prescription, existing_agg],
+        drug_count=3,
+        last_check_data=last_check,
+    ) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    assert existing_agg.status == "s"
+    assert prescription.status == "s"
+    mocks.audit_check.assert_not_called()
+
+
+def test_a_new_agg_prescription_inherits_an_unchanged_check():
+    """A first agg row for an already-checked prescription starts checked.
+
+    The DB trigger inserts it as unchecked, so the service writes the status
+    back explicitly.
+    """
+    prescription = _prescription(status="s")
+    last_check = SimpleNamespace(PrescriptionAudit=SimpleNamespace(totalItens=3))
+
+    with prescalc_env(
+        rows=[prescription, None], drug_count=3, last_check_data=last_check
+    ) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    agg = _added(mocks, Prescription)[0]
+    assert agg.status == "s"
+    assert prescription.status == "s"
+
+    extra = mocks.audit_check.call_args.kwargs["extra"]
+    assert extra["is_new_prescription"] is True
+    assert extra["prescalc_source"] == prescription.id
+
+
+def test_no_check_is_touched_when_the_prescription_has_no_validated_items():
+    """Diets and materials alone do not carry a check to withdraw."""
+    prescription = _prescription(status="s")
+    existing_agg = _prescription(id=999, status="s")
+
+    with prescalc_env(
+        rows=[prescription, existing_agg], drug_count=0
+    ) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    assert existing_agg.status == "s"
+    assert prescription.status == "s"
+    mocks.audit_check.assert_not_called()
+
+
+def test_the_check_count_ignores_diets_and_materials():
+    """Only drugs, solutions and procedures are validated by a pharmacist."""
+    prescription = _prescription(status="s")
+
+    with prescalc_env(rows=[prescription, None]) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    drug_types = mocks.count_drugs.call_args.kwargs["drug_types"]
+    assert drug_types == [
+        DrugTypeEnum.DRUG.value,
+        DrugTypeEnum.PROCEDURE.value,
+        DrugTypeEnum.SOLUTION.value,
+    ]
+    assert DrugTypeEnum.DIET.value not in drug_types
+    assert DrugTypeEnum.MATERIAL.value not in drug_types
+
+
+def test_a_checked_agg_row_is_withdrawn_when_new_items_arrive():
+    """An unchecked prescription with new items still unchecks the agg row."""
+    prescription = _prescription(status=0)
+    existing_agg = _prescription(id=999, status="s")
+
+    with prescalc_env(
+        rows=[prescription, existing_agg], processed_status="NEW_ITENS"
+    ) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA, id_prescription=prescription.id, user_context=_user()
+        )
+
+    assert existing_agg.status == 0
+    assert prescription.status == 0
+    audited = [call.kwargs["prescription"] for call in mocks.audit_check.call_args_list]
+    assert audited == [existing_agg]
+
+
+def test_a_checked_agg_row_survives_a_reprocessed_prescription():
+    """A forced recalculation of processed items leaves the agg check alone."""
+    prescription = _prescription(status=0, features=_features())
+    existing_agg = _prescription(id=999, status="s")
+
+    with prescalc_env(
+        rows=[prescription, existing_agg], processed_status="PROCESSED"
+    ) as mocks:
+        _create_by_prescription(
+            schema=SCHEMA,
+            id_prescription=prescription.id,
+            user_context=_user(),
+            force=True,
+        )
+
+    assert existing_agg.status == "s"
+    mocks.audit_check.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# create_agg_prescription_by_date (CPOE)
+# --------------------------------------------------------------------------
+
+
+def _by_date_rows(existing=None, reloaded=None):
+    """Queue the two rows ``create_agg_prescription_by_date`` reads.
+
+    The flow looks the agg prescription up, then re-reads it after
+    ``session.expire`` to pick up what the insert trigger wrote. ``existing``
+    is the first lookup (``None`` when the row has to be created) and
+    ``reloaded`` is what the second one returns.
+    """
+    return [existing, reloaded if reloaded is not None else _prescription(id=999)]
+
+
+@contextmanager
+def _by_date_env(last_prescription, **kwargs):
+    """Run ``prescalc_env`` with the last-prescription lookup patched."""
+    with prescalc_env(**kwargs) as mocks:
+        with patch.object(
+            prescription_agg_service.prescription_repository,
+            "get_last_prescription",
+            return_value=last_prescription,
+        ) as get_last:
+            mocks.get_last_prescription = get_last
+            yield mocks
+
+
+def test_by_date_prefers_an_existing_agg_prescription_as_the_template():
+    """The agg row is looked up first; the individual one is the fallback."""
+    last = _prescription(id=888)
+
+    with _by_date_env(last, rows=_by_date_rows()) as mocks:
+        _create_by_date(
+            schema=SCHEMA,
+            admission_number=ADMISSION,
+            p_date=date(2026, 3, 10),
+            user_context=_user(),
+        )
+
+    assert mocks.get_last_prescription.call_args_list[0].kwargs == {
+        "admission_number": ADMISSION,
+        "cpoe": True,
+        "agg": True,
+    }
+
+
+def test_by_date_falls_back_to_the_last_individual_prescription():
+    """With no agg row yet, the newest individual prescription is the template."""
+    individual = _prescription(id=777)
+
+    with prescalc_env(rows=_by_date_rows()) as mocks:
+        with patch.object(
+            prescription_agg_service.prescription_repository,
+            "get_last_prescription",
+            side_effect=[None, individual],
+        ) as get_last:
+            _create_by_date(
+                schema=SCHEMA,
+                admission_number=ADMISSION,
+                p_date=date(2026, 3, 10),
+                user_context=_user(),
+            )
+
+    assert get_last.call_args_list[1].kwargs["agg"] is False
+    agg = _added(mocks, Prescription)[0]
+    assert agg.idPatient == individual.idPatient
+
+
+def test_by_date_skips_an_admission_with_no_prescription():
+    """Nothing to aggregate: log the reason and give up without locking."""
+    with _by_date_env(None, rows=[]) as mocks:
+        result = _create_by_date(
+            schema=SCHEMA,
+            admission_number=ADMISSION,
+            p_date=date(2026, 3, 10),
+            user_context=_user(),
+        )
+
+    assert result is None
+    mocks.acquire_lock.assert_not_called()
+    assert _logged_events(mocks.logger)[0]["message"] == (
+        "Não foi possível encontrar o segmento deste atendimento"
+    )
+
+
+def test_by_date_skips_a_template_without_a_segment():
+    """A prescription the integration has not segmented cannot seed an agg row."""
+    with _by_date_env(_prescription(id_segment=None), rows=[]) as mocks:
+        result = _create_by_date(
+            schema=SCHEMA,
+            admission_number=ADMISSION,
+            p_date=date(2026, 3, 10),
+            user_context=_user(),
+        )
+
+    assert result is None
+    mocks.acquire_lock.assert_not_called()
+
+
+def test_by_date_skips_when_the_admission_lock_is_held():
+    """Same serialization guarantee as the by-prescription entry point."""
+    with _by_date_env(_prescription(), rows=[], lock_acquired=False) as mocks:
+        result = _create_by_date(
+            schema=SCHEMA,
+            admission_number=ADMISSION,
+            p_date=date(2026, 3, 10),
+            user_context=_user(),
+        )
+
+    assert result is None
+    mocks.static_get_prescription.assert_not_called()
+    assert [e["event"] for e in _logged_events(mocks.logger)] == [
+        "prescalc_lock_timeout"
+    ]
+
+
+def test_by_date_creates_the_agg_prescription_with_the_derived_id():
+    """The row is inserted under ``gen_agg_id`` and audited as CREATE_AGG."""
+    last = _prescription(id=888)
+    p_date = date(2026, 3, 10)
+    expected_id = prescriptionutils.gen_agg_id(ADMISSION, last.idSegment, p_date)
+
+    with _by_date_env(last, rows=_by_date_rows()) as mocks:
+        _create_by_date(
+            schema=SCHEMA,
+            admission_number=ADMISSION,
+            p_date=p_date,
+            user_context=_user(),
+        )
+
+    agg = _added(mocks, Prescription)[0]
+    assert agg.id == expected_id
+    assert agg.date == p_date
+    assert agg.agg is True
+    assert agg.prescriber == "Prescrição Agregada"
+
+    audits = _added(mocks, PrescriptionAudit)
+    assert [a.auditType for a in audits] == [
+        PrescriptionAuditTypeEnum.CREATE_AGG.value
+    ]
+
+
+def test_by_date_reuses_an_existing_agg_prescription():
+    """A recalculation of the same day updates the row instead of inserting."""
+    existing = _prescription(id=999)
+
+    with _by_date_env(
+        _prescription(id=888), rows=_by_date_rows(existing, existing)
+    ) as mocks:
+        _create_by_date(
+            schema=SCHEMA,
+            admission_number=ADMISSION,
+            p_date=date(2026, 3, 10),
+            user_context=_user(),
+        )
+
+    assert mocks.db.session.added == []
+    assert existing.features["scoreVariation"] == DEFAULT_VARIATION
+    # CPOE items carry their own period, so intervals are not re-anchored
+    assert mocks.get_features.call_args.kwargs["intervals_for_agg_date"] is False
+    assert existing.features["should_update"] is False
+
+
+def test_by_date_restores_a_segment_cleared_by_the_trigger():
+    """The insert trigger can null the segment; the service writes it back."""
+    reloaded = _prescription(id=999, id_segment=None)
+
+    with _by_date_env(
+        _prescription(id=888, id_segment=4), rows=_by_date_rows(reloaded=reloaded)
+    ):
+        _create_by_date(
+            schema=SCHEMA,
+            admission_number=ADMISSION,
+            p_date=date(2026, 3, 10),
+            user_context=_user(),
+        )
+
+    assert reloaded.idSegment == 4
+
+
+def test_by_date_skips_a_processed_outpatient_admission():
+    """With the outpatient flag on, an already-processed day is rolled back."""
+    with _by_date_env(
+        _prescription(id=888),
+        rows=[None],
+        has_feature=True,
+        outpatient_processed_status="PROCESSED",
+    ) as mocks:
+        result = _create_by_date(
+            schema=SCHEMA,
+            admission_number=ADMISSION,
+            p_date=date(2026, 3, 10),
+            user_context=_user(),
+        )
+
+    assert result is None
+    mocks.db.session.rollback.assert_called_once()
+    mocks.log_processed_date.assert_not_called()
+    assert [e["message"] for e in _logged_events(mocks.logger)] == [
+        "Prescrição já foi processada (fluxo ambulatorial)"
+    ]
+
+
+def test_by_date_processes_a_pending_outpatient_admission():
+    """A day with unprocessed items proceeds normally under the same flag."""
+    with _by_date_env(
+        _prescription(id=888),
+        rows=_by_date_rows(),
+        has_feature=True,
+        outpatient_processed_status="PENDING",
+    ) as mocks:
+        _create_by_date(
+            schema=SCHEMA,
+            admission_number=ADMISSION,
+            p_date=date(2026, 3, 10),
+            user_context=_user(),
+        )
+
+    mocks.db.session.rollback.assert_not_called()
+    mocks.log_processed_date.assert_called_once()
+
+
+def test_by_date_marks_the_internal_prescriptions_as_processed():
+    """Every individual prescription rolled into the day is stamped."""
+    with _by_date_env(
+        _prescription(id=888),
+        rows=_by_date_rows(),
+        internal_prescription_ids=[100100, 100200],
+    ) as mocks:
+        _create_by_date(
+            schema=SCHEMA,
+            admission_number=ADMISSION,
+            p_date=date(2026, 3, 10),
+            user_context=_user(),
+        )
+
+    mocks.log_processed_date.assert_called_once_with(
+        id_prescription_array=[100100, 100200], schema=SCHEMA
+    )
+
+
+def test_by_date_runs_the_automatic_check_and_conciliation_update():
+    """The CPOE flow finishes with the auto-check and conciliation hooks."""
+    reloaded = _prescription(id=999)
+
+    with prescalc_env(rows=_by_date_rows(reloaded=reloaded)) as mocks:
+        with patch.object(
+            prescription_agg_service.prescription_repository,
+            "get_last_prescription",
+            return_value=_prescription(id=888),
+        ), patch.object(prescription_agg_service, "_automatic_check") as auto_check:
+            _create_by_date(
+                schema=SCHEMA,
+                admission_number=ADMISSION,
+                p_date=date(2026, 3, 10),
+                user_context=_user(),
+            )
+
+    assert auto_check.call_args.kwargs["prescription"] is reloaded
+    mocks.update_conciliation.assert_called_once_with(
+        admission_number=ADMISSION, is_concilia=False
+    )
+
+
+# --------------------------------------------------------------------------
+# _get_score_variation — the day-over-day delta shown in the queue
+# --------------------------------------------------------------------------
+
+
+def _run_score_variation(features, previous):
+    """Invoke ``_get_score_variation`` with the previous-day row mocked."""
+    prescription = _prescription(id=999, p_date=datetime(2026, 3, 10, 0, 0))
+    fake_db = _fake_db([previous])
+
+    with patch.object(prescription_agg_service, "db", fake_db):
+        return prescription_agg_service._get_score_variation(
+            prescription=prescription, features=features
+        )
+
+
+def test_score_variation_without_a_previous_day_is_a_full_increase():
+    """The first day of an admission has nothing to compare against."""
+    result = _run_score_variation(_features(globalScore=40), previous=None)
+
+    assert result == {
+        "variation": 100,
+        "currentGlobalScore": 40,
+        "previousGlobalScore": 0,
+    }
+
+
+def test_score_variation_treats_a_zero_previous_score_as_a_full_increase():
+    """Dividing by the previous score is only meaningful when it is non-zero."""
+    previous = _prescription(id=1, features={"globalScore": 0})
+
+    result = _run_score_variation(_features(globalScore=40), previous=previous)
+
+    assert result["variation"] == 100
+    assert result["previousGlobalScore"] == 0
+
+
+def test_score_variation_computes_a_percentage_increase():
+    """A rise from 40 to 60 is reported as +50%."""
+    previous = _prescription(id=1, features={"globalScore": 40})
+
+    result = _run_score_variation(_features(globalScore=60), previous=previous)
+
+    assert result == {
+        "variation": 50.0,
+        "currentGlobalScore": 60,
+        "previousGlobalScore": 40,
+    }
+
+
+def test_score_variation_computes_a_percentage_decrease():
+    """An improving patient yields a negative variation."""
+    previous = _prescription(id=1, features={"globalScore": 80})
+
+    result = _run_score_variation(_features(globalScore=60), previous=previous)
+
+    assert result["variation"] == -25.0
+    assert result["previousGlobalScore"] == 80
+
+
+def test_score_variation_is_rounded_to_two_decimals():
+    """The value is displayed as-is, so it is rounded at the source."""
+    previous = _prescription(id=1, features={"globalScore": 30})
+
+    result = _run_score_variation(_features(globalScore=40), previous=previous)
+
+    assert result["variation"] == 33.33
+
+
+def test_score_variation_defaults_a_missing_global_score_to_zero():
+    """Features computed before scoring ran must not break the queue."""
+    previous = _prescription(id=1, features={"globalScore": 40})
+
+    result = _run_score_variation({}, previous=previous)
+
+    assert result["currentGlobalScore"] == 0
+    assert result["variation"] == -100.0
+
+
+def test_score_variation_compares_against_the_previous_calendar_day():
+    """The lookup id is the agg id of the same admission/segment, one day back."""
+    prescription = _prescription(id=999, p_date=datetime(2026, 3, 10, 0, 0))
+    fake_db = _fake_db([None])
+
+    with patch.object(prescription_agg_service, "db", fake_db), patch.object(
+        prescription_agg_service.prescriptionutils, "gen_agg_id"
+    ) as gen_agg_id:
+        prescription_agg_service._get_score_variation(
+            prescription=prescription, features=_features()
+        )
+
+    assert gen_agg_id.call_args.kwargs == {
+        "admission_number": ADMISSION,
+        "id_segment": prescription.idSegment,
+        "pdate": datetime(2026, 3, 9, 0, 0),
+    }
+
+
+# --------------------------------------------------------------------------
+# _update_patient_conciliation_status
+# --------------------------------------------------------------------------
+
+
+def _run_conciliation_status(rows, *, is_concilia):
+    """Invoke ``_update_patient_conciliation_status`` over ``rows``."""
+    fake_db = _fake_db(rows)
+
+    with patch.object(prescription_agg_service, "db", fake_db):
+        prescription_agg_service._update_patient_conciliation_status(
+            admission_number=ADMISSION, is_concilia=is_concilia
+        )
+
+    return fake_db
+
+
+def _patient(status=PatientConciliationStatusEnum.PENDING.value):
+    """Build a Patient row with a given conciliation status."""
+    patient = Patient()
+    patient.idPatient = 55
+    patient.admissionNumber = ADMISSION
+    patient.st_conciliation = status
+    return patient
+
+
+def test_a_conciliation_prescription_advances_the_patient_status():
+    """The prescription being a conciliation is enough — no extra lookup."""
+    patient = _patient()
+
+    fake_db = _run_conciliation_status([patient], is_concilia=True)
+
+    assert patient.st_conciliation == PatientConciliationStatusEnum.CREATED.value
+    fake_db.session.flush.assert_called_once()
+
+
+def test_an_existing_conciliation_elsewhere_advances_the_patient_status():
+    """A regular prescription still advances a patient who has a conciliation."""
+    patient = _patient()
+
+    _run_conciliation_status([patient, SimpleNamespace(id=1)], is_concilia=False)
+
+    assert patient.st_conciliation == PatientConciliationStatusEnum.CREATED.value
+
+
+def test_a_patient_with_no_conciliation_at_all_stays_pending():
+    """Nothing to record, so the status is left alone."""
+    patient = _patient()
+
+    fake_db = _run_conciliation_status([patient, None], is_concilia=False)
+
+    assert patient.st_conciliation == PatientConciliationStatusEnum.PENDING.value
+    fake_db.session.flush.assert_not_called()
+
+
+def test_an_already_created_status_is_not_rewritten():
+    """The transition is one-way: CREATED is never recomputed."""
+    patient = _patient(status=PatientConciliationStatusEnum.CREATED.value)
+
+    fake_db = _run_conciliation_status([patient], is_concilia=True)
+
+    assert patient.st_conciliation == PatientConciliationStatusEnum.CREATED.value
+    fake_db.session.flush.assert_not_called()
+
+
+def test_a_missing_patient_is_tolerated():
+    """Prescriptions can arrive before the admission row; that is not an error."""
+    fake_db = _run_conciliation_status([None], is_concilia=True)
+
+    fake_db.session.flush.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# _audit_create
+# --------------------------------------------------------------------------
+
+
+def test_audit_create_maps_the_prescription_header():
+    """The audit row carries enough context to reconstruct the insert."""
+    prescription = _prescription(id=999, p_date=datetime(2026, 3, 10, 8, 0))
+    prescription.agg = True
+    prescription.concilia = None
+    fake_db = _fake_db()
+
+    with patch.object(prescription_agg_service, "db", fake_db):
+        prescription_agg_service._audit_create(prescription=prescription)
+
+    audit = fake_db.session.added[0]
+    assert audit.auditType == PrescriptionAuditTypeEnum.CREATE_AGG.value
+    assert audit.idPrescription == 999
+    assert audit.admissionNumber == ADMISSION
+    assert audit.prescriptionDate == prescription.date
+    assert audit.idDepartment == prescription.idDepartment
+    assert audit.idSegment == prescription.idSegment
+    assert audit.agg is True
+    assert audit.bed == prescription.bed
+    assert audit.extra is None
+    # -1 marks "not counted": the items are only known after the roll-up
+    assert audit.totalItens == -1
+    # attributed to the prescalc service user, not to a person
+    assert audit.createdBy == 0
+
+
+# --------------------------------------------------------------------------
+# _automatic_check
+# --------------------------------------------------------------------------
+
+
+def _run_automatic_check(features, *, status, has_feature):
+    """Invoke ``_automatic_check`` and return the check-service mock."""
+    prescription = _prescription(id=999, status=status)
+    module = prescription_agg_service
+
+    with patch.object(
+        module.feature_service, "has_feature", return_value=has_feature
+    ), patch.object(
+        module.prescription_check_service, "check_prescription"
+    ) as check_prescription:
+        module._automatic_check(
+            prescription=prescription, features=features, user_context=_user()
+        )
+
+    return check_prescription, prescription
+
+
+def test_a_day_with_no_validated_items_is_checked_automatically():
+    """Nothing for a pharmacist to review, so the day is closed by the system."""
+    check_prescription, prescription = _run_automatic_check(
+        _features(totalItens=0), status=0, has_feature=True
+    )
+
+    check_prescription.assert_called_once()
+    kwargs = check_prescription.call_args.kwargs
+    assert kwargs["idPrescription"] == prescription.id
+    assert kwargs["p_status"] == "s"
+    assert kwargs["alerts"] == []
+    assert kwargs["fast_check"] is True
+    assert kwargs["service_user"] is False
+
+
+def test_a_day_with_items_is_left_for_a_pharmacist():
+    """Anything reviewable must reach the work queue unchecked."""
+    check_prescription, _ = _run_automatic_check(
+        _features(totalItens=2), status=0, has_feature=True
+    )
+
+    check_prescription.assert_not_called()
+
+
+def test_an_already_checked_day_is_not_checked_again():
+    """Re-checking would create a spurious audit event."""
+    check_prescription, _ = _run_automatic_check(
+        _features(totalItens=0), status="s", has_feature=True
+    )
+
+    check_prescription.assert_not_called()
+
+
+def test_the_automatic_check_is_behind_a_feature_flag():
+    """Tenants without the flag keep every day in the queue."""
+    check_prescription, _ = _run_automatic_check(
+        _features(totalItens=0), status=0, has_feature=False
+    )
+
+    check_prescription.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# _log_processed_date and _set_schema
+# --------------------------------------------------------------------------
+
+
+def test_log_processed_date_stamps_the_items_of_every_prescription():
+    """One PROCESSED audit row per item, attributed to the service user."""
+    fake_db = _fake_db()
+
+    with patch.object(prescription_agg_service, "db", fake_db):
+        prescription_agg_service._log_processed_date(
+            id_prescription_array=[100100, 100200], schema=SCHEMA
+        )
+
+    query, params = fake_db.session.execute.call_args.args
+    assert f"insert into {SCHEMA}.presmed_audit" in str(query)
+    assert params["auditType"] == PrescriptionDrugAuditTypeEnum.PROCESSED.value
+    assert params["prescriptionArray"] == [100100, 100200]
+
+
+def test_set_schema_rejects_an_unknown_schema():
+    """A bad schema name must fail loudly instead of querying the wrong tenant."""
+    module = prescription_agg_service
+    session = MagicMock()
+    session.execute.return_value = [("public",), ("demo",)]
+
+    with patch.object(module, "db"), patch.object(
+        module, "Session", return_value=session
+    ), patch.object(module, "dbSession") as db_session:
+        with pytest.raises(ValidationError) as exc:
+            module._set_schema("does_not_exist")
+
+    assert exc.value.code == "errors.invalidSchema"
+    assert exc.value.httpStatus == 400
+    db_session.setSchema.assert_not_called()
+
+
+def test_set_schema_switches_to_a_known_schema():
+    """A valid schema is handed to the session's tenant switch."""
+    module = prescription_agg_service
+    session = MagicMock()
+    session.execute.return_value = [("public",), ("demo",)]
+
+    with patch.object(module, "db"), patch.object(
+        module, "Session", return_value=session
+    ), patch.object(module, "dbSession") as db_session:
+        module._set_schema("demo")
+
+    db_session.setSchema.assert_called_once_with("demo")
+    # the probe session is not left open
+    session.close.assert_called_once()


### PR DESCRIPTION
Adds tests for two features that had **no coverage at all**.

## Why these two

| Module | Tests before | Why it matters |
|---|---|---|
| `decorators/api_endpoint_decorator.py` + `utils/post_commit.py` | none | every route in the app is wrapped in `@api_endpoint()`; it owns the transaction, the schema switch, the authorization backstop and the response envelope |
| `services/prescription_agg_service.py` | none | the prescalc pipeline that builds the prescription-day rows the pharmacist work queue is made of, including whether a pharmacist's *check* survives a recalculation |

Unit tests fit better than integration tests here: the `api_endpoint` branches are error paths a real request cannot reach on demand (JWT families, pydantic failures, the missing-permission backstop), and prescalc needs CPOE segments, advisory-lock contention and `PROCESSED`/`NEW_ITENS` audit states that the seed data does not carry. `db` is faked and the collaborators are patched, but real SQLAlchemy model instances are used as rows so the services' attribute writes are exercised for real — the same approach as the existing `tests/unit/test_regulation_solicitation.py`.

## What is covered

**`tests/unit/test_api_endpoint_decorator.py`** (22 tests)
- success envelope, `commit`/`close`/`remove`, the `dbSession.setSchema` tenant switch, and `user_context` injected only when the handler declares it
- the authorization backstop: a handler that never went through `@has_permission` is refused (401) and rolled back rather than served
- `is_admin` routes blocked in production, served in the other environments
- error mapping: `ValidationError` code and HTTP status passed through verbatim (including non-400), pydantic per-field `validations`, both JWT exception families → "Login expirado", and a generic 500 that keeps the internal message out of the response body
- `download_headers` applied on the success path only
- the `finally` request-completion log, including the no-user-resolved case

**`tests/unit/test_post_commit.py`** (10 tests)
- registration order, no de-duplication, draining after a run, a nested registration deferring to the next batch
- a failing callback is logged and never raised (the transaction is already committed) and does not stop the remaining callbacks
- callbacks do not leak between requests — this is what makes the rollback path safe

**`tests/unit/test_prescription_agg_service.py`** (59 tests)
- guards: unknown prescription, missing segment, CPOE routed to the by-date flow, and the conciliation exception to that rule
- concurrency and idempotency: advisory-lock timeout skip (with the log payload), `PROCESSED` skip, `force` reprocess, and reprocess when features were never computed
- agg row construction: `gen_agg_id` derivation, `CREATE_AGG` audit, reuse of an existing row, which day `NEW_ITENS` land on, primary-care per-admission aggregation
- the check decision — the clinically consequential branch: withdraw both checks when the item count changed, keep them when it did not, inherit an unchanged check onto a newly created agg row, and ignore diets/materials in the count
- the CPOE `by_date` flow: agg-then-individual template lookup, the outpatient-flow `PROCESSED` rollback, the segment the insert trigger clears being written back
- helpers: score variation (no previous day, zero previous score, increase, decrease, rounding, missing score), patient conciliation status transitions, audit field mapping, the automatic check and its feature flag, processed stamping, schema validation

## Verification

- full suite: **2241 passed** (was 2150), `ruff check .` clean
- coverage of the three modules: `api_endpoint_decorator.py` 100%, `prescription_agg_service.py` 99% (the one uncovered line is the `get_last_agg_prescription` query builder), `post_commit.py` 100%
- the tests were mutation-checked rather than just run green — six deliberate regressions were each caught: never withdrawing the check, ignoring the lock timeout, dropping the score rounding, removing the permission backstop, leaking the internal exception message, and letting a post-commit callback propagate

No production code was changed — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBxwJeD3SgUKLaBT6KGuGc

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBxwJeD3SgUKLaBT6KGuGc)_