### PR TITLE
test: cover the drug form lookups and the static prescription check

### DIFF
--- a/tests/integration/test_drug_form_resources.py
+++ b/tests/integration/test_drug_form_resources.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 import pytest
 from sqlalchemy import text
 
+from models.appendix import Frequency, MeasureUnit
 from models.enums import MemoryEnum
 from models.main import Drug, PrescriptionAgg
 from security.role import Role
@@ -155,11 +156,25 @@ def test_drug_resources_sorts_the_catalogues_by_description(client, analyst_head
     """GET /drugs/resources - ordena unidades e frequências por descrição"""
     data = _get(client, analyst_headers).get_json()["data"]
 
-    unit_names = [u["description"] for u in data["units"]]
-    frequency_names = [f["description"] for f in data["frequencies"]]
+    # compared against what the database itself returns rather than against a
+    # Python sort: ordering by description is the database's, and it differs
+    # between collations ('UI' sorts before 'mcg' under C, after it under en_US)
+    expected_units = [
+        row.description
+        for row in session.query(MeasureUnit).order_by(MeasureUnit.description).all()
+    ]
+    expected_frequencies = [
+        row.description
+        for row in session.query(Frequency).order_by(Frequency.description).all()
+    ]
 
-    assert unit_names == sorted(unit_names)
-    assert frequency_names == sorted(frequency_names)
+    # the catalogue is appended after the previously prescribed entries
+    assert [u["description"] for u in data["units"]][
+        -len(expected_units) :
+    ] == expected_units
+    assert [f["description"] for f in data["frequencies"]][
+        -len(expected_frequencies) :
+    ] == expected_frequencies
 
 
 def test_drug_resources_counts_previously_prescribed_units_and_frequencies(

--- a/tests/integration/test_drug_form_resources.py
+++ b/tests/integration/test_drug_form_resources.py
@@ -1,0 +1,331 @@
+"""Tests: lookup data the prescription drug form loads
+
+Covers the three endpoints the drug form calls before it can be rendered:
+
+* ``GET /drugs/resources/<idDrug>/<idSegment>[/<idHospital>]`` — the drug plus
+  the measure-unit and frequency catalogues, annotated with how often each one
+  was already prescribed for that drug/segment;
+* ``GET /drugs/frequencies`` — the frequency catalogue on its own;
+* ``GET /lists/routes`` — the routes configured in the ``map-routes`` memory.
+"""
+
+import json
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import MemoryEnum
+from models.main import Drug, PrescriptionAgg
+from security.role import Role
+from tests.conftest import get_access, make_headers, session, session_commit
+from tests.utils.utils_test_unit_conversion import (
+    create_test_drug,
+    create_test_substance,
+)
+
+RESOURCES_URL = "/drugs/resources"
+FREQUENCIES_URL = "/drugs/frequencies"
+ROUTES_URL = "/lists/routes"
+
+# demo seed drug and the only segment it has aggregated data for
+SEED_DRUG = 3
+SEED_SEGMENT = 1
+SEED_HOSPITAL = 1
+
+# reserved ids, cleaned by tests/conftest.py::_cleanup (>= 90000)
+FORM_DRUG = 90201
+FORM_SUBSTANCE = 90201
+
+
+def _get(client, headers, id_drug=SEED_DRUG, id_segment=SEED_SEGMENT, id_hospital=None):
+    url = f"{RESOURCES_URL}/{id_drug}/{id_segment}"
+    if id_hospital is not None:
+        url = f"{url}/{id_hospital}"
+
+    return client.get(url, headers=headers)
+
+
+def _by_id(items, item_id):
+    """Every entry of the given list matching the id (the catalogue and the
+    prescribed history are concatenated, so an id can show up twice)"""
+    return [i for i in items if i["id"] == item_id]
+
+
+@contextmanager
+def _memory(kind: str, value: str | None):
+    """Make the demo schema hold exactly the given memory record for this kind.
+
+    ``value`` of ``None`` leaves the kind unset. Whatever the schema had is put
+    back on exit, so the surrounding session keeps its seed data and a re-run
+    never stacks duplicates (``get_memory`` reads a single row per kind).
+    """
+    previous = [
+        row[0]
+        for row in session.execute(
+            text("SELECT valor FROM demo.memoria WHERE tipo = :kind"), {"kind": kind}
+        ).all()
+    ]
+
+    _delete_memory(kind)
+    if value is not None:
+        _insert_memory(kind, value)
+
+    try:
+        yield
+    finally:
+        _delete_memory(kind)
+        for restored in previous:
+            _insert_memory(kind, json.dumps(restored))
+
+
+def _insert_memory(kind: str, value: str):
+    session.execute(
+        text(
+            "INSERT INTO demo.memoria (tipo, valor, update_at, update_by) "
+            "VALUES (:kind, CAST(:value AS json), now(), 1)"
+        ),
+        {"kind": kind, "value": value},
+    )
+    session_commit()
+
+
+def _delete_memory(kind: str):
+    session.execute(text("DELETE FROM demo.memoria WHERE tipo = :kind"), {"kind": kind})
+    session_commit()
+
+
+@pytest.fixture
+def prescribed_drug():
+    """A drug with aggregated history: 7 prescriptions in 'mg' at '8h/8h'"""
+    session.query(PrescriptionAgg).filter(PrescriptionAgg.idDrug == FORM_DRUG).delete()
+    session.query(Drug).filter(Drug.id == FORM_DRUG).delete()
+    session_commit()
+
+    create_test_substance(id=FORM_SUBSTANCE, name="Substancia Formulario")
+    create_test_drug(id=FORM_DRUG, name="Medicamento Formulario", sctid=FORM_SUBSTANCE)
+
+    agg = PrescriptionAgg()
+    agg.idHospital = SEED_HOSPITAL
+    agg.idDepartment = 1
+    agg.idSegment = SEED_SEGMENT
+    agg.idDrug = FORM_DRUG
+    agg.idMeasureUnit = "1"  # mg
+    agg.idFrequency = "3"  # 8h/8h
+    agg.dose = 10
+    agg.frequency = 3
+    agg.countNum = 7
+
+    session.add(agg)
+    session_commit()
+
+    return FORM_DRUG
+
+
+def test_drug_resources_returns_the_drug_and_the_full_catalogues(
+    client, analyst_headers
+):
+    """GET /drugs/resources - retorna o medicamento e os catálogos completos de unidades e frequências"""
+    response = _get(client, analyst_headers)
+
+    assert response.status_code == 200
+
+    data = response.get_json()["data"]
+    assert data["drug"] == {"id": SEED_DRUG, "name": "ANLODIPINO 10 mg CP"}
+
+    # the whole catalogue is offered, not only what was already prescribed
+    assert {u["description"] for u in data["units"]} == {
+        "UI",
+        "Un",
+        "mcg",
+        "mg",
+        "mg/ml",
+        "ml",
+    }
+    assert {f["description"] for f in data["frequencies"]} == {
+        "1x/dia",
+        "12h/12h",
+        "8h/8h",
+        "6h/6h",
+        "4h/4h",
+    }
+
+
+def test_drug_resources_sorts_the_catalogues_by_description(client, analyst_headers):
+    """GET /drugs/resources - ordena unidades e frequências por descrição"""
+    data = _get(client, analyst_headers).get_json()["data"]
+
+    unit_names = [u["description"] for u in data["units"]]
+    frequency_names = [f["description"] for f in data["frequencies"]]
+
+    assert unit_names == sorted(unit_names)
+    assert frequency_names == sorted(frequency_names)
+
+
+def test_drug_resources_counts_previously_prescribed_units_and_frequencies(
+    client, analyst_headers, prescribed_drug
+):
+    """GET /drugs/resources - traz a contagem das unidades e frequências já prescritas"""
+    data = _get(client, analyst_headers, id_drug=prescribed_drug).get_json()["data"]
+
+    # 'mg' and '8h/8h' come back twice: once from the drug history carrying the
+    # count, once from the catalogue with zero
+    assert sorted(u["amount"] for u in _by_id(data["units"], "1")) == [0, 7]
+    assert sorted(f["amount"] for f in _by_id(data["frequencies"], "3")) == [0, 7]
+
+    # a unit that was never prescribed for this drug only shows the zeroed entry
+    assert [u["amount"] for u in _by_id(data["units"], "4")] == [0]
+
+
+def test_drug_resources_ignores_history_of_another_segment(
+    client, analyst_headers, prescribed_drug
+):
+    """GET /drugs/resources - desconsidera o histórico de outro segmento"""
+    data = _get(
+        client, analyst_headers, id_drug=prescribed_drug, id_segment=2
+    ).get_json()["data"]
+
+    assert [u["amount"] for u in _by_id(data["units"], "1")] == [0]
+    assert [f["amount"] for f in _by_id(data["frequencies"], "3")] == [0]
+
+
+def test_drug_resources_accepts_the_hospital_variant(client, analyst_headers):
+    """GET /drugs/resources/<idHospital> - a rota com hospital devolve o mesmo conteúdo"""
+    without_hospital = _get(client, analyst_headers).get_json()["data"]
+    with_hospital = _get(client, analyst_headers, id_hospital=SEED_HOSPITAL).get_json()[
+        "data"
+    ]
+
+    assert with_hospital == without_hospital
+
+
+def test_drug_resources_returns_an_empty_name_for_an_unknown_drug(
+    client, analyst_headers
+):
+    """GET /drugs/resources - medicamento inexistente devolve nome vazio e o id informado"""
+    response = _get(client, analyst_headers, id_drug=999999)
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["drug"] == {"id": 999999, "name": ""}
+
+
+def test_drug_resources_leaves_routes_and_intervals_empty(client, analyst_headers):
+    """GET /drugs/resources - vias e horários só são calculados no modo completo"""
+    data = _get(client, analyst_headers).get_json()["data"]
+
+    assert data["routes"] == []
+    assert data["intervals"] == []
+
+
+def test_drug_resources_returns_the_configured_transcription_fields(
+    client, analyst_headers
+):
+    """GET /drugs/resources - devolve os campos extras e removidos configurados na memória"""
+    with (
+        _memory(MemoryEnum.TRANSCRIPTION_FIELDS.value, '["dose", "peso"]'),
+        _memory(MemoryEnum.TRANSCRIPTION_REMOVE_FIELDS.value, '["interval"]'),
+    ):
+        data = _get(client, analyst_headers).get_json()["data"]
+
+    assert data["extraFields"] == ["dose", "peso"]
+    assert data["removeFields"] == ["interval"]
+
+
+def test_drug_resources_returns_empty_field_lists_without_memory(
+    client, analyst_headers
+):
+    """GET /drugs/resources - sem memória configurada, os campos voltam como listas vazias"""
+    with (
+        _memory(MemoryEnum.TRANSCRIPTION_FIELDS.value, None),
+        _memory(MemoryEnum.TRANSCRIPTION_REMOVE_FIELDS.value, None),
+    ):
+        data = _get(client, analyst_headers).get_json()["data"]
+
+    assert data["extraFields"] == []
+    assert data["removeFields"] == []
+
+
+def test_drug_resources_requires_prescription_read_permission(
+    client, user_manager_headers
+):
+    """GET /drugs/resources - deve retornar erro [401 UNAUTHORIZED] sem permissão de leitura de prescrição"""
+    assert _get(client, user_manager_headers).status_code == 401
+
+
+def test_frequencies_lists_the_catalogue_sorted_by_description(client, analyst_headers):
+    """GET /drugs/frequencies - lista as frequências ordenadas por descrição"""
+    response = client.get(FREQUENCIES_URL, headers=analyst_headers)
+
+    assert response.status_code == 200
+
+    data = response.get_json()["data"]
+    assert [f["description"] for f in data] == [
+        "12h/12h",
+        "1x/dia",
+        "4h/4h",
+        "6h/6h",
+        "8h/8h",
+    ]
+    assert {f["id"] for f in data} == {"1", "2", "3", "4", "6"}
+
+
+def test_frequencies_does_not_repeat_ids(client, analyst_headers):
+    """GET /drugs/frequencies - não repete frequências"""
+    data = client.get(FREQUENCIES_URL, headers=analyst_headers).get_json()["data"]
+
+    ids = [f["id"] for f in data]
+    assert len(ids) == len(set(ids))
+
+
+def test_frequencies_requires_prescription_read_permission(
+    client, user_manager_headers
+):
+    """GET /drugs/frequencies - deve retornar erro [401 UNAUTHORIZED] sem permissão de leitura de prescrição"""
+    response = client.get(FREQUENCIES_URL, headers=user_manager_headers)
+
+    assert response.status_code == 401
+
+
+def test_routes_are_empty_when_the_memory_is_absent(client, analyst_headers):
+    """GET /lists/routes - sem a memória map-routes, a lista volta vazia"""
+    with _memory(MemoryEnum.MAP_ROUTES.value, None):
+        response = client.get(ROUTES_URL, headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == []
+
+
+def test_routes_returns_the_configured_map_routes(client, analyst_headers):
+    """GET /lists/routes - devolve as vias configuradas na memória map-routes"""
+    with _memory(
+        MemoryEnum.MAP_ROUTES.value,
+        '[{"id": "VO", "value": "Via Oral"}, {"id": "IV", "value": "Intravenosa"}]',
+    ):
+        response = client.get(ROUTES_URL, headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == [
+        {"id": "VO", "name": "Via Oral"},
+        {"id": "IV", "name": "Intravenosa"},
+    ]
+
+
+def test_routes_skips_malformed_entries(client, analyst_headers):
+    """GET /lists/routes - ignora entradas malformadas da memória map-routes"""
+    with _memory(
+        MemoryEnum.MAP_ROUTES.value,
+        '["VO", {"value": "sem id"}, {"id": "IV", "value": "Intravenosa"}]',
+    ):
+        response = client.get(ROUTES_URL, headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] == [{"id": "IV", "name": "Intravenosa"}]
+
+
+def test_routes_requires_basic_features_permission(client):
+    """GET /lists/routes - deve retornar erro [401 UNAUTHORIZED] sem permissão básica de leitura"""
+    headers = make_headers(get_access(client, roles=[Role.SERVICE_INTEGRATOR.value]))
+
+    response = client.get(ROUTES_URL, headers=headers)
+
+    assert response.status_code == 401

--- a/tests/integration/test_static_prescription_status.py
+++ b/tests/integration/test_static_prescription_status.py
@@ -1,0 +1,363 @@
+"""Tests: static prescription check (POST /static/prescriptions/status)
+
+The endpoint an external system calls to check a prescription on behalf of one
+of its own users. The caller authenticates as a service integrator (RUN_AS) and
+identifies the real author by their external id; the check is then recorded as
+if that user had performed it.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import func
+
+from models.enums import PrescriptionAuditTypeEnum
+from models.main import User, UserAuthorization
+from models.prescription import Prescription, PrescriptionAudit
+from security.role import Role
+from tests.conftest import get_access, make_headers, session, session_commit
+from tests.utils.utils_test_prescription import create_basic_prescription
+
+STATIC_CHECK_URL = "/static/prescriptions/status"
+
+# emails follow the pattern wiped by tests/conftest.py::_cleanup
+ANALYST_EMAIL = "test-static-analyst@example.com"
+VIEWER_EMAIL = "test-static-viewer@example.com"
+INACTIVE_EMAIL = "test-static-inactive@example.com"
+FOREIGN_EMAIL = "test-static-foreign@example.com"
+UNAUTHORIZED_EMAIL = "test-static-nosegment@example.com"
+
+ANALYST_EXTERNAL = "ZZTEST-EXT-ANALYST"
+VIEWER_EXTERNAL = "ZZTEST-EXT-VIEWER"
+INACTIVE_EXTERNAL = "ZZTEST-EXT-INACTIVE"
+FOREIGN_EXTERNAL = "ZZTEST-EXT-FOREIGN"
+UNAUTHORIZED_EXTERNAL = "ZZTEST-EXT-NOSEGMENT"
+
+# the demo schema runs with AUTHORIZATION_SEGMENT on, so an origin user only
+# reaches the check once it is authorized on the prescription's segment
+SEED_SEGMENT = 1
+
+TEST_EMAILS = (
+    ANALYST_EMAIL,
+    VIEWER_EMAIL,
+    INACTIVE_EMAIL,
+    FOREIGN_EMAIL,
+    UNAUTHORIZED_EMAIL,
+)
+
+
+def _payload(id_prescription, status="s", id_origin_user=ANALYST_EXTERNAL):
+    return {
+        "idPrescription": id_prescription,
+        "status": status,
+        "idOriginUser": id_origin_user,
+    }
+
+
+def _create_origin_user(
+    email, external, roles, active=True, schema="demo", id_segment=SEED_SEGMENT
+):
+    """Create (or recreate) a user the static check can run as"""
+    _delete_origin_user(email)
+
+    user = User()
+    user.email = email
+    user.name = "Fulano Integracao"
+    user.schema = schema
+    user.external = external
+    user.active = active
+    user.config = {"roles": roles, "features": []}
+    user.password = func.crypt("zztest-static", func.gen_salt("bf", 8))
+
+    session.add(user)
+    session_commit()
+    session.refresh(user)
+
+    if id_segment is not None:
+        authorization = UserAuthorization()
+        authorization.idUser = user.id
+        authorization.idSegment = id_segment
+        authorization.createdAt = datetime.today()
+        authorization.createdBy = user.id
+
+        session.add(authorization)
+        session_commit()
+
+    return user
+
+
+def _delete_origin_user(email):
+    """Drop the user and the segment authorizations left behind by a prior run"""
+    ids = [row.id for row in session.query(User.id).filter(User.email == email).all()]
+    if ids:
+        session.query(UserAuthorization).filter(
+            UserAuthorization.idUser.in_(ids)
+        ).delete(synchronize_session=False)
+        session.query(User).filter(User.id.in_(ids)).delete(synchronize_session=False)
+
+    session_commit()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def origin_users():
+    """The origin users every test in this module runs as"""
+    users = {
+        "analyst": _create_origin_user(
+            ANALYST_EMAIL, ANALYST_EXTERNAL, [Role.PRESCRIPTION_ANALYST.value]
+        ),
+        "viewer": _create_origin_user(
+            VIEWER_EMAIL, VIEWER_EXTERNAL, [Role.VIEWER.value]
+        ),
+        "inactive": _create_origin_user(
+            INACTIVE_EMAIL,
+            INACTIVE_EXTERNAL,
+            [Role.PRESCRIPTION_ANALYST.value],
+            active=False,
+        ),
+        "foreign": _create_origin_user(
+            FOREIGN_EMAIL,
+            FOREIGN_EXTERNAL,
+            [Role.PRESCRIPTION_ANALYST.value],
+            schema="teste",
+        ),
+        "unauthorized": _create_origin_user(
+            UNAUTHORIZED_EMAIL,
+            UNAUTHORIZED_EXTERNAL,
+            [Role.PRESCRIPTION_ANALYST.value],
+            id_segment=None,
+        ),
+    }
+
+    # ids are read here because the objects expire between tests
+    ids = {key: user.id for key, user in users.items()}
+
+    yield ids
+
+    for email in TEST_EMAILS:
+        _delete_origin_user(email)
+
+
+@pytest.fixture
+def integrator_headers(client):
+    """Headers with SERVICE_INTEGRATOR role — the only role holding RUN_AS"""
+    return make_headers(get_access(client, roles=[Role.SERVICE_INTEGRATOR.value]))
+
+
+def test_static_check_sets_the_status_on_behalf_of_the_origin_user(
+    client, integrator_headers, origin_users
+):
+    """POST /static/prescriptions/status - checa a prescrição em nome do usuário de origem"""
+    id_prescription = create_basic_prescription().id
+
+    response = client.post(
+        STATIC_CHECK_URL, json=_payload(id_prescription), headers=integrator_headers
+    )
+
+    assert response.status_code == 200
+
+    session.expire_all()
+    prescription = (
+        session.query(Prescription).filter(Prescription.id == id_prescription).first()
+    )
+    assert prescription.status == "s"
+    # attributed to the origin user, never to the service integrator
+    assert prescription.user == origin_users["analyst"]
+
+
+def test_static_check_returns_the_checked_prescription(client, integrator_headers):
+    """POST /static/prescriptions/status - devolve a prescrição checada"""
+    id_prescription = create_basic_prescription().id
+
+    response = client.post(
+        STATIC_CHECK_URL, json=_payload(id_prescription), headers=integrator_headers
+    )
+
+    assert response.get_json()["data"] == [
+        {"idPrescription": str(id_prescription), "status": "s"}
+    ]
+
+
+def test_static_check_audits_the_check_as_a_service_user(
+    client, integrator_headers, origin_users
+):
+    """POST /static/prescriptions/status - registra a auditoria marcando a origem como serviço"""
+    id_prescription = create_basic_prescription().id
+
+    client.post(
+        STATIC_CHECK_URL, json=_payload(id_prescription), headers=integrator_headers
+    )
+
+    session.expire_all()
+    audit = (
+        session.query(PrescriptionAudit)
+        .filter(PrescriptionAudit.idPrescription == id_prescription)
+        .filter(PrescriptionAudit.auditType == PrescriptionAuditTypeEnum.CHECK.value)
+        .first()
+    )
+
+    assert audit is not None
+    assert audit.createdBy == origin_users["analyst"]
+    assert audit.extra["serviceUser"] is True
+
+
+def test_static_check_undoes_a_previous_check(client, integrator_headers):
+    """POST /static/prescriptions/status - desfaz a checagem quando o status enviado é 0"""
+    id_prescription = create_basic_prescription().id
+
+    client.post(
+        STATIC_CHECK_URL, json=_payload(id_prescription), headers=integrator_headers
+    )
+    response = client.post(
+        STATIC_CHECK_URL,
+        json=_payload(id_prescription, status="0"),
+        headers=integrator_headers,
+    )
+
+    assert response.status_code == 200
+
+    session.expire_all()
+    prescription = (
+        session.query(Prescription).filter(Prescription.id == id_prescription).first()
+    )
+    assert prescription.status == "0"
+
+
+def test_static_check_rejects_an_unknown_origin_user(client, integrator_headers):
+    """POST /static/prescriptions/status - deve retornar erro [400] quando o id externo não existe"""
+    id_prescription = create_basic_prescription().id
+
+    response = client.post(
+        STATIC_CHECK_URL,
+        json=_payload(id_prescription, id_origin_user="ZZTEST-EXT-UNKNOWN"),
+        headers=integrator_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Usuário origem inválido"
+
+
+def test_static_check_rejects_an_origin_user_without_segment_authorization(
+    client, integrator_headers
+):
+    """POST /static/prescriptions/status - deve retornar erro [401 UNAUTHORIZED] quando o usuário de origem não tem o segmento autorizado"""
+    id_prescription = create_basic_prescription().id
+
+    response = client.post(
+        STATIC_CHECK_URL,
+        json=_payload(id_prescription, id_origin_user=UNAUTHORIZED_EXTERNAL),
+        headers=integrator_headers,
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["message"] == "Usuário não autorizado neste segmento"
+
+
+def test_static_check_rejects_an_inactive_origin_user(client, integrator_headers):
+    """POST /static/prescriptions/status - deve retornar erro [400] quando o usuário de origem está inativo"""
+    id_prescription = create_basic_prescription().id
+
+    response = client.post(
+        STATIC_CHECK_URL,
+        json=_payload(id_prescription, id_origin_user=INACTIVE_EXTERNAL),
+        headers=integrator_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Usuário origem inválido"
+
+
+def test_static_check_rejects_an_origin_user_of_another_schema(
+    client, integrator_headers
+):
+    """POST /static/prescriptions/status - deve retornar erro [400] quando o usuário de origem é de outro schema"""
+    id_prescription = create_basic_prescription().id
+
+    response = client.post(
+        STATIC_CHECK_URL,
+        json=_payload(id_prescription, id_origin_user=FOREIGN_EXTERNAL),
+        headers=integrator_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Usuário origem inválido"
+
+
+def test_static_check_rejects_an_origin_user_without_write_permission(
+    client, integrator_headers
+):
+    """POST /static/prescriptions/status - deve retornar erro [400] quando o usuário de origem não pode checar"""
+    id_prescription = create_basic_prescription().id
+
+    response = client.post(
+        STATIC_CHECK_URL,
+        json=_payload(id_prescription, id_origin_user=VIEWER_EXTERNAL),
+        headers=integrator_headers,
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.get_json()["message"]
+        == "Usuário origem não possui permissão para checagem"
+    )
+
+
+def test_static_check_leaves_the_prescription_untouched_when_it_fails(
+    client, integrator_headers
+):
+    """POST /static/prescriptions/status - não altera a prescrição quando o usuário de origem não pode checar"""
+    id_prescription = create_basic_prescription().id
+
+    client.post(
+        STATIC_CHECK_URL,
+        json=_payload(id_prescription, id_origin_user=VIEWER_EXTERNAL),
+        headers=integrator_headers,
+    )
+
+    session.expire_all()
+    prescription = (
+        session.query(Prescription).filter(Prescription.id == id_prescription).first()
+    )
+    assert prescription.status == "0"
+
+
+def test_static_check_rejects_an_unknown_prescription(client, integrator_headers):
+    """POST /static/prescriptions/status - deve retornar erro [400] quando a prescrição não existe"""
+    response = client.post(
+        STATIC_CHECK_URL, json=_payload(999999999), headers=integrator_headers
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Prescrição inexistente"
+
+
+def test_static_check_rejects_a_status_that_does_not_change(client, integrator_headers):
+    """POST /static/prescriptions/status - deve retornar erro [400] quando o status enviado não altera a prescrição"""
+    id_prescription = create_basic_prescription().id
+
+    client.post(
+        STATIC_CHECK_URL, json=_payload(id_prescription), headers=integrator_headers
+    )
+    response = client.post(
+        STATIC_CHECK_URL, json=_payload(id_prescription), headers=integrator_headers
+    )
+
+    assert response.status_code == 400
+    assert "já está checada" in response.get_json()["message"]
+
+
+def test_static_check_requires_the_run_as_permission(client, analyst_headers):
+    """POST /static/prescriptions/status - deve retornar erro [401 UNAUTHORIZED] sem a permissão RUN_AS"""
+    id_prescription = create_basic_prescription().id
+
+    response = client.post(
+        STATIC_CHECK_URL, json=_payload(id_prescription), headers=analyst_headers
+    )
+
+    assert response.status_code == 401
+
+
+def test_static_check_requires_authentication(client):
+    """POST /static/prescriptions/status - deve retornar erro [401 UNAUTHORIZED] sem autenticação"""
+    response = client.post(STATIC_CHECK_URL, json=_payload(1))
+
+    assert response.status_code == 401


### PR DESCRIPTION
Increases test coverage on two features that had none. Tests only — no production code changes.

## Drug form lookups — `tests/integration/test_drug_form_resources.py` (17 tests)

The catalogues the prescription drug form loads before it can be rendered:
`GET /drugs/resources/<idDrug>/<idSegment>[/<idHospital>]`, `GET /drugs/frequencies`
and `GET /lists/routes`.

- the full measure-unit and frequency catalogues, and their ordering by description
- the counts carried over from the drug's aggregated history, including the fact that a
  previously prescribed id comes back twice (history entry with the count, catalogue
  entry with zero) and that history from another segment is ignored
- the `/<idHospital>` variant returning the same payload as the two-segment route
- an unknown drug returning an empty name with the requested id echoed back
- `routes` and `intervals` staying empty outside the `complete` mode
- `extraFields` / `removeFields` read from the `transcription-fields` and
  `transcription-remove-fields` memories, and the empty case
- `map-routes` parsing: configured entries, absent memory, and malformed entries skipped
- the permission gates (`READ_PRESCRIPTION` on the drug endpoints,
  `READ_BASIC_FEATURES` on `/lists/routes`)

## Static prescription check — `tests/integration/test_static_prescription_status.py` (14 tests)

`POST /static/prescriptions/status` — the endpoint an external system calls to check a
prescription on behalf of one of its own users, identified by external id. The caller
authenticates as a `SERVICE_INTEGRATOR` (`RUN_AS`).

- happy path: the status is set, attributed to the **origin** user rather than the
  service integrator, and audited with `serviceUser: true`
- the response payload, and undoing a check with status `0`
- rejections: unknown external id, inactive origin user, origin user of another schema,
  origin user without segment authorization, origin user without `WRITE_PRESCRIPTION`,
  unknown prescription, and a status that does not change the prescription
- the prescription is left untouched when the origin user is refused
- the `RUN_AS` permission gate and the authentication gate

## Test hygiene

Both files clean their own rows and are re-runnable: the drug fixture reuses the
reserved `>= 90000` id range already wiped by `tests/conftest.py::_cleanup`, the origin
users use the `test%@example.com` pattern and drop their own `usuario_autorizacao` rows,
and the memory helper snapshots and restores whatever the schema already held instead of
deleting seed data.

## Verification

Full suite against a local PostgreSQL loaded from `noharm-ai/database` (the same SQL
files CI uses): **2323 passed** (2292 before), and green on a second consecutive run to
confirm re-runnability. `ruff check .` passes.

## Note (no change made)

While covering `static_check`, one behaviour stood out and was deliberately left
untested rather than pinned down: when `idOriginUser` is absent from the payload, the
lookup becomes `User.external IS NULL`, which matches whichever seed user comes back
first — so a caller omitting the field can end up running as an arbitrary user. It is
non-deterministic, so no test asserts it. Worth a look separately if you agree it's a
hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJNm2wnqhhzgxa3bx8NSpS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJNm2wnqhhzgxa3bx8NSpS)_