### PR TITLE
test: cover the drug dashboard and the admin copy-attributes bulk action

### DIFF
--- a/tests/integration/test_admin_drug_copy_attributes.py
+++ b/tests/integration/test_admin_drug_copy_attributes.py
@@ -1,0 +1,568 @@
+"""Integration tests for the admin copy-drug-attributes endpoint.
+
+``POST /admin/drug/copy-attributes``
+(``admin_drug_service.copy_drug_attributes`` /
+``admin_drug_repository.copy_attributes``) is the bulk action of the drug
+curation screen. It had no coverage at all, and it is the widest write in the
+admin area: a single call rewrites the chosen attributes of *every*
+``medatributos`` row of a segment, in one of two modes.
+
+* ``fromAdminSchema: true`` (the default) takes the values from the shared
+  substance catalog — the tag columns of ``public.substancia`` become the
+  boolean flags, and the kidney/liver columns are picked by the destination
+  segment's type, so an adult and a pediatric segment get different values
+  from the same substance.
+* ``fromAdminSchema: false`` copies from another segment of the same schema,
+  which additionally allows the two cost attributes.
+
+The rules that protect a curator's work are the point of most tests here:
+only the attributes named in the request are written, rows already edited by a
+real user are skipped unless ``overwriteAll`` is used (and that flag needs a
+permission ``CURATOR`` does not have), drugs with no substance are never
+touched, and every affected row gets an audit entry.
+
+Each test seeds its own rows, because a copy leaves the rows it touched marked
+as curated, which would change what a later copy is allowed to do. The
+destination segments are created by this module (``9911`` block) so a copy
+never reaches the seed data of the demo schema, and drug/substance ids use the
+reserved ``>= 90000`` range (91000 block).
+"""
+
+import pytest
+from sqlalchemy import bindparam, text
+
+from models.enums import DrugAttributesAuditTypeEnum
+from tests.conftest import session, session_commit
+from utils import status
+
+URL = "/admin/drug/copy-attributes"
+
+# Segments created by this module. Every copy is aimed at one of them, so the
+# schema-wide statement can only ever reach this module's rows.
+_SEG_REFERENCE = 9911  # adult destination, fed from the substance catalog
+_SEG_PEDIATRIC = 9912  # pediatric destination, asserts the column choice
+_SEG_ORIGIN = 9913  # source of the segment-to-segment copy
+_SEG_DESTINY = 9914  # destination of the segment-to-segment copy
+
+_SEGMENTS = (
+    (_SEG_REFERENCE, "ZZTest Segmento Referencia", 1),
+    (_SEG_PEDIATRIC, "ZZTest Segmento Pediatrico", 2),
+    (_SEG_ORIGIN, "ZZTest Segmento Origem", 1),
+    (_SEG_DESTINY, "ZZTest Segmento Destino", 1),
+)
+
+# Ids reserved for this module (91000 block, distinct from other modules').
+_SCTID = 91001
+
+_DRUG_UNCURATED = 91001  # attributes never edited by a user -> always copied
+_DRUG_CURATED = 91002  # edited by a real user -> only with overwriteAll
+_DRUG_NO_SUBSTANCE = 91003  # no sctid -> outside the copy, whatever the flags
+_DRUG_PEDIATRIC = 91004  # lives on the pediatric destination
+_DRUG_SEGMENT_COPY = 91005  # lives on both segment-to-segment segments
+
+_DRUG_IDS = (
+    _DRUG_UNCURATED,
+    _DRUG_CURATED,
+    _DRUG_NO_SUBSTANCE,
+    _DRUG_PEDIATRIC,
+    _DRUG_SEGMENT_COPY,
+)
+
+# Substance reference values. The tags drive the boolean attributes; the
+# kidney/liver pairs differ so the segment type is observable.
+_TAGS = ["antimicro", "tube", "dialyzable"]
+_KIDNEY_ADULT = 30
+_KIDNEY_PEDIATRIC = 11
+_LIVER_ADULT = 40
+_LIVER_PEDIATRIC = 12
+_PLATELETS = 50
+_FALL_RISK = 3
+_LACTATING = "2"
+_PREGNANT = "4"
+
+# Values seeded on the origin segment of the segment-to-segment copy
+_ORIGIN_KIDNEY = 77
+_ORIGIN_PRICE = 9.5
+_ORIGIN_PRICE_UNIT = "4"
+
+# seed demo.unidademedida rows
+_DESTINY_PRICE_UNIT = "1"
+
+# public.usuario seed ids
+_ADMIN_ID = 2  # behind admin_headers, holds ADMIN_DRUGS__OVERWRITE_ATTRIBUTES
+_CURATOR_ID = 3  # behind curator_headers, holds ADMIN_DRUGS only
+_OTHER_USER_ID = 8  # a hospital user, so its rows count as curated
+
+# every boolean attribute the substance catalog can fill
+_TAG_ATTRIBUTES = [
+    "antimicro",
+    "mav",
+    "controlados",
+    "idoso",
+    "linhabranca",
+    "sonda",
+    "quimio",
+    "dialisavel",
+    "jejum",
+    "naopadronizado",
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def seed_segments(clean_test_artifacts):  # noqa: ARG001
+    """Create the destination/origin segments used by every test.
+
+    Segments fall outside the id windows the shared cleanup wipes, so they are
+    removed here — and also before the inserts, so an interrupted run does not
+    leave the next one stuck on the primary key.
+    """
+    _delete_segments()
+
+    for id_segment, name, segment_type in _SEGMENTS:
+        session.execute(
+            text(
+                "INSERT INTO demo.segmento (idsegmento, nome, status, tp_segmento, cpoe) "
+                "VALUES (:id, :name, 1, :segment_type, false)"
+            ),
+            {"id": id_segment, "name": name, "segment_type": segment_type},
+        )
+    session_commit()
+
+    yield
+
+    _delete_segments()
+
+
+def _delete_segments():
+    """Remove this module's segments."""
+    session.execute(
+        text("DELETE FROM demo.segmento WHERE idsegmento IN :ids").bindparams(
+            bindparam("ids", expanding=True)
+        ),
+        {"ids": [segment[0] for segment in _SEGMENTS]},
+    )
+    session_commit()
+
+
+@pytest.fixture(autouse=True)
+def seed_drugs():
+    """Substance, drugs and attribute rows, rebuilt for every test.
+
+    A successful copy stamps ``update_by`` on the rows it touched, which turns
+    them into curated rows; rebuilding keeps each test independent of the ones
+    that ran before it.
+    """
+    _delete_drugs()
+
+    session.execute(
+        text(
+            "INSERT INTO public.substancia "
+            "(sctid, nome, link, ativo, unidadepadrao, tags, "
+            "renal_adulto, renal_pediatrico, hepatico_adulto, hepatico_pediatrico, "
+            "plaquetas, risco_queda, lactante, gestante) "
+            "VALUES (:id, 'ZZTest Substancia Copia', '', true, 'mg', :tags, "
+            ":kidney_adult, :kidney_pediatric, :liver_adult, :liver_pediatric, "
+            ":platelets, :fall_risk, :lactating, :pregnant)"
+        ),
+        {
+            "id": _SCTID,
+            "tags": _TAGS,
+            "kidney_adult": _KIDNEY_ADULT,
+            "kidney_pediatric": _KIDNEY_PEDIATRIC,
+            "liver_adult": _LIVER_ADULT,
+            "liver_pediatric": _LIVER_PEDIATRIC,
+            "platelets": _PLATELETS,
+            "fall_risk": _FALL_RISK,
+            "lactating": _LACTATING,
+            "pregnant": _PREGNANT,
+        },
+    )
+
+    for id_drug, name, sctid in (
+        (_DRUG_UNCURATED, "ZZTest Medicamento Nao Curado", _SCTID),
+        (_DRUG_CURATED, "ZZTest Medicamento Curado", _SCTID),
+        (_DRUG_NO_SUBSTANCE, "ZZTest Medicamento Sem Substancia Copia", None),
+        (_DRUG_PEDIATRIC, "ZZTest Medicamento Pediatrico", _SCTID),
+        (_DRUG_SEGMENT_COPY, "ZZTest Medicamento Copia Segmento", _SCTID),
+    ):
+        session.execute(
+            text(
+                "INSERT INTO demo.medicamento (fkhospital, fkmedicamento, nome, sctid) "
+                "VALUES (1, :id, :name, :sctid)"
+            ),
+            {"id": id_drug, "name": name, "sctid": sctid},
+        )
+
+    # blank rows on the reference destination: two of them are copy targets and
+    # one is protected by its update_by
+    for id_drug, id_segment, update_by in (
+        (_DRUG_UNCURATED, _SEG_REFERENCE, None),
+        (_DRUG_CURATED, _SEG_REFERENCE, _OTHER_USER_ID),
+        (_DRUG_NO_SUBSTANCE, _SEG_REFERENCE, None),
+        (_DRUG_PEDIATRIC, _SEG_PEDIATRIC, None),
+        (_DRUG_SEGMENT_COPY, _SEG_DESTINY, None),
+    ):
+        session.execute(
+            text(
+                "INSERT INTO demo.medatributos "
+                "(fkmedicamento, idsegmento, renal, hepatico, plaquetas, "
+                "risco_queda, lactante, gestante, antimicro, mav, controlados, "
+                "idoso, linhabranca, sonda, quimio, dialisavel, jejum, "
+                "naopadronizado, custo, fkunidademedidacusto, update_by) "
+                "VALUES (:id_drug, :id_segment, null, null, null, "
+                "null, null, null, false, false, false, "
+                "false, false, false, false, false, false, "
+                "false, 1, :price_unit, :update_by) "
+            ),
+            {
+                "id_drug": id_drug,
+                "id_segment": id_segment,
+                "price_unit": _DESTINY_PRICE_UNIT,
+                "update_by": update_by,
+            },
+        )
+
+    # the row the segment-to-segment copy reads from
+    session.execute(
+        text(
+            "INSERT INTO demo.medatributos "
+            "(fkmedicamento, idsegmento, renal, antimicro, custo, "
+            "fkunidademedidacusto, update_by) "
+            "VALUES (:id_drug, :id_segment, :kidney, true, :price, :price_unit, "
+            ":update_by)"
+        ),
+        {
+            "id_drug": _DRUG_SEGMENT_COPY,
+            "id_segment": _SEG_ORIGIN,
+            "kidney": _ORIGIN_KIDNEY,
+            "price": _ORIGIN_PRICE,
+            "price_unit": _ORIGIN_PRICE_UNIT,
+            "update_by": _OTHER_USER_ID,
+        },
+    )
+    session_commit()
+
+    yield
+
+    _delete_drugs()
+
+
+def _delete_drugs():
+    """Remove this module's drug rows, attributes and audit trail."""
+    for table in ("medatributos_audit", "medatributos", "medicamento"):
+        session.execute(
+            text(f"DELETE FROM demo.{table} WHERE fkmedicamento IN :ids").bindparams(
+                bindparam("ids", expanding=True)
+            ),
+            {"ids": list(_DRUG_IDS)},
+        )
+    session.execute(
+        text("DELETE FROM public.substancia WHERE sctid = :id"), {"id": _SCTID}
+    )
+    session_commit()
+
+
+def _post(client, headers, **body):
+    """Call the copy endpoint with the given payload."""
+    return client.post(URL, json=body, headers=headers)
+
+
+def _copy_from_reference(client, headers, attributes, **body):
+    """Copy the given attributes from the substance catalog into a segment."""
+    payload = {
+        "idSegmentDestiny": _SEG_REFERENCE,
+        "attributes": attributes,
+        "fromAdminSchema": True,
+    }
+    payload.update(body)
+
+    return _post(client, headers, **payload)
+
+
+def _attributes(id_drug, id_segment):
+    """The attribute row of a drug/segment pair, as a dict."""
+    row = session.execute(
+        text(
+            "SELECT renal, hepatico, plaquetas, risco_queda, lactante, gestante, "
+            "antimicro, mav, controlados, idoso, linhabranca, sonda, quimio, "
+            "dialisavel, jejum, naopadronizado, custo, fkunidademedidacusto, "
+            "update_by "
+            "FROM demo.medatributos "
+            "WHERE fkmedicamento = :id_drug AND idsegmento = :id_segment"
+        ),
+        {"id_drug": id_drug, "id_segment": id_segment},
+    ).fetchone()
+
+    return dict(row._mapping)
+
+
+def _audit_rows(id_drug):
+    """Copy-from-reference audit entries of a drug."""
+    return session.execute(
+        text(
+            "SELECT idsegmento, extra, created_by FROM demo.medatributos_audit "
+            "WHERE fkmedicamento = :id_drug AND tp_audit = :audit_type"
+        ),
+        {
+            "id_drug": id_drug,
+            "audit_type": DrugAttributesAuditTypeEnum.COPY_FROM_REFERENCE.value,
+        },
+    ).fetchall()
+
+
+def test_copy_attributes_permission_denied(client, analyst_headers):
+    """Teste post /admin/drug/copy-attributes - Deve negar acesso sem ADMIN_DRUGS [401]"""
+    response = _copy_from_reference(client, analyst_headers, ["antimicro"])
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert _attributes(_DRUG_UNCURATED, _SEG_REFERENCE)["antimicro"] is False
+
+
+def test_copy_attributes_overwrite_all_requires_extra_permission(
+    client, curator_headers
+):
+    """Teste post /admin/drug/copy-attributes - overwriteAll exige permissão adicional [401]"""
+    response = _copy_from_reference(
+        client, curator_headers, ["antimicro"], overwriteAll=True
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.get_json()["code"] == "errors.unauthorizedUser"
+    assert _attributes(_DRUG_UNCURATED, _SEG_REFERENCE)["antimicro"] is False
+
+
+def test_copy_attributes_curator_may_copy_without_overwrite(client, curator_headers):
+    """Teste post /admin/drug/copy-attributes - CURATOR pode copiar sem overwriteAll"""
+    response = _copy_from_reference(client, curator_headers, ["antimicro"])
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == 1
+    assert _attributes(_DRUG_UNCURATED, _SEG_REFERENCE)["update_by"] == _CURATOR_ID
+
+
+def test_copy_attributes_requires_destiny_segment(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Segmento destino é obrigatório [400]"""
+    response = _post(
+        client, admin_headers, attributes=["antimicro"], fromAdminSchema=True
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_copy_attributes_from_segment_requires_origin_segment(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Cópia entre segmentos exige origem [400]"""
+    response = _post(
+        client,
+        admin_headers,
+        idSegmentDestiny=_SEG_DESTINY,
+        attributes=["renal"],
+        fromAdminSchema=False,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_copy_attributes_from_segment_rejects_same_segment(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Origem igual ao destino é recusada [400]"""
+    response = _post(
+        client,
+        admin_headers,
+        idSegmentOrigin=_SEG_DESTINY,
+        idSegmentDestiny=_SEG_DESTINY,
+        attributes=["renal"],
+        fromAdminSchema=False,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidParams"
+
+
+def test_copy_attributes_writes_only_the_requested_attributes(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Apenas os atributos informados são gravados"""
+    response = _copy_from_reference(client, admin_headers, ["antimicro", "renal"])
+
+    assert response.status_code == status.HTTP_200_OK
+
+    attributes = _attributes(_DRUG_UNCURATED, _SEG_REFERENCE)
+    assert attributes["antimicro"] is True
+    assert attributes["renal"] == _KIDNEY_ADULT
+    # the substance also defines these, but they were not requested
+    assert attributes["sonda"] is False
+    assert attributes["dialisavel"] is False
+    assert attributes["hepatico"] is None
+    assert attributes["plaquetas"] is None
+    assert attributes["update_by"] == _ADMIN_ID
+
+
+def test_copy_attributes_maps_substance_tags_to_flags(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Tags da substância viram atributos booleanos"""
+    response = _copy_from_reference(client, admin_headers, _TAG_ATTRIBUTES)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    attributes = _attributes(_DRUG_UNCURATED, _SEG_REFERENCE)
+    # tags present on the substance
+    assert attributes["antimicro"] is True
+    assert attributes["sonda"] is True
+    assert attributes["dialisavel"] is True
+    # every other flag is absent from the tags, so it must be false
+    assert attributes["mav"] is False
+    assert attributes["controlados"] is False
+    assert attributes["idoso"] is False
+    assert attributes["linhabranca"] is False
+    assert attributes["quimio"] is False
+    assert attributes["jejum"] is False
+    assert attributes["naopadronizado"] is False
+
+
+def test_copy_attributes_copies_non_tag_reference_columns(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Colunas diretas da substância são copiadas"""
+    response = _copy_from_reference(
+        client,
+        admin_headers,
+        ["hepatico", "plaquetas", "risco_queda", "lactante", "gestante"],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    attributes = _attributes(_DRUG_UNCURATED, _SEG_REFERENCE)
+    assert attributes["hepatico"] == _LIVER_ADULT
+    assert attributes["plaquetas"] == _PLATELETS
+    assert attributes["risco_queda"] == _FALL_RISK
+    assert attributes["lactante"] == _LACTATING
+    assert attributes["gestante"] == _PREGNANT
+
+
+def test_copy_attributes_skips_rows_curated_by_a_user(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Linhas editadas por usuário são preservadas"""
+    response = _copy_from_reference(client, admin_headers, ["antimicro"])
+
+    assert response.status_code == status.HTTP_200_OK
+    # only the uncurated row is counted
+    assert response.get_json()["data"] == 1
+
+    curated = _attributes(_DRUG_CURATED, _SEG_REFERENCE)
+    assert curated["antimicro"] is False
+    assert curated["update_by"] == _OTHER_USER_ID
+
+
+def test_copy_attributes_overwrite_all_includes_curated_rows(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - overwriteAll também grava linhas curadas"""
+    response = _copy_from_reference(
+        client, admin_headers, ["antimicro"], overwriteAll=True
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == 2
+
+    for id_drug in (_DRUG_UNCURATED, _DRUG_CURATED):
+        attributes = _attributes(id_drug, _SEG_REFERENCE)
+        assert attributes["antimicro"] is True
+        assert attributes["update_by"] == _ADMIN_ID
+
+
+def test_copy_attributes_ignores_drugs_without_substance(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Medicamento sem substância não é alterado"""
+    response = _copy_from_reference(
+        client, admin_headers, ["antimicro"], overwriteAll=True
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    # there is no reference to copy from, so the row must stay untouched even
+    # though it sits on the destination segment and has no update_by
+    untouched = _attributes(_DRUG_NO_SUBSTANCE, _SEG_REFERENCE)
+    assert untouched["antimicro"] is False
+    assert untouched["update_by"] is None
+    assert _audit_rows(_DRUG_NO_SUBSTANCE) == []
+
+
+def test_copy_attributes_uses_pediatric_reference_for_pediatric_segment(
+    client, admin_headers
+):
+    """Teste post /admin/drug/copy-attributes - Segmento pediátrico usa as colunas pediátricas"""
+    response = _copy_from_reference(
+        client,
+        admin_headers,
+        ["renal", "hepatico"],
+        idSegmentDestiny=_SEG_PEDIATRIC,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == 1
+
+    attributes = _attributes(_DRUG_PEDIATRIC, _SEG_PEDIATRIC)
+    assert attributes["renal"] == _KIDNEY_PEDIATRIC
+    assert attributes["hepatico"] == _LIVER_PEDIATRIC
+
+
+def test_copy_attributes_from_reference_ignores_cost_attributes(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Custo não é copiado da substância"""
+    response = _copy_from_reference(
+        client, admin_headers, ["custo", "fkunidademedidacusto"]
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    attributes = _attributes(_DRUG_UNCURATED, _SEG_REFERENCE)
+    # the substance catalog holds no cost, so these two are only assignable in
+    # the segment-to-segment mode; the row is still stamped as visited
+    assert attributes["custo"] == 1
+    assert attributes["fkunidademedidacusto"] == _DESTINY_PRICE_UNIT
+    assert attributes["update_by"] == _ADMIN_ID
+
+
+def test_copy_attributes_from_segment_copies_origin_values(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Cópia entre segmentos usa os valores da origem"""
+    response = _post(
+        client,
+        admin_headers,
+        idSegmentOrigin=_SEG_ORIGIN,
+        idSegmentDestiny=_SEG_DESTINY,
+        attributes=["renal", "antimicro"],
+        fromAdminSchema=False,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get_json()["data"] == 1
+
+    attributes = _attributes(_DRUG_SEGMENT_COPY, _SEG_DESTINY)
+    assert attributes["renal"] == _ORIGIN_KIDNEY
+    assert attributes["antimicro"] is True
+    # the origin row is the reference, never a target
+    assert _attributes(_DRUG_SEGMENT_COPY, _SEG_ORIGIN)["update_by"] == _OTHER_USER_ID
+
+
+def test_copy_attributes_from_segment_allows_cost_attributes(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Cópia entre segmentos permite custo"""
+    response = _post(
+        client,
+        admin_headers,
+        idSegmentOrigin=_SEG_ORIGIN,
+        idSegmentDestiny=_SEG_DESTINY,
+        attributes=["custo", "fkunidademedidacusto"],
+        fromAdminSchema=False,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    attributes = _attributes(_DRUG_SEGMENT_COPY, _SEG_DESTINY)
+    assert attributes["custo"] == pytest.approx(_ORIGIN_PRICE)
+    assert attributes["fkunidademedidacusto"] == _ORIGIN_PRICE_UNIT
+
+
+def test_copy_attributes_records_an_audit_entry_per_affected_row(client, admin_headers):
+    """Teste post /admin/drug/copy-attributes - Deve registrar auditoria dos atributos copiados"""
+    response = _copy_from_reference(client, admin_headers, ["antimicro", "sonda"])
+
+    assert response.status_code == status.HTTP_200_OK
+
+    audit = _audit_rows(_DRUG_UNCURATED)
+    assert len(audit) == 1
+    assert audit[0][0] == _SEG_REFERENCE
+    assert audit[0][1] == {"attributes": "antimicro,sonda"}
+    assert audit[0][2] == _ADMIN_ID
+    # the skipped row is not audited either
+    assert _audit_rows(_DRUG_CURATED) == []

--- a/tests/integration/test_drug_dashboard.py
+++ b/tests/integration/test_drug_dashboard.py
@@ -1,0 +1,442 @@
+"""Integration tests for the drug dashboard endpoint.
+
+``GET /drugs/dashboard/<segment>/<drug>`` (``drug_service.get_drug_dashboard``)
+is the screen a pharmacist opens from a prescription line to see how the drug
+behaves in that segment: the substance reference, the segment attributes, every
+dose/frequency pair already scored for it (``outlier``) and the unit
+conversions configured for the segment.
+
+The endpoint had no coverage, and it is not a plain read:
+
+* it answers with a *stub* payload (drug name only) when the drug has no
+  substance linked yet, which is how the front end knows to send the user to
+  the curation screen first;
+* the segment attributes row is optional, so every attribute-derived field of
+  the response has a fallback;
+* when the caller passes ``dose`` and ``frequency`` (the prescribed values) the
+  matching outlier is flagged ``selected``, and when no outlier matches, one is
+  *created* with score 4 so the pair shows up on the dashboard from then on.
+  That write is the reason this is an integration test: it has to be observed
+  in the database, not only in the response.
+
+Fixtures use the reserved ``>= 90000`` id range (90700 block) so the
+session-scoped ``clean_test_artifacts`` fixture removes anything left behind;
+rows created inside that range by the endpoint itself are dropped on teardown
+as well, since other modules in the same session share the seed.
+"""
+
+import pytest
+from sqlalchemy import bindparam, text
+
+from tests.conftest import session, session_commit
+from utils import status
+
+URL = "/drugs/dashboard"
+
+# demo.segmento seed rows
+_SEGMENT_ADULT = 1
+_SEGMENT_CPOE = 2
+
+# Ids reserved for this module (90700 block, distinct from other modules').
+_SCTID = 90701
+
+_DRUG_FULL = 90701  # substance + attributes + outliers + conversions
+_DRUG_NO_SUBSTANCE = 90702  # no sctid, so the stub payload is returned
+_DRUG_NO_ATTRIBUTES = 90703  # substance, but no medatributos on the segment
+_DRUG_CREATES = 90704  # target of the "unseen pair is created" test
+_DRUG_ROUNDS = 90705  # target of the dose-rounding test
+_DRUG_IGNORES = 90706  # target of the invalid/partial parameter tests
+_UNKNOWN_DRUG = 90799
+
+_DRUG_IDS = (
+    _DRUG_FULL,
+    _DRUG_NO_SUBSTANCE,
+    _DRUG_NO_ATTRIBUTES,
+    _DRUG_CREATES,
+    _DRUG_ROUNDS,
+    _DRUG_IGNORES,
+)
+
+# outlier ids, ordered here as the endpoint should return them:
+# countNum desc, then frequency asc
+_OUTLIER_TOP = 90701  # count 50, freq 1
+_OUTLIER_SECOND = 90702  # count 50, freq 2
+_OUTLIER_LAST = 90703  # count 10, freq 33 -> labelled "SN"
+_OUTLIER_NO_ATTRIBUTES = 90704  # belongs to _DRUG_NO_ATTRIBUTES
+
+_NOTE_TEXT = "ZZTest observacao do outlier"
+
+# seed demo.unidademedida rows
+_UNIT_ATTRIBUTES = "1"
+_UNIT_CONVERSION = "2"
+_UNIT_OTHER_SEGMENT = "4"
+
+# the demo user behind the analyst_headers fixture
+CALLER_ID = 1
+
+
+@pytest.fixture(scope="module", autouse=True)
+def seed_dashboard_data(clean_test_artifacts):  # noqa: ARG001
+    """Substance, drugs, attributes, outliers and conversions for the dashboard."""
+    session.execute(
+        text(
+            "INSERT INTO public.substancia "
+            "(sctid, nome, link, ativo, unidadepadrao, divisor_faixa) "
+            "VALUES (:id, 'ZZTest Substancia Dashboard', '', true, 'mg', 2.5)"
+        ),
+        {"id": _SCTID},
+    )
+
+    for id_drug, name, sctid in (
+        (_DRUG_FULL, "ZZTest Medicamento Dashboard", _SCTID),
+        (_DRUG_NO_SUBSTANCE, "ZZTest Medicamento Sem Substancia", None),
+        (_DRUG_NO_ATTRIBUTES, "ZZTest Medicamento Sem Atributos", _SCTID),
+        (_DRUG_CREATES, "ZZTest Medicamento Novo Outlier", _SCTID),
+        (_DRUG_ROUNDS, "ZZTest Medicamento Arredonda", _SCTID),
+        (_DRUG_IGNORES, "ZZTest Medicamento Ignora", _SCTID),
+    ):
+        session.execute(
+            text(
+                "INSERT INTO demo.medicamento (fkhospital, fkmedicamento, nome, sctid) "
+                "VALUES (1, :id, :name, :sctid)"
+            ),
+            {"id": id_drug, "name": name, "sctid": sctid},
+        )
+
+    # _DRUG_NO_ATTRIBUTES is deliberately left without a medatributos row
+    for id_drug in (
+        _DRUG_FULL,
+        _DRUG_NO_SUBSTANCE,
+        _DRUG_CREATES,
+        _DRUG_ROUNDS,
+        _DRUG_IGNORES,
+    ):
+        session.execute(
+            text(
+                "INSERT INTO demo.medatributos "
+                "(fkmedicamento, idsegmento, fkunidademedida, divisor, usapeso) "
+                "VALUES (:id, :segment, :unit, 5, true)"
+            ),
+            {"id": id_drug, "segment": _SEGMENT_ADULT, "unit": _UNIT_ATTRIBUTES},
+        )
+
+    for id_outlier, id_drug, count, dose, frequency, score, manual_score in (
+        (_OUTLIER_TOP, _DRUG_FULL, 50, 100, 1, 1, None),
+        (_OUTLIER_SECOND, _DRUG_FULL, 50, 200, 2, 3, 2),
+        (_OUTLIER_LAST, _DRUG_FULL, 10, 300, 33, 2, None),
+        (_OUTLIER_NO_ATTRIBUTES, _DRUG_NO_ATTRIBUTES, 7, 400, 1, 4, None),
+    ):
+        session.execute(
+            text(
+                "INSERT INTO demo.outlier "
+                "(idoutlier, fkmedicamento, idsegmento, contagem, doseconv, "
+                "frequenciadia, escore, escoremanual, update_at, update_by) "
+                "VALUES (:id_outlier, :id_drug, :segment, :count, :dose, "
+                ":frequency, :score, :manual_score, "
+                "'2025-01-02 03:04:05', :caller)"
+            ),
+            {
+                "id_outlier": id_outlier,
+                "id_drug": id_drug,
+                "segment": _SEGMENT_ADULT,
+                "count": count,
+                "dose": dose,
+                "frequency": frequency,
+                "score": score,
+                "manual_score": manual_score,
+                "caller": CALLER_ID,
+            },
+        )
+
+    # only the least prescribed outlier carries a note
+    session.execute(
+        text(
+            "INSERT INTO demo.observacao "
+            "(idoutlier, fkpresmed, nratendimento, idsegmento, fkmedicamento, text) "
+            "VALUES (:id_outlier, 0, 1, :segment, :id_drug, :text)"
+        ),
+        {
+            "id_outlier": _OUTLIER_LAST,
+            "segment": _SEGMENT_ADULT,
+            "id_drug": _DRUG_FULL,
+            "text": _NOTE_TEXT,
+        },
+    )
+
+    # one conversion on the requested segment and one on another, to assert the
+    # response is restricted to the segment being viewed
+    for id_segment, id_measure_unit, factor in (
+        (_SEGMENT_ADULT, _UNIT_CONVERSION, 0.5),
+        (_SEGMENT_CPOE, _UNIT_OTHER_SEGMENT, 0.001),
+    ):
+        session.execute(
+            text(
+                "INSERT INTO demo.unidadeconverte "
+                "(fkmedicamento, idsegmento, fkunidademedida, fator) "
+                "VALUES (:id_drug, :segment, :unit, :factor)"
+            ),
+            {
+                "id_drug": _DRUG_FULL,
+                "segment": id_segment,
+                "unit": id_measure_unit,
+                "factor": factor,
+            },
+        )
+
+    session_commit()
+
+    yield
+
+    session.execute(text("DELETE FROM demo.observacao WHERE idoutlier >= 90700"))
+    for table in ("outlier", "unidadeconverte", "medatributos", "medicamento"):
+        session.execute(
+            text(f"DELETE FROM demo.{table} WHERE fkmedicamento IN :ids").bindparams(
+                bindparam("ids", expanding=True)
+            ),
+            {"ids": list(_DRUG_IDS)},
+        )
+    session.execute(
+        text("DELETE FROM public.substancia WHERE sctid = :id"), {"id": _SCTID}
+    )
+    session_commit()
+
+
+def _get(client, headers, id_drug, id_segment=_SEGMENT_ADULT, **params):
+    """Call the dashboard for one drug/segment pair."""
+    query = "&".join(f"{key}={value}" for key, value in params.items())
+    url = f"{URL}/{id_segment}/{id_drug}"
+
+    return client.get(f"{url}?{query}" if query else url, headers=headers)
+
+
+def _outliers(response):
+    """Outlier rows of the response, in response order."""
+    return response.get_json()["data"]["outliers"]
+
+
+def _count_outliers(id_drug):
+    """How many outlier rows the drug has on the adult segment."""
+    return session.execute(
+        text(
+            "SELECT count(*) FROM demo.outlier "
+            "WHERE fkmedicamento = :id_drug AND idsegmento = :segment"
+        ),
+        {"id_drug": id_drug, "segment": _SEGMENT_ADULT},
+    ).scalar()
+
+
+def test_drug_dashboard_permission_denied(client, config_manager_headers):
+    """Teste get /drugs/dashboard - Deve negar acesso sem READ_PRESCRIPTION [401]"""
+    response = _get(client, config_manager_headers, _DRUG_FULL)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_drug_dashboard_unknown_drug_is_rejected(client, analyst_headers):
+    """Teste get /drugs/dashboard - Medicamento inexistente deve ser recusado [400]"""
+    response = _get(client, analyst_headers, _UNKNOWN_DRUG)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRecord"
+
+
+def test_drug_dashboard_without_substance_returns_stub(client, analyst_headers):
+    """Teste get /drugs/dashboard - Sem substância, retorna apenas o medicamento"""
+    response = _get(client, analyst_headers, _DRUG_NO_SUBSTANCE)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.get_json()["data"]
+    # the front end uses the missing substance to require curation first, so
+    # the attribute/outlier/conversion blocks must not be there at all
+    assert data == {
+        "drug": {
+            "idDrug": _DRUG_NO_SUBSTANCE,
+            "name": "ZZTest Medicamento Sem Substancia",
+        },
+        "substance": None,
+    }
+
+
+def test_drug_dashboard_payload_shape(client, analyst_headers):
+    """Teste get /drugs/dashboard - Deve retornar medicamento, substância e atributos"""
+    response = _get(client, analyst_headers, _DRUG_FULL)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.get_json()["data"]
+    assert set(data.keys()) == {
+        "drug",
+        "substance",
+        "attributes",
+        "outliers",
+        "conversions",
+    }
+    assert data["drug"] == {
+        "idDrug": _DRUG_FULL,
+        "name": "ZZTest Medicamento Dashboard",
+    }
+    assert data["substance"] == {
+        "name": "ZZTest Substancia Dashboard",
+        "sctid": str(_SCTID),
+        "idMeasureUnit": "mg",
+        "divisionRange": 2.5,
+    }
+    assert data["attributes"] == {
+        "divisionRange": 5,
+        "idMeasureUnit": _UNIT_ATTRIBUTES,
+        "useWeight": True,
+    }
+
+
+def test_drug_dashboard_attributes_fall_back_when_segment_has_no_row(
+    client, analyst_headers
+):
+    """Teste get /drugs/dashboard - Sem medatributos no segmento, usa valores padrão"""
+    response = _get(client, analyst_headers, _DRUG_NO_ATTRIBUTES)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.get_json()["data"]
+    assert data["attributes"] == {
+        "divisionRange": None,
+        "idMeasureUnit": None,
+        "useWeight": False,
+    }
+    # the same fallback has to reach the outlier rows
+    assert data["outliers"][0]["unit"] is None
+    assert data["outliers"][0]["divisionRange"] is None
+    assert data["outliers"][0]["useWeight"] is False
+
+
+def test_drug_dashboard_outliers_ordered_by_count_then_frequency(
+    client, analyst_headers
+):
+    """Teste get /drugs/dashboard - Outliers ordenados por contagem desc e frequência asc"""
+    response = _get(client, analyst_headers, _DRUG_FULL)
+
+    assert [o["idOutlier"] for o in _outliers(response)] == [
+        _OUTLIER_TOP,
+        _OUTLIER_SECOND,
+        _OUTLIER_LAST,
+    ]
+
+
+def test_drug_dashboard_outlier_row_shape(client, analyst_headers):
+    """Teste get /drugs/dashboard - Deve expor escore, observação e atributos do outlier"""
+    rows = {
+        o["idOutlier"]: o for o in _outliers(_get(client, analyst_headers, _DRUG_FULL))
+    }
+
+    assert rows[_OUTLIER_SECOND] == {
+        "idOutlier": _OUTLIER_SECOND,
+        "idDrug": _DRUG_FULL,
+        "countNum": 50,
+        "dose": 200,
+        "unit": _UNIT_ATTRIBUTES,
+        "frequency": 2,
+        "score": 3,
+        "manualScore": 2,
+        "obs": "",
+        "divisionRange": 5,
+        "useWeight": True,
+        "updatedAt": "2025-01-02T03:04:05",
+        "selected": False,
+    }
+    # the note is joined by outlier, so only the annotated row carries it
+    assert rows[_OUTLIER_LAST]["obs"] == _NOTE_TEXT
+    # special frequencies are translated to their label
+    assert rows[_OUTLIER_LAST]["frequency"] == "SN"
+
+
+def test_drug_dashboard_conversions_limited_to_requested_segment(
+    client, analyst_headers
+):
+    """Teste get /drugs/dashboard - Conversões devem ser apenas do segmento consultado"""
+    response = _get(client, analyst_headers, _DRUG_FULL)
+
+    assert response.get_json()["data"]["conversions"] == [
+        {"idMeasureUnit": _UNIT_CONVERSION, "name": "mcg", "factor": 0.5}
+    ]
+
+
+def test_drug_dashboard_marks_prescribed_pair_as_selected(client, analyst_headers):
+    """Teste get /drugs/dashboard - Dose e frequência prescritas marcam o outlier existente"""
+    before = _count_outliers(_DRUG_FULL)
+
+    response = _get(client, analyst_headers, _DRUG_FULL, dose=200, frequency=2)
+
+    selected = [o["idOutlier"] for o in _outliers(response) if o["selected"]]
+    assert selected == [_OUTLIER_SECOND]
+    # an existing pair must not add a row
+    assert _count_outliers(_DRUG_FULL) == before
+
+
+def test_drug_dashboard_creates_outlier_for_unknown_pair(client, analyst_headers):
+    """Teste get /drugs/dashboard - Par dose/frequência inédito deve gerar outlier escore 4"""
+    assert _count_outliers(_DRUG_CREATES) == 0
+
+    response = _get(client, analyst_headers, _DRUG_CREATES, dose=75, frequency=4)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    rows = _outliers(response)
+    assert len(rows) == 1
+    assert rows[0]["dose"] == 75
+    assert rows[0]["frequency"] == 4
+    assert rows[0]["countNum"] == 1
+    assert rows[0]["score"] == 4
+    assert rows[0]["manualScore"] is None
+    assert rows[0]["selected"] is True
+
+    # the new pair is persisted, so the next prescription of it is not "new"
+    stored = session.execute(
+        text(
+            "SELECT idoutlier, contagem, doseconv, frequenciadia, escore, update_by "
+            "FROM demo.outlier "
+            "WHERE fkmedicamento = :id_drug AND idsegmento = :segment"
+        ),
+        {"id_drug": _DRUG_CREATES, "segment": _SEGMENT_ADULT},
+    ).fetchall()
+    assert len(stored) == 1
+    assert stored[0][0] == rows[0]["idOutlier"]
+    assert (stored[0][1], stored[0][2], stored[0][3], stored[0][4]) == (1, 75, 4, 4)
+    assert stored[0][5] == CALLER_ID
+
+
+def test_drug_dashboard_rounds_created_dose_to_two_decimals(client, analyst_headers):
+    """Teste get /drugs/dashboard - Dose do novo outlier é arredondada em duas casas"""
+    response = _get(client, analyst_headers, _DRUG_ROUNDS, dose=12.3456, frequency=1)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _outliers(response)[0]["dose"] == 12.35
+
+    stored_dose = session.execute(
+        text(
+            "SELECT doseconv FROM demo.outlier "
+            "WHERE fkmedicamento = :id_drug AND idsegmento = :segment"
+        ),
+        {"id_drug": _DRUG_ROUNDS, "segment": _SEGMENT_ADULT},
+    ).scalar()
+    assert stored_dose == pytest.approx(12.35)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"dose": "abc", "frequency": 1},
+        {"dose": 10, "frequency": "abc"},
+        {"dose": 10},
+        {"frequency": 1},
+    ],
+    ids=["invalid dose", "invalid frequency", "frequency missing", "dose missing"],
+)
+def test_drug_dashboard_ignores_unusable_dose_frequency(
+    client, analyst_headers, params
+):
+    """Teste get /drugs/dashboard - Dose ou frequência inválida não gera outlier"""
+    response = _get(client, analyst_headers, _DRUG_IGNORES, **params)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _outliers(response) == []
+    assert _count_outliers(_DRUG_IGNORES) == 0


### PR DESCRIPTION
Two features had no coverage at all. Both are reachable only through their endpoint and both write to the database, so they are covered as integration tests.

## `GET /drugs/dashboard/<segment>/<drug>`

`drug_service.get_drug_dashboard` — the screen opened from a prescription line to see how a drug behaves in a segment. Besides the read it has behaviour worth pinning down:

- a **stub payload** (drug name only) when the drug has no substance linked yet, which is how the front end knows to send the user to curation first;
- a fallback on every attribute-derived field of the response (and of each outlier row) when the segment has no `medatributos` row;
- the prescribed `dose`/`frequency` pair is flagged `selected`, and when no outlier matches, one is **created** with score 4 so the pair shows up from then on.

`tests/integration/test_drug_dashboard.py` (15 tests) asserts that write in the database, the two-decimal dose rounding, the outlier ordering and row shape (note join, special frequency labels), the conversions being restricted to the requested segment, and the parameter combinations that must not create anything (non-numeric or partial dose/frequency).

## `POST /admin/drug/copy-attributes`

`admin_drug_service.copy_drug_attributes` / `admin_drug_repository.copy_attributes` — the bulk action of the drug curation screen, and the widest write in the admin area: one call rewrites the chosen attributes of every `medatributos` row of a segment.

`tests/integration/test_admin_drug_copy_attributes.py` (17 tests) covers both modes and the rules that protect a curator's work:

- **substance catalog mode** (`fromAdminSchema: true`): substance tags map to the boolean attributes, direct columns are copied as-is, and the kidney/liver columns are picked by the destination segment's type — an adult and a pediatric segment get different values from the same substance;
- **segment-to-segment mode** (`fromAdminSchema: false`): origin values are copied, and the two cost attributes only this mode allows are written (they stay untouched in catalog mode);
- only the attributes named in the request are written;
- rows already edited by a real user are skipped, unless `overwriteAll` is used — and that flag requires a permission `CURATOR` does not have;
- drugs with no substance are never touched and never audited;
- every affected row gets a `COPY_FROM_REFERENCE` audit entry naming the copied attributes.

## Notes

- The copy statement rewrites a whole segment, so the tests aim it at segments they create themselves (`9911` block) and never at the seed segments of the demo schema. Each test rebuilds its rows, because a successful copy leaves them marked as curated.
- Fixtures use the reserved id ranges the shared `clean_test_artifacts` fixture wipes (`90700` and `91000` blocks); the segments, which fall outside those windows, are removed by the module both before and after.
- Mutation-checked: inverting the adult/pediatric column choice, changing the new outlier's score, and changing the dose rounding each make the relevant tests fail.

## Coverage

| module | before | after |
| --- | --- | --- |
| `repository/admin/admin_drug_repository.py` | 24% | 100% |
| `services/admin/admin_drug_service.py` | 79% | 85% |
| `services/drug_service.py` | 66% | 76% |
| `repository/outlier_repository.py` | 62% | 75% |

Full suite locally: 2289 passed (2257 before), `ruff check` clean. No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDmGqQSfhPFUXAFsQj4G7o

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDmGqQSfhPFUXAFsQj4G7o)_