### PR TITLE
test: cover the discharge summary and the LLM provider dispatch

### DIFF
--- a/tests/integration/test_summary.py
+++ b/tests/integration/test_summary.py
@@ -1,0 +1,598 @@
+"""Integration tests for the discharge summary feature.
+
+``GET /summary/<admission_number>`` assembles everything the discharge summary
+screen needs for one admission: the patient header (including the derived
+IMC), the recent out-of-range exams, the active allergies, the saved draft and
+— the heart of the feature — the ``summaryConfig`` block, where each of the
+eight summary topics gets an LLM prompt built from the annotations that the
+text-mining step wrote on the admission's clinical notes.
+
+Those annotations are not simply "everything ever written". Each topic reads
+its own time window relative to the *first* or the *last* note of the
+admission: the admission reason only counts what was written in the first four
+days, the discharge condition only what was written in the last day, and so
+on. These tests cover that windowing, the de-duplication across notes, the
+``clinicalSummary`` composition, the mock mode used to preview prompts, and
+the validation/authorization boundaries.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from tests.conftest import session, session_commit
+
+# test-generated ids use the reserved ranges cleaned by tests/conftest.py
+ADMISSION = 100501
+ID_PATIENT = 100501
+ADMISSION_NO_NOTES = 100502
+ID_PATIENT_NO_NOTES = 100502
+
+NOTE_FIRST = 100801
+NOTE_SECOND_DAY_TWO = 100802
+NOTE_EVE_OF_LAST = 100803
+NOTE_LAST = 100804
+NOTE_IDS = [NOTE_FIRST, NOTE_SECOND_DAY_TWO, NOTE_EVE_OF_LAST, NOTE_LAST]
+
+# the admission spans 2024-01-10 (first note) to 2024-01-20 (last note)
+DATE_FIRST = "2024-01-10 08:00:00"
+DATE_DAY_TWO = "2024-01-12 08:00:00"
+DATE_EVE_OF_LAST = "2024-01-19 08:00:00"
+DATE_LAST = "2024-01-20 08:00:00"
+
+DRUG_WITH_SUBSTANCE = 90501
+DRUG_WITHOUT_SUBSTANCE = 90502
+SUBSTANCE = 90501
+SUBSTANCE_NAME = "ZZTEST SUBSTANCIA"
+
+EXAM_OUT_OF_RANGE = "zztestcreat"
+EXAM_IN_RANGE = "zztestsod"
+EXAM_OUT_OF_RANGE_OLD = "zztestpot"
+EXAM_TYPES = [EXAM_OUT_OF_RANGE, EXAM_IN_RANGE, EXAM_OUT_OF_RANGE_OLD]
+
+PROMPT_CONFIG_KIND = "zztest-summary-prompt"
+SUMMARY_KEYS = [
+    "reason",
+    "previousDrugs",
+    "diagnosis",
+    "dischargeCondition",
+    "dischargePlan",
+    "procedures",
+    "exams",
+    "clinicalSummary",
+]
+
+
+def _url(admission_number, mock=False):
+    """Build the endpoint URL, optionally asking for the mock prompt preview"""
+    return f"/summary/{admission_number}" + ("?mock=true" if mock else "")
+
+
+def _insert_patient(id_patient, admission_number, weight=None, height=None):
+    """Insert a synthetic patient/admission row"""
+    session.execute(
+        text(
+            "INSERT INTO demo.pessoa "
+            "(fkpessoa, nratendimento, dtinternacao, dtalta, dtnascimento, "
+            "sexo, peso, altura, dtpeso, cor) "
+            "VALUES (:id_patient, :admission, '2024-01-10 06:00:00', "
+            "'2024-01-21 10:00:00', '1970-05-04', 'F', :weight, :height, "
+            "'2024-01-10 06:00:00', 'ZZTEST COR')"
+        ),
+        {
+            "id_patient": id_patient,
+            "admission": admission_number,
+            "weight": weight,
+            "height": height,
+        },
+    )
+
+
+def _insert_note(id, admission_number, date, summary):
+    """Insert a clinical note carrying the given mined summary annotations"""
+    session.execute(
+        text(
+            "INSERT INTO demo.evolucao "
+            "(fkevolucao, nratendimento, texto, dtevolucao, cargo, exame, sumario) "
+            "VALUES (:id, :admission, 'Evolução de teste', :date, "
+            "'Médico', false, CAST(:summary AS jsonb))"
+        ),
+        {
+            "id": id,
+            "admission": admission_number,
+            "date": date,
+            "summary": json.dumps(summary),
+        },
+    )
+
+
+@pytest.fixture
+def summary_setup():
+    """Patient, notes, exams, allergies and prompt configuration of the feature
+
+    The notes are laid out so that every annotation window has a note that
+    falls inside it and a note that falls outside it.
+    """
+    _insert_patient(ID_PATIENT, ADMISSION, weight=70, height=170)
+    _insert_patient(ID_PATIENT_NO_NOTES, ADMISSION_NO_NOTES)
+
+    # first note of the admission: opens both the "first days" windows
+    _insert_note(
+        NOTE_FIRST,
+        ADMISSION,
+        DATE_FIRST,
+        {
+            "motivo": ["Dor abdominal"],
+            "medprevio": ["Losartana"],
+            "diagnostico": ["Apendicite"],
+            "procedimentos": ["Apendicectomia"],
+            "exames": ["Ultrassom de abdome"],
+            "resumo": ["Resumo do primeiro dia"],
+            "planoalta": ["Plano do primeiro dia"],
+            "condicaoalta": ["Condicao do primeiro dia"],
+        },
+    )
+    # two days in: inside the 4-day reason window, outside the 1-day
+    # previous-drugs window
+    _insert_note(
+        NOTE_SECOND_DAY_TWO,
+        ADMISSION,
+        DATE_DAY_TWO,
+        {
+            "motivo": ["Febre persistente"],
+            "medprevio": ["Metformina"],
+            "diagnostico": ["Apendicite"],
+        },
+    )
+    # eve of the last note: inside the 1-day discharge windows
+    _insert_note(
+        NOTE_EVE_OF_LAST,
+        ADMISSION,
+        DATE_EVE_OF_LAST,
+        {"resumo": ["Resumo da vespera"]},
+    )
+    # last note of the admission: closes the discharge windows
+    _insert_note(
+        NOTE_LAST,
+        ADMISSION,
+        DATE_LAST,
+        {
+            "motivo": ["Motivo registrado tardiamente"],
+            "resumo": ["Resumo final"],
+            "planoalta": ["Plano final"],
+            "condicaoalta": ["Alta melhorada"],
+            "procedimentos": ["Curativo"],
+        },
+    )
+
+    session.execute(
+        text(
+            "INSERT INTO public.substancia (sctid, nome, update_at, update_by) "
+            "VALUES (:sctid, :name, now(), 1)"
+        ),
+        {"sctid": SUBSTANCE, "name": SUBSTANCE_NAME},
+    )
+    session.execute(
+        text(
+            "INSERT INTO demo.medicamento (fkmedicamento, nome, sctid) "
+            "VALUES (:id, 'ZZTEST MEDICAMENTO', :sctid)"
+        ),
+        {"id": DRUG_WITH_SUBSTANCE, "sctid": SUBSTANCE},
+    )
+    session.execute(
+        text(
+            "INSERT INTO demo.medicamento (fkmedicamento, nome, sctid) "
+            "VALUES (:id, 'ZZTEST MEDICAMENTO SEM SUBSTANCIA', null)"
+        ),
+        {"id": DRUG_WITHOUT_SUBSTANCE},
+    )
+
+    # allergy resolved through the substance catalogue
+    session.execute(
+        text(
+            "INSERT INTO demo.alergia "
+            "(fkpessoa, fkmedicamento, nome_medicamento, ativo, created_by) "
+            "VALUES (:id_patient, :drug, 'ZZTEST NOME LOCAL', true, 1)"
+        ),
+        {"id_patient": ID_PATIENT, "drug": DRUG_WITH_SUBSTANCE},
+    )
+    # allergy that falls back to the free-text drug name
+    session.execute(
+        text(
+            "INSERT INTO demo.alergia "
+            "(fkpessoa, fkmedicamento, nome_medicamento, ativo, created_by) "
+            "VALUES (:id_patient, null, 'ZZTEST DIPIRONA', true, 1)"
+        ),
+        {"id_patient": ID_PATIENT},
+    )
+    # inactive allergy: must not reach the summary
+    session.execute(
+        text(
+            "INSERT INTO demo.alergia "
+            "(fkpessoa, fkmedicamento, nome_medicamento, ativo, created_by) "
+            "VALUES (:id_patient, :drug, 'ZZTEST INATIVA', false, 1)"
+        ),
+        {"id_patient": ID_PATIENT, "drug": DRUG_WITHOUT_SUBSTANCE},
+    )
+
+    for position, (exam_type, abbrev, minimum, maximum) in enumerate(
+        [
+            (EXAM_OUT_OF_RANGE, "ZZTESTCREAT", 0.5, 1.2),
+            (EXAM_IN_RANGE, "ZZTESTSOD", 135, 145),
+            (EXAM_OUT_OF_RANGE_OLD, "ZZTESTPOT", 3.5, 5.5),
+        ],
+        start=1,
+    ):
+        session.execute(
+            text(
+                "INSERT INTO demo.segmentoexame "
+                "(idsegmento, tpexame, abrev, nome, min, max, referencia, "
+                "posicao, ativo, update_by) "
+                "VALUES (1, :type, :abbrev, :abbrev, :min, :max, "
+                "'ZZTEST referencia', :position, true, 1)"
+            ),
+            {
+                "type": exam_type,
+                "abbrev": abbrev,
+                "min": minimum,
+                "max": maximum,
+                "position": position,
+            },
+        )
+
+    for exam_id, (exam_type, result, days_ago) in enumerate(
+        [
+            # out of range and inside the 7-day window: the only one shown
+            (EXAM_OUT_OF_RANGE, 3.5, 1),
+            # inside the reference range: not an alert
+            (EXAM_IN_RANGE, 140, 1),
+            # out of range but older than the 7-day window
+            (EXAM_OUT_OF_RANGE_OLD, 9.9, 30),
+        ],
+        start=1,
+    ):
+        session.execute(
+            text(
+                "INSERT INTO demo.exame "
+                "(fkexame, fkpessoa, nratendimento, dtexame, tpexame, "
+                "resultado, unidade) "
+                "VALUES (:id, :id_patient, :admission, "
+                "now() - CAST(:days || ' days' AS interval), :type, "
+                ":result, 'ZZTESTUN')"
+            ),
+            {
+                "id": 100900 + exam_id,
+                "id_patient": ID_PATIENT,
+                "admission": ADMISSION,
+                "days": days_ago,
+                "type": exam_type,
+                "result": result,
+            },
+        )
+
+    # the feature is driven by two global memory records: the config points at
+    # the prompt record, and the prompt record holds one message list per topic
+    session.execute(
+        text(
+            "INSERT INTO public.memoria (tipo, valor, update_at, update_by) "
+            "VALUES ('summary-config', CAST(:value AS json), now(), 1)"
+        ),
+        {
+            "value": json.dumps(
+                {"provider": "claude", "prompt-config": PROMPT_CONFIG_KIND}
+            )
+        },
+    )
+    session.execute(
+        text(
+            "INSERT INTO public.memoria (tipo, valor, update_at, update_by) "
+            "VALUES (:kind, CAST(:value AS json), now(), 1)"
+        ),
+        {
+            "kind": PROMPT_CONFIG_KIND,
+            "value": json.dumps(
+                {
+                    key: [{"role": "user", "content": f"{key}: :replace_text"}]
+                    for key in SUMMARY_KEYS
+                }
+            ),
+        },
+    )
+
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM demo.evolucao WHERE fkevolucao = ANY(:ids)"),
+        {"ids": NOTE_IDS},
+    )
+    session.execute(
+        text("DELETE FROM demo.exame WHERE fkpessoa = :id_patient"),
+        {"id_patient": ID_PATIENT},
+    )
+    session.execute(
+        text("DELETE FROM demo.segmentoexame WHERE tpexame = ANY(:types)"),
+        {"types": EXAM_TYPES},
+    )
+    session.execute(
+        text("DELETE FROM demo.alergia WHERE fkpessoa = :id_patient"),
+        {"id_patient": ID_PATIENT},
+    )
+    session.execute(
+        text("DELETE FROM demo.medicamento WHERE fkmedicamento = ANY(:ids)"),
+        {"ids": [DRUG_WITH_SUBSTANCE, DRUG_WITHOUT_SUBSTANCE]},
+    )
+    session.execute(
+        text("DELETE FROM public.substancia WHERE sctid = :sctid"),
+        {"sctid": SUBSTANCE},
+    )
+    session.execute(
+        text("DELETE FROM public.memoria WHERE tipo IN ('summary-config', :kind)"),
+        {"kind": PROMPT_CONFIG_KIND},
+    )
+    session.execute(
+        text("DELETE FROM demo.pessoa WHERE nratendimento = ANY(:admissions)"),
+        {"admissions": [ADMISSION, ADMISSION_NO_NOTES]},
+    )
+    session.execute(
+        text("DELETE FROM demo.pessoa_audit WHERE nratendimento = ANY(:admissions)"),
+        {"admissions": [ADMISSION, ADMISSION_NO_NOTES]},
+    )
+    session_commit()
+
+
+@pytest.fixture
+def summary_draft():
+    """A previously saved discharge summary draft for the admission"""
+    kind = f"draft_summary_{ADMISSION}"
+    session.execute(
+        text(
+            "INSERT INTO demo.memoria (tipo, valor, update_at, update_by) "
+            "VALUES (:kind, CAST(:value AS json), now(), 1)"
+        ),
+        {"kind": kind, "value": json.dumps({"reason": "Rascunho salvo"})},
+    )
+    session_commit()
+
+    yield
+
+    session.execute(text("DELETE FROM demo.memoria WHERE tipo = :kind"), {"kind": kind})
+    session_commit()
+
+
+@pytest.fixture
+def summary_mock_texts():
+    """Sample texts used by the prompt preview (``?mock=true``)"""
+    for key in SUMMARY_KEYS:
+        session.execute(
+            text(
+                "INSERT INTO demo.memoria (tipo, valor, update_at, update_by) "
+                "VALUES (:kind, CAST(:value AS json), now(), 1)"
+            ),
+            {
+                "kind": f"summary_text_{key}",
+                "value": json.dumps({"text": f"ZZTEST exemplo {key}"}),
+            },
+        )
+    session_commit()
+
+    yield
+
+    session.execute(
+        text("DELETE FROM demo.memoria WHERE tipo LIKE 'summary!_text!_%' ESCAPE '!'")
+    )
+    session_commit()
+
+
+def _get_summary(client, headers, admission_number=ADMISSION, mock=False):
+    """Call the endpoint and return the parsed ``data`` payload"""
+    response = client.get(_url(admission_number, mock=mock), headers=headers)
+
+    assert response.status_code == 200
+
+    return response.get_json()["data"]
+
+
+def _audit(data, key):
+    """Annotations that fed the prompt of one summary topic, order-independent"""
+    return sorted(data["summaryConfig"][key]["audit"])
+
+
+def test_summary_no_token(client, summary_setup):
+    """GET /summary/<admission> — returns 401 without authentication"""
+    response = client.get(_url(ADMISSION), headers={"Accept": "application/json"})
+
+    assert response.status_code == 401
+
+
+def test_summary_permission_denied(client, viewer_headers, summary_setup):
+    """GET /summary/<admission> — a role without READ_DISCHARGE_SUMMARY is rejected"""
+    response = client.get(_url(ADMISSION), headers=viewer_headers)
+
+    assert response.status_code == 401
+
+
+def test_summary_unknown_admission(client, navigator_headers, summary_setup):
+    """GET /summary/<admission> — an admission that does not exist is rejected"""
+    response = client.get(_url(999999999), headers=navigator_headers)
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.invalidRecord"
+
+
+def test_summary_patient_header(client, navigator_headers, summary_setup):
+    """GET /summary/<admission> — returns the patient header with the derived IMC"""
+    patient = _get_summary(client, navigator_headers)["patient"]
+
+    assert patient["idPatient"] == str(ID_PATIENT)
+    assert patient["admissionNumber"] == ADMISSION
+    assert patient["admissionDate"].startswith("2024-01-10")
+    assert patient["dischargeDate"].startswith("2024-01-21")
+    assert patient["birthdate"] == "1970-05-04"
+    assert patient["gender"] == "F"
+    assert patient["weight"] == 70
+    assert patient["height"] == 170
+    assert patient["weightDate"].startswith("2024-01-10")
+    assert patient["color"] == "ZZTEST COR"
+    # 70 kg / (1.70 m)^2
+    assert patient["imc"] == 24.22
+
+
+def test_summary_imc_is_none_without_weight_and_height(
+    client, navigator_headers, summary_setup
+):
+    """GET /summary/<admission> — the IMC is omitted when weight/height are unknown"""
+    patient = _get_summary(client, navigator_headers, ADMISSION_NO_NOTES)["patient"]
+
+    assert patient["weight"] is None
+    assert patient["height"] is None
+    assert patient["imc"] is None
+
+
+def test_summary_lists_only_active_allergies(client, navigator_headers, summary_setup):
+    """GET /summary/<admission> — active allergies only, named by substance when known"""
+    allergies = _get_summary(client, navigator_headers)["allergies"]
+
+    names = sorted(a["name"] for a in allergies)
+
+    # the substance name wins over the local drug name of the same allergy
+    assert names == ["ZZTEST DIPIRONA", SUBSTANCE_NAME]
+    assert "ZZTEST INATIVA" not in names
+    assert "ZZTEST NOME LOCAL" not in names
+
+
+def test_summary_exams_are_recent_and_out_of_range(
+    client, navigator_headers, summary_setup
+):
+    """GET /summary/<admission> — only out-of-range exams of the last 7 days show up"""
+    exams = _get_summary(client, navigator_headers)["exams"]
+
+    assert [e["name"] for e in exams] == ["ZZTESTCREAT"]
+    assert exams[0]["result"] == 3.5
+    assert exams[0]["measureUnit"] == "ZZTESTUN"
+    assert exams[0]["date"] is not None
+
+
+def test_summary_reason_window_covers_the_first_four_days(
+    client, navigator_headers, summary_setup
+):
+    """GET /summary/<admission> — the admission reason reads the first four days"""
+    data = _get_summary(client, navigator_headers)
+
+    # written on the first note and two days later: both inside the window
+    assert _audit(data, "reason") == ["Dor abdominal", "Febre persistente"]
+    # written ten days after the first note: outside the window
+    assert "Motivo registrado tardiamente" not in _audit(data, "reason")
+
+
+def test_summary_previous_drugs_window_covers_the_first_day(
+    client, navigator_headers, summary_setup
+):
+    """GET /summary/<admission> — previous drugs read only the first day"""
+    data = _get_summary(client, navigator_headers)
+
+    assert _audit(data, "previousDrugs") == ["Losartana"]
+    # recorded on day two, already outside the one-day window
+    assert "Metformina" not in _audit(data, "previousDrugs")
+
+
+def test_summary_discharge_annotations_window_covers_the_last_day(
+    client, navigator_headers, summary_setup
+):
+    """GET /summary/<admission> — discharge topics read backwards from the last note"""
+    data = _get_summary(client, navigator_headers)
+
+    # the last note and its eve are inside the window, the first note is not
+    assert _audit(data, "dischargeCondition") == ["Alta melhorada"]
+    assert _audit(data, "dischargePlan") == ["Plano final"]
+    assert "Condicao do primeiro dia" not in _audit(data, "dischargeCondition")
+    assert "Plano do primeiro dia" not in _audit(data, "dischargePlan")
+
+
+def test_summary_unwindowed_topics_read_the_whole_admission(
+    client, navigator_headers, summary_setup
+):
+    """GET /summary/<admission> — diagnosis, procedures and exams span every note"""
+    data = _get_summary(client, navigator_headers)
+
+    # written on two different notes, reported once
+    assert _audit(data, "diagnosis") == ["Apendicite"]
+    # first and last note, ten days apart, both kept
+    assert _audit(data, "procedures") == ["Apendicectomia", "Curativo"]
+    assert _audit(data, "exams") == ["Ultrassom de abdome"]
+
+
+def test_summary_clinical_summary_joins_reason_procedures_and_summary(
+    client, navigator_headers, summary_setup
+):
+    """GET /summary/<admission> — the clinical summary composes three other topics"""
+    data = _get_summary(client, navigator_headers)
+
+    expected = (
+        _audit(data, "reason")
+        + _audit(data, "procedures")
+        # the "resumo" annotations, which have no topic of their own
+        + ["Resumo da vespera", "Resumo final"]
+    )
+
+    assert _audit(data, "clinicalSummary") == sorted(expected)
+    # the first-day summary is outside the one-day window of the last note
+    assert "Resumo do primeiro dia" not in _audit(data, "clinicalSummary")
+
+
+def test_summary_prompt_carries_the_annotation_text(
+    client, navigator_headers, summary_setup
+):
+    """GET /summary/<admission> — the placeholder is replaced by the annotations"""
+    data = _get_summary(client, navigator_headers)
+
+    prompt = data["summaryConfig"]["previousDrugs"]["prompt"]
+
+    assert prompt == [{"role": "user", "content": "previousDrugs: Losartana"}]
+    assert sorted(data["summaryConfig"].keys()) == sorted(SUMMARY_KEYS)
+
+
+def test_summary_mock_prompt_uses_the_sample_text(
+    client, navigator_headers, summary_setup, summary_mock_texts
+):
+    """GET /summary/<admission>?mock=true — prompts preview the stored sample text"""
+    data = _get_summary(client, navigator_headers, mock=True)
+
+    prompt = data["summaryConfig"]["previousDrugs"]["prompt"]
+
+    assert prompt == [
+        {"role": "user", "content": "previousDrugs: ZZTEST exemplo previousDrugs"}
+    ]
+    # the audit trail still reports the real annotations of the admission
+    assert _audit(data, "previousDrugs") == ["Losartana"]
+
+
+def test_summary_without_notes_has_empty_annotations(
+    client, navigator_headers, summary_setup
+):
+    """GET /summary/<admission> — an admission with no notes yields empty topics"""
+    data = _get_summary(client, navigator_headers, ADMISSION_NO_NOTES)
+
+    for key in SUMMARY_KEYS:
+        assert data["summaryConfig"][key]["audit"] == []
+        assert data["summaryConfig"][key]["prompt"] == [
+            {"role": "user", "content": f"{key}: "}
+        ]
+
+
+def test_summary_returns_no_draft_when_none_was_saved(
+    client, navigator_headers, summary_setup
+):
+    """GET /summary/<admission> — the draft is null until one is saved"""
+    assert _get_summary(client, navigator_headers)["draft"] is None
+
+
+def test_summary_returns_the_saved_draft(
+    client, navigator_headers, summary_setup, summary_draft
+):
+    """GET /summary/<admission> — a saved draft comes back with the summary"""
+    assert _get_summary(client, navigator_headers)["draft"] == {
+        "reason": "Rascunho salvo"
+    }

--- a/tests/unit/test_llm_service.py
+++ b/tests/unit/test_llm_service.py
@@ -1,0 +1,295 @@
+"""Unit tests for services.llm_service.prompt.
+
+``prompt`` is the single entry point the discharge summary screen uses to talk
+to a language model. Which model answers is not decided by the caller: the
+``summary-config`` global memory record names the provider, and ``prompt``
+dispatches to the matching backend, each of which has its own request body,
+its own Bedrock region and its own response shape to unwrap.
+
+Both boundaries are mocked — the ``summary-config`` lookup (``db``) and the
+Bedrock client (``utils.aws``) — so these tests cover the dispatch table, the
+request bodies that are actually sent, the answer extraction of each provider
+and the validation branches without a database or any AWS access.
+
+The service is guarded by ``@has_permission(READ_DISCHARGE_SUMMARY)``. The
+decorator resolves the caller from the JWT identity, so the JWT lookup and
+``User`` model are patched to inject a fabricated user carrying (or missing)
+the required role inside a Flask request context.
+"""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from exception.authorization_error import AuthorizationError
+from exception.validation_error import ValidationError
+from mobile import app
+from security.role import Role
+from services import llm_service
+from utils import status
+
+MESSAGES = [
+    {"role": "user", "content": "Resuma a internação"},
+    {"role": "assistant", "content": "Claro"},
+]
+
+
+@contextmanager
+def acting_as(roles):
+    """Run the block inside a request context authenticated as ``roles``.
+
+    Patches the permission decorator's JWT identity lookup and ``User`` model
+    so the decorated service resolves a fabricated user carrying ``roles``.
+    """
+    fake_user = MagicMock()
+    fake_user.config = {"roles": roles}
+    with app.test_request_context():
+        with (
+            patch(
+                "decorators.has_permission_decorator.get_jwt_identity", return_value=1
+            ),
+            patch("decorators.has_permission_decorator.User") as mock_user_cls,
+        ):
+            mock_user_cls.find.return_value = fake_user
+            yield
+
+
+@contextmanager
+def summary_config(value):
+    """Make the ``summary-config`` lookup return a record with ``value``.
+
+    ``None`` stands for "no configuration stored".
+    """
+    record = None
+    if value is not None:
+        record = MagicMock()
+        record.value = value
+
+    with patch("services.llm_service.db") as mock_db:
+        mock_db.session.query.return_value.filter.return_value.first.return_value = (
+            record
+        )
+        yield
+
+
+@contextmanager
+def bedrock_answering(payload):
+    """Make the Bedrock client return ``payload`` as the model response body"""
+    client = MagicMock()
+    body = MagicMock()
+    body.read.return_value = json.dumps(payload).encode("utf-8")
+    client.invoke_model.return_value = {"body": body}
+
+    with patch("services.llm_service.aws") as mock_aws:
+        mock_aws.get_client.return_value = client
+        yield mock_aws, client
+
+
+def _sent_body(client):
+    """The request body the service handed to Bedrock, decoded"""
+    return json.loads(client.invoke_model.call_args.kwargs["body"])
+
+
+class TestGuards:
+    """Permission gating, empty input and configuration validation."""
+
+    def test_permission_denied_without_discharge_summary_role(self):
+        """A role lacking READ_DISCHARGE_SUMMARY cannot prompt the model"""
+        with acting_as([Role.VIEWER.value]):
+            with pytest.raises(AuthorizationError):
+                llm_service.prompt(MESSAGES)
+
+    @pytest.mark.parametrize("messages", [None, []])
+    def test_empty_messages_return_empty_answer(self, messages):
+        """Nothing to ask means nothing to answer, and no provider is consulted"""
+        with acting_as([Role.NAVIGATOR.value]):
+            with patch("services.llm_service.aws") as mock_aws:
+                assert llm_service.prompt(messages) == ""
+
+        mock_aws.get_client.assert_not_called()
+
+    def test_missing_configuration_is_rejected(self):
+        """Without a summary-config record there is no provider to dispatch to"""
+        with acting_as([Role.NAVIGATOR.value]), summary_config(None):
+            with pytest.raises(ValidationError) as exc:
+                llm_service.prompt(MESSAGES)
+
+        assert exc.value.code == "errors.invalidParams"
+        assert exc.value.httpStatus == status.HTTP_400_BAD_REQUEST
+
+    def test_unknown_provider_is_rejected(self):
+        """A provider outside the supported list is rejected before any call"""
+        with (
+            acting_as([Role.NAVIGATOR.value]),
+            summary_config({"provider": "some-other-llm"}),
+        ):
+            with pytest.raises(ValidationError) as exc:
+                llm_service.prompt(MESSAGES)
+
+        assert exc.value.code == "errors.invalidParams"
+
+    @pytest.mark.parametrize(
+        "provider,message",
+        [("openai_azure", "OpenAi"), ("maritaca", "Maritaca")],
+    )
+    def test_accepted_but_unimplemented_providers(self, provider, message):
+        """Configurable providers that have no backend yet report it explicitly"""
+        with acting_as([Role.NAVIGATOR.value]), summary_config({"provider": provider}):
+            with pytest.raises(ValidationError) as exc:
+                llm_service.prompt(MESSAGES)
+
+        assert exc.value.code == "errors.invalidModule"
+        assert message in str(exc.value)
+
+
+class TestClaudeProvider:
+    """Dispatch to the Anthropic models hosted on Bedrock."""
+
+    def test_returns_the_first_content_block(self):
+        """The answer is the text of the first content block of the response"""
+        with (
+            acting_as([Role.NAVIGATOR.value]),
+            summary_config({"provider": "claude"}),
+            bedrock_answering(
+                {"content": [{"text": "Paciente estável"}, {"text": "ignorado"}]}
+            ),
+        ):
+            result = llm_service.prompt(MESSAGES)
+
+        assert result == {"answer": "Paciente estável"}
+
+    def test_sends_the_messages_and_the_anthropic_version(self):
+        """The conversation is forwarded verbatim with the Bedrock API version"""
+        with (
+            acting_as([Role.NAVIGATOR.value]),
+            summary_config({"provider": "claude"}),
+            bedrock_answering({"content": [{"text": "ok"}]}) as (mock_aws, client),
+        ):
+            llm_service.prompt(MESSAGES)
+
+        body = _sent_body(client)
+        assert body["messages"] == MESSAGES
+        assert body["max_tokens"] == 1024
+        assert body["anthropic_version"] == "bedrock-2023-05-31"
+        assert client.invoke_model.call_args.kwargs["contentType"] == "application/json"
+        mock_aws.get_client.assert_called_once_with(
+            "bedrock-runtime", region_name="us-east-1"
+        )
+
+
+class TestGptOssProvider:
+    """Dispatch to the open-weights GPT model hosted on Bedrock."""
+
+    def test_returns_the_first_choice_message(self):
+        """The answer is the content of the first choice of the response"""
+        with (
+            acting_as([Role.NAVIGATOR.value]),
+            summary_config({"provider": "gpt_oss"}),
+            bedrock_answering(
+                {"choices": [{"message": {"content": "Alta em bom estado"}}]}
+            ),
+        ):
+            result = llm_service.prompt(MESSAGES)
+
+        assert result == {"answer": "Alta em bom estado"}
+
+    def test_strips_the_reasoning_block(self):
+        """The model's chain of thought is removed before the answer is returned"""
+        answer = "<reasoning>pensando\nem varias linhas</reasoning>Conduta mantida"
+        with (
+            acting_as([Role.NAVIGATOR.value]),
+            summary_config({"provider": "gpt_oss"}),
+            bedrock_answering({"choices": [{"message": {"content": answer}}]}),
+        ):
+            result = llm_service.prompt(MESSAGES)
+
+        assert result == {"answer": "Conduta mantida"}
+
+    def test_strips_every_reasoning_block(self):
+        """More than one reasoning block is removed, not only the first"""
+        answer = "<reasoning>a</reasoning>parte 1<reasoning>b</reasoning>parte 2"
+        with (
+            acting_as([Role.NAVIGATOR.value]),
+            summary_config({"provider": "gpt_oss"}),
+            bedrock_answering({"choices": [{"message": {"content": answer}}]}),
+        ):
+            result = llm_service.prompt(MESSAGES)
+
+        assert result == {"answer": "parte 1parte 2"}
+
+    def test_sends_the_messages_to_the_gpt_oss_model(self):
+        """The conversation is forwarded to the gpt-oss model in us-east-1"""
+        with (
+            acting_as([Role.NAVIGATOR.value]),
+            summary_config({"provider": "gpt_oss"}),
+            bedrock_answering({"choices": [{"message": {"content": "ok"}}]}) as (
+                mock_aws,
+                client,
+            ),
+        ):
+            llm_service.prompt(MESSAGES)
+
+        body = _sent_body(client)
+        assert body["messages"] == MESSAGES
+        assert body["max_tokens"] == 1024
+        # the Anthropic-only field must not leak into the other providers
+        assert "anthropic_version" not in body
+        assert "gpt-oss" in client.invoke_model.call_args.kwargs["modelId"]
+        mock_aws.get_client.assert_called_once_with(
+            "bedrock-runtime", region_name="us-east-1"
+        )
+
+
+class TestLlamaProvider:
+    """Dispatch to the Llama model, which takes a flat prompt string."""
+
+    def test_returns_the_generation(self):
+        """The answer is the ``generation`` field of the response"""
+        with (
+            acting_as([Role.NAVIGATOR.value]),
+            summary_config({"provider": "llama"}),
+            bedrock_answering({"generation": "Resumo gerado"}),
+        ):
+            result = llm_service.prompt(MESSAGES)
+
+        assert result == {"answer": "Resumo gerado"}
+
+    def test_renders_the_conversation_with_llama_header_tokens(self):
+        """Each message becomes a header/content pair, ending on the assistant turn"""
+        with (
+            acting_as([Role.NAVIGATOR.value]),
+            summary_config({"provider": "llama"}),
+            bedrock_answering({"generation": "ok"}) as (mock_aws, client),
+        ):
+            llm_service.prompt(MESSAGES)
+
+        prompt = _sent_body(client)["prompt"]
+
+        assert prompt == (
+            "<|begin_of_text|>"
+            "<|start_header_id|>user<|end_header_id|>\n"
+            "Resuma a internação<|eot_id|>\n"
+            "<|start_header_id|>assistant<|end_header_id|>\n"
+            "Claro<|eot_id|>\n"
+            "<|start_header_id|>assistant<|end_header_id|>"
+        )
+        # Llama is served from a different region than the other providers
+        mock_aws.get_client.assert_called_once_with(
+            "bedrock-runtime", region_name="us-west-2"
+        )
+
+    def test_sends_the_generation_parameters(self):
+        """The sampling parameters travel with the prompt"""
+        with (
+            acting_as([Role.NAVIGATOR.value]),
+            summary_config({"provider": "llama"}),
+            bedrock_answering({"generation": "ok"}) as (_, client),
+        ):
+            llm_service.prompt(MESSAGES)
+
+        body = _sent_body(client)
+        assert body["max_gen_len"] == 1024
+        assert body["temperature"] == 0.5
+        assert body["top_p"] == 0.9


### PR DESCRIPTION
Two features had no tests at all. This adds one integration suite and one unit suite for them.

## `GET /summary/<admission_number>` — discharge summary (integration)

`tests/integration/test_summary.py` — 17 tests, `services/summary_service.py` goes from **30% → 100%**.

The interesting logic is the annotation windowing: each summary topic reads its own time window relative to the *first* or the *last* clinical note of the admission (the admission reason covers the first four days, previous drugs only the first day, the discharge topics only the last day, and diagnosis/procedures/exams have no window at all). The fixture lays out four notes so every window has a note inside it and a note outside it, and the tests assert both sides.

Also covered: the patient header and the derived IMC (and the `None` case when weight/height are unknown), the exams filter (out-of-range **and** within the last 7 days), active-only allergies named by substance when the drug is catalogued, de-duplication across notes, the `clinicalSummary` composition from reason + procedures + summary, the saved draft, the `?mock=true` prompt preview, an admission with no notes, and the 401/400 boundaries.

## `llm_service.prompt` — model provider dispatch (unit)

`tests/unit/test_llm_service.py` — 16 tests, `services/llm_service.py` goes from **24% → 100%**.

Both boundaries are mocked (the `summary-config` lookup and the Bedrock client), so no database and no AWS access. Covers the dispatch table, each provider's request body, model id and region, the answer extraction for claude / gpt_oss / llama (including the `<reasoning>` stripping, single and repeated), and the guards: permission gating, empty messages, missing configuration, unknown provider, and the two configurable-but-unimplemented providers.

## Notes

- All test data is synthetic and self-cleaning; the suite was run twice back-to-back with no leftover rows.
- Full suite: 2326 → 2359 passing. `ruff check` clean.
- Combined `services` + `repository` coverage: 80% → 81%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kmjcsax3vdE2YXXDKEBk96

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kmjcsax3vdE2YXXDKEBk96)_