### PR TITLE
test: cover the raw exams report and the user security-group update

### DIFF
--- a/tests/integration/test_admin_integration.py
+++ b/tests/integration/test_admin_integration.py
@@ -1,0 +1,253 @@
+"""Tests: POST /admin/integration/update-user-security-group
+
+Support tooling: it opens the client's AWS security group for the machine the
+caller is asking from, so an operator can reach the integration environment.
+The backend itself changes nothing -- a Lambda does -- and everything worth
+pinning down is what the backend decides around that call:
+
+* only a role holding UPDATE_USER_SG may ask (the route is also refused
+  outright in production, which ``api_endpoint(is_admin=True)`` handles and
+  ``tests/unit/test_api_endpoint_decorator.py`` covers);
+* the rule is opened for the *caller's* address, taken from the proxy headers
+  the way the API Gateway forwards it, narrowed to a single host (``/32``);
+* the Lambda answer is handed back untouched, including when it arrives
+  double-encoded (a JSON string holding JSON), which is how the function
+  replies today;
+* an answer flagged ``error`` becomes a business-rule error, and then nothing
+  is audited;
+* a successful change leaves an audit record naming the schema, the new
+  address and who asked.
+
+The Lambda is replaced by a recorder throughout: the test asserts on the
+payload the backend sends, which is the part it actually decides.
+"""
+
+import io
+import json
+
+import pytest
+from sqlalchemy import text
+
+from config import Config
+from models.enums import SchemaConfigAuditTypeEnum
+from services.admin import admin_integration_service
+from tests.conftest import session, session_commit
+from utils import status
+
+URL = "/admin/integration/update-user-security-group"
+
+# public.usuario row behind the admin_headers fixture
+_ADMIN_USER_ID = 2
+_ADMIN_USER_EMAIL = "user@admin.com"
+_ADMIN_USER_SCHEMA = "demo"
+
+# the command the backend Lambda dispatches on
+_COMMAND = "lambda_create_schema.update_user_sec_group_rules"
+
+# a documentation address (RFC 5737), forwarded as if by the API Gateway
+_CALLER_IP = "203.0.113.7"
+
+# what the test client itself connects from, when no proxy header is present
+_CONNECTION_IP = "127.0.0.1"
+
+_AUDIT_TYPE = SchemaConfigAuditTypeEnum.USER_SECURITY_GROUP.value
+
+
+class _FakeLambda:
+    """Records every invoke and replies with what the test asked for."""
+
+    def __init__(self):
+        self.clients = []
+        self.invocations = []
+        self.reply = {"status": "ok"}
+
+    def get_client(self, service_name: str, region_name: str = None):
+        """Stands in for ``utils.aws.get_client``."""
+        self.clients.append((service_name, region_name))
+        return self
+
+    def invoke(self, **kwargs):
+        """Stands in for the boto3 Lambda client."""
+        self.invocations.append(kwargs)
+
+        body = self.reply
+        if not isinstance(body, str):
+            body = json.dumps(body)
+
+        return {"Payload": io.BytesIO(body.encode("utf-8"))}
+
+    @property
+    def payload(self):
+        """The payload of the single invocation the endpoint made."""
+        assert len(self.invocations) == 1
+        return json.loads(self.invocations[0]["Payload"])
+
+
+@pytest.fixture
+def aws_lambda(monkeypatch):
+    """Replace the AWS layer of the service with a recorder."""
+    fake = _FakeLambda()
+    monkeypatch.setattr(admin_integration_service.aws, "get_client", fake.get_client)
+
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def clean_audit():
+    """The seed dump has no audit record of this kind: keep it that way."""
+    _remove_audit()
+    yield
+    _remove_audit()
+
+
+def _remove_audit():
+    """Drop the audit records this endpoint writes."""
+    session.execute(
+        text("DELETE FROM public.schema_config_audit WHERE tp_audit = :type"),
+        {"type": _AUDIT_TYPE},
+    )
+    session_commit()
+
+
+def _audit_records():
+    """Every security-group audit record, oldest first."""
+    return session.execute(
+        text(
+            "SELECT schema_name, tp_audit, extra, created_by "
+            "FROM public.schema_config_audit "
+            "WHERE tp_audit = :type ORDER BY idschema_config_audit"
+        ),
+        {"type": _AUDIT_TYPE},
+    ).all()
+
+
+def _call(client, headers, caller_ip=_CALLER_IP):
+    """Ask for the caller's address to be allowed."""
+    if caller_ip is not None:
+        headers = {**headers, "X-Forwarded-For": caller_ip}
+
+    return client.post(URL, headers=headers)
+
+
+def test_update_requires_the_update_user_sg_permission(
+    client, analyst_headers, aws_lambda
+):
+    """POST /admin/integration/update-user-security-group - a role without UPDATE_USER_SG is refused [401 UNAUTHORIZED]"""
+    response = _call(client, analyst_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    # the Lambda must not have been reached at all
+    assert aws_lambda.invocations == []
+    assert _audit_records() == []
+
+
+def test_update_invokes_the_backend_lambda_synchronously(
+    client, admin_headers, aws_lambda
+):
+    """POST /admin/integration/update-user-security-group - the backend function is invoked once, synchronously"""
+    response = _call(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert aws_lambda.clients == [("lambda", Config.NIFI_SQS_QUEUE_REGION)]
+    assert len(aws_lambda.invocations) == 1
+    assert aws_lambda.invocations[0]["FunctionName"] == Config.BACKEND_FUNCTION_NAME
+    assert aws_lambda.invocations[0]["InvocationType"] == "RequestResponse"
+
+
+def test_update_asks_for_the_caller_address_as_a_single_host_rule(
+    client, admin_headers, aws_lambda
+):
+    """POST /admin/integration/update-user-security-group - the forwarded caller address is opened as a /32"""
+    _call(client, admin_headers)
+
+    assert aws_lambda.payload == {
+        "command": _COMMAND,
+        "user": _ADMIN_USER_EMAIL,
+        "new_cidr": f"{_CALLER_IP}/32",
+    }
+
+
+def test_update_falls_back_to_the_connection_address(client, admin_headers, aws_lambda):
+    """POST /admin/integration/update-user-security-group - without a proxy header the connection address is used"""
+    _call(client, admin_headers, caller_ip=None)
+
+    assert aws_lambda.payload["new_cidr"] == f"{_CONNECTION_IP}/32"
+
+
+def test_update_uses_the_first_forwarded_address(client, admin_headers, aws_lambda):
+    """POST /admin/integration/update-user-security-group - the original client wins over the proxies behind it"""
+    _call(client, admin_headers, caller_ip=f"{_CALLER_IP}, 198.51.100.4")
+
+    assert aws_lambda.payload["new_cidr"] == f"{_CALLER_IP}/32"
+
+
+def test_update_returns_the_lambda_answer(client, admin_headers, aws_lambda):
+    """POST /admin/integration/update-user-security-group - the Lambda answer is handed back untouched"""
+    aws_lambda.reply = {"error": False, "message": "grupo atualizado"}
+
+    response = _call(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert json.loads(response.data)["data"] == {
+        "error": False,
+        "message": "grupo atualizado",
+    }
+
+
+def test_update_unwraps_a_double_encoded_answer(client, admin_headers, aws_lambda):
+    """POST /admin/integration/update-user-security-group - an answer encoded as a JSON string is decoded twice"""
+    aws_lambda.reply = json.dumps({"status": "ok", "rules": 2})
+
+    response = _call(client, admin_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert json.loads(response.data)["data"] == {"status": "ok", "rules": 2}
+
+
+def test_update_audits_the_new_address(client, admin_headers, aws_lambda):
+    """POST /admin/integration/update-user-security-group - the change is audited with the schema, address and author"""
+    _call(client, admin_headers)
+
+    records = _audit_records()
+
+    assert len(records) == 1
+    schema_name, audit_type, extra, created_by = records[0]
+    assert schema_name == _ADMIN_USER_SCHEMA
+    assert audit_type == _AUDIT_TYPE
+    assert extra == {"new_user_ip": _CALLER_IP}
+    assert created_by == _ADMIN_USER_ID
+
+
+def test_update_reports_a_lambda_error_as_a_business_rule_error(
+    client, admin_headers, aws_lambda
+):
+    """POST /admin/integration/update-user-security-group - an answer flagged error is reported to the caller [400 BAD REQUEST]"""
+    aws_lambda.reply = {"error": True, "message": "limite de regras atingido"}
+
+    response = _call(client, admin_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    body = json.loads(response.data)
+    assert body["message"] == "limite de regras atingido"
+    assert body["code"] == "errors.businessRules"
+
+
+def test_update_does_not_audit_a_failed_change(client, admin_headers, aws_lambda):
+    """POST /admin/integration/update-user-security-group - a refused change leaves no audit record"""
+    aws_lambda.reply = {"error": True, "message": "limite de regras atingido"}
+
+    _call(client, admin_headers)
+
+    assert _audit_records() == []
+
+
+def test_update_reports_a_default_message_for_a_mute_error(
+    client, admin_headers, aws_lambda
+):
+    """POST /admin/integration/update-user-security-group - an error without a message still says something [400 BAD REQUEST]"""
+    aws_lambda.reply = {"error": True}
+
+    response = _call(client, admin_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert json.loads(response.data)["message"] == ("Erro inesperado. Consulte os logs")

--- a/tests/integration/test_reports_exams.py
+++ b/tests/integration/test_reports_exams.py
@@ -1,0 +1,248 @@
+"""Tests: GET /reports/exams/raw
+
+The raw-exams report is the one endpoint that hands a patient's laboratory
+results over untransformed: no reference range, no segment configuration, no
+alert. It exists so an integration can pull the results the backend received,
+so what matters is exactly the part the service decides:
+
+* the caller needs READ_REPORTS -- which every reading role holds, VIEWER
+  included -- and ``idPatient`` is mandatory;
+* the results are the patient's own, and only the ones from the last 30 days --
+  the window is applied against the exam date, not against when the row was
+  received;
+* every identifier and the result value leave as strings (the report is
+  consumed by clients that cannot be trusted with 64-bit numbers), and the
+  date leaves as ISO-8601;
+* the rows arrive grouped by exam type, newest result of each type first.
+
+The seed dump's exams are all from 2019, so they sit outside the window by
+construction: every test here inserts the results it expects to read back.
+"""
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import bindparam, text
+
+from tests.conftest import session, session_commit
+from utils import status
+
+URL = "/reports/exams/raw"
+
+# patient / admission present in the seed data (see tests/integration/test_exams.py)
+PATIENT_ID = 5
+ADMISSION = 5
+
+# another seeded patient, used to prove the report is scoped to one patient
+OTHER_PATIENT_ID = 3
+
+# a patient that has no exam at all
+UNKNOWN_PATIENT_ID = 999999
+
+# exam ids inserted by this module (kept clear of the 900001/900002 pair used
+# by tests/integration/test_exams.py)
+_ID_BASE = 951000
+
+# the window the service asks the repository for
+_WINDOW_DAYS = 30
+
+
+def _url(id_patient=None):
+    """The report URL, optionally naming the patient."""
+    return URL if id_patient is None else f"{URL}?idPatient={id_patient}"
+
+
+def _data(response):
+    """The payload of a successful api_endpoint response."""
+    return json.loads(response.data)["data"]
+
+
+def _days_ago(days: int):
+    """An exam date the given number of days in the past.
+
+    Anchored at midday so the app's timezone (America/Sao_Paulo, applied per
+    request) can never move a date across the day boundary the window is
+    measured from.
+    """
+    return datetime.now().replace(
+        hour=12, minute=0, second=0, microsecond=0
+    ) - timedelta(days=days)
+
+
+class _Exams:
+    """Inserts exam results and removes exactly the rows it inserted."""
+
+    def __init__(self):
+        self.ids = []
+
+    def add(
+        self,
+        type_exam: str,
+        exam_date: datetime,
+        value: float,
+        unit: str = "mg/dL",
+        id_patient: int = PATIENT_ID,
+    ):
+        """Insert one result and return its id."""
+        id_exam = _ID_BASE + len(self.ids) + 1
+        self.ids.append(id_exam)
+
+        session.execute(
+            text(
+                "INSERT INTO demo.exame "
+                "(fkexame, fkpessoa, nratendimento, dtexame, tpexame, resultado, "
+                "unidade, created_by) "
+                "VALUES (:id, :patient, :admission, :date, :type, :value, :unit, 1)"
+            ),
+            {
+                "id": id_exam,
+                "patient": id_patient,
+                "admission": ADMISSION,
+                "date": exam_date,
+                "type": type_exam,
+                "value": value,
+                "unit": unit,
+            },
+        )
+        session_commit()
+
+        return id_exam
+
+    def remove(self):
+        """Drop every row this helper inserted."""
+        if not self.ids:
+            return
+
+        session.execute(
+            text("DELETE FROM demo.exame WHERE fkexame IN :ids").bindparams(
+                bindparam("ids", expanding=True)
+            ),
+            {"ids": self.ids},
+        )
+        session_commit()
+
+
+@pytest.fixture
+def exams():
+    """A recorder for the exams a test inserts, cleaned up afterwards."""
+    recorder = _Exams()
+    yield recorder
+    recorder.remove()
+
+
+def test_raw_exams_requires_the_read_reports_permission(client, user_manager_headers):
+    """GET /reports/exams/raw - a role without READ_REPORTS is refused [401 UNAUTHORIZED]"""
+    response = client.get(_url(PATIENT_ID), headers=user_manager_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_raw_exams_is_open_to_a_read_only_role(client, viewer_headers, exams):
+    """GET /reports/exams/raw - READ_REPORTS is enough: VIEWER may pull the results"""
+    id_exam = exams.add("tgo", _days_ago(1), 1.0)
+
+    response = client.get(_url(PATIENT_ID), headers=viewer_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert [i["idExam"] for i in _data(response)] == [str(id_exam)]
+
+
+def test_raw_exams_without_a_patient_is_rejected(client, analyst_headers):
+    """GET /reports/exams/raw - the patient is mandatory [400 BAD REQUEST]"""
+    response = client.get(_url(), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert json.loads(response.data)["code"] == "errors.invalidParams"
+
+
+def test_raw_exams_maps_every_column(client, analyst_headers, exams):
+    """GET /reports/exams/raw - a result is reported with its full mapping"""
+    exam_date = _days_ago(1)
+    id_exam = exams.add("tgo", exam_date, 42.0)
+
+    response = client.get(_url(PATIENT_ID), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response) == [
+        {
+            "idExam": str(id_exam),
+            "typeExam": "tgo",
+            "idPatient": str(PATIENT_ID),
+            "admissionNumber": str(ADMISSION),
+            "dateExam": exam_date.isoformat(),
+            "value": "42.0",
+            "unit": "mg/dL",
+        }
+    ]
+
+
+def test_raw_exams_reports_a_missing_unit_as_null(client, analyst_headers, exams):
+    """GET /reports/exams/raw - a result stored without a unit keeps a null unit"""
+    exams.add("tgp", _days_ago(1), 12.25, unit=None)
+
+    response = client.get(_url(PATIENT_ID), headers=analyst_headers)
+
+    assert _data(response)[0]["unit"] is None
+
+
+def test_raw_exams_keeps_the_last_thirty_days(client, analyst_headers, exams):
+    """GET /reports/exams/raw - a result from the edge of the window is still reported"""
+    id_exam = exams.add("tgo", _days_ago(_WINDOW_DAYS), 1.0)
+
+    response = client.get(_url(PATIENT_ID), headers=analyst_headers)
+
+    assert [i["idExam"] for i in _data(response)] == [str(id_exam)]
+
+
+def test_raw_exams_drops_what_is_older_than_the_window(client, analyst_headers, exams):
+    """GET /reports/exams/raw - a result past the window is left out"""
+    recent = exams.add("tgo", _days_ago(_WINDOW_DAYS - 1), 1.0)
+    exams.add("tgo", _days_ago(_WINDOW_DAYS + 1), 2.0)
+
+    response = client.get(_url(PATIENT_ID), headers=analyst_headers)
+
+    assert [i["idExam"] for i in _data(response)] == [str(recent)]
+
+
+def test_raw_exams_of_a_patient_with_only_old_results_is_empty(client, analyst_headers):
+    """GET /reports/exams/raw - the seeded 2019 results are all outside the window"""
+    response = client.get(_url(PATIENT_ID), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response) == []
+
+
+def test_raw_exams_of_an_unknown_patient_is_empty(client, analyst_headers):
+    """GET /reports/exams/raw - a patient with no result at all reports an empty list"""
+    response = client.get(_url(UNKNOWN_PATIENT_ID), headers=analyst_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _data(response) == []
+
+
+def test_raw_exams_are_scoped_to_the_requested_patient(client, analyst_headers, exams):
+    """GET /reports/exams/raw - another patient's result is never reported"""
+    mine = exams.add("tgo", _days_ago(1), 1.0)
+    exams.add("tgo", _days_ago(1), 2.0, id_patient=OTHER_PATIENT_ID)
+
+    response = client.get(_url(PATIENT_ID), headers=analyst_headers)
+
+    assert [i["idExam"] for i in _data(response)] == [str(mine)]
+
+
+def test_raw_exams_are_grouped_by_type_newest_first(client, analyst_headers, exams):
+    """GET /reports/exams/raw - results come ordered by exam type, newest of each first"""
+    old_tgo = exams.add("tgo", _days_ago(5), 1.0)
+    new_tgo = exams.add("tgo", _days_ago(2), 2.0)
+    old_creat = exams.add("creatinina", _days_ago(4), 0.5)
+    new_creat = exams.add("creatinina", _days_ago(3), 2.5)
+
+    response = client.get(_url(PATIENT_ID), headers=analyst_headers)
+
+    assert [i["idExam"] for i in _data(response)] == [
+        str(new_creat),
+        str(old_creat),
+        str(new_tgo),
+        str(old_tgo),
+    ]


### PR DESCRIPTION
Two features had no test at all. Both are now covered by integration tests, 22 in total.

## `GET /reports/exams/raw` — `tests/integration/test_reports_exams.py`

The raw-exams report hands a patient's laboratory results to an integration untransformed, so the tests pin exactly what the service decides:

- READ_REPORTS is required (a USER_MANAGER is refused) and is enough (a VIEWER may pull the results);
- `idPatient` is mandatory (`400 errors.invalidParams`);
- the 30-day window, including its edge: a result exactly 30 days old is still reported, one 31 days old is not, and the seeded 2019 results are outside it by construction;
- the results are scoped to the requested patient, and an unknown patient reports an empty list;
- the rows are grouped by exam type, newest result of each type first;
- the full column mapping — every identifier and the result value leave as strings, the date as ISO-8601, and a result stored without a unit keeps a null unit.

Exam dates are anchored at midday so the per-request `America/Sao_Paulo` timezone cannot move a date across the day boundary the window is measured from. Each test removes exactly the rows it inserted, so the file is re-runnable.

## `POST /admin/integration/update-user-security-group` — `tests/integration/test_admin_integration.py`

This support endpoint opens the client's AWS security group for the machine the caller is asking from. The Lambda is replaced by a recorder, so the tests assert the part the backend actually decides:

- only a role holding UPDATE_USER_SG may ask, and a refused caller never reaches the Lambda;
- the backend function is invoked once, synchronously, on the configured region;
- the rule is opened for the caller's own address, taken from the forwarded proxy headers (first entry wins, connection address as fallback) and narrowed to a single host (`/32`);
- the Lambda answer is handed back untouched, including when it arrives double-encoded as a JSON string holding JSON;
- an answer flagged `error` becomes `400 errors.businessRules`, carrying the Lambda's message or a default one when it is mute;
- a successful change leaves an audit record naming the schema, the new address and the author — and a refused change leaves none.

The production refusal of `api_endpoint(is_admin=True)` is already covered by `tests/unit/test_api_endpoint_decorator.py`, so it is not repeated here.

## Validation

- `ENV=test pytest` — 2529 passed (2507 before, +22), against the same seed data CI loads
- `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DA8MQTchTCXwGc7f63xJap

---
_Generated by [Claude Code](https://claude.ai/code/session_01DA8MQTchTCXwGc7f63xJap)_