### PR TITLE
test: cover the PEP deep link and the dispensation form update

### DIFF
--- a/tests/integration/test_prescription_drug_form.py
+++ b/tests/integration/test_prescription_drug_form.py
@@ -1,0 +1,204 @@
+"""Tests: dispensation form update (PUT /prescriptions/drug/form)
+
+The endpoint the dispensation screen calls to store the pharmacy form of one or
+more prescribed drugs. The payload is a map of prescription-drug id to the form
+payload, and each entry is gated twice: by the WRITE_DISPENSATION permission
+and by the caller's authorization on the drug's segment.
+
+The whole map is written inside a single request transaction, so a rejected
+entry has to leave the entries beside it untouched.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from models.prescription import PrescriptionDrug
+from security.role import Role
+from tests.conftest import get_access, make_headers, session, session_commit
+from tests.utils.utils_test_prescription import (
+    create_prescription,
+    create_prescription_drug,
+    test_counters,
+)
+
+URL = "/prescriptions/drug/form"
+
+# demo user 1 is authorized on segments 1 and 2 only (public.usuario_autorizacao),
+# and the demo schema runs with AUTHORIZATION_SEGMENT on
+AUTHORIZED_SEGMENT = 1
+UNAUTHORIZED_SEGMENT = 99
+
+# presmed ids the endpoint will never find
+UNKNOWN_PD_ID = 100999999
+
+A_FORM = {"tp": "capsula", "quantidade": 2}
+
+
+@pytest.fixture
+def dispensing_headers(client):
+    """Headers with DISPENSING_MANAGER role — the role holding WRITE_DISPENSATION"""
+    return make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+
+
+def _create_drug(id_segment=AUTHORIZED_SEGMENT, form=None):
+    """Create a prescription holding one drug and return that drug's id.
+
+    The segment is written with an UPDATE because the presmed BEFORE INSERT
+    trigger recomputes idsegmento from the department, which would pull an
+    unauthorized segment back to the seeded one.
+    """
+    id_prescription = test_counters["id_prescription"]
+    admission_number = test_counters["admission_number"]
+    test_counters["id_prescription"] += 1
+    test_counters["admission_number"] += 1
+
+    create_prescription(
+        id=id_prescription,
+        admissionNumber=admission_number,
+        idPatient=1,
+    )
+    drug = create_prescription_drug(
+        id=int(f"{id_prescription}001"),
+        idPrescription=id_prescription,
+        idDrug=3,
+    )
+
+    drug.idSegment = id_segment
+    if form is not None:
+        drug.form = form
+    session_commit()
+
+    return drug.id
+
+
+def _reload(id_prescription_drug) -> PrescriptionDrug:
+    """Read a prescription drug back from the database, ignoring the test session cache"""
+    session.expire_all()
+    return (
+        session.query(PrescriptionDrug)
+        .filter(PrescriptionDrug.id == id_prescription_drug)
+        .first()
+    )
+
+
+def test_update_form_stores_the_payload(client, dispensing_headers):
+    """PUT /prescriptions/drug/form - grava o form do medicamento prescrito"""
+    id_pd = _create_drug()
+
+    response = client.put(URL, json={str(id_pd): A_FORM}, headers=dispensing_headers)
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] is True
+
+    updated = _reload(id_pd)
+    assert updated.form == A_FORM
+    assert updated.user == 1
+    assert updated.update is not None
+
+
+def test_update_form_records_the_author_and_moment(client, dispensing_headers):
+    """The write stamps the caller and the update timestamp on the row"""
+    id_pd = _create_drug()
+    before = datetime.today()
+
+    response = client.put(URL, json={str(id_pd): A_FORM}, headers=dispensing_headers)
+
+    assert response.status_code == 200
+
+    updated = _reload(id_pd)
+    assert updated.user == 1
+    assert updated.update >= before.replace(microsecond=0)
+
+
+def test_update_form_writes_every_entry_of_the_payload(client, dispensing_headers):
+    """A payload with several drugs updates each one of them"""
+    first = _create_drug()
+    second = _create_drug()
+
+    response = client.put(
+        URL,
+        json={str(first): {"tp": "comprimido"}, str(second): {"tp": "gotas"}},
+        headers=dispensing_headers,
+    )
+
+    assert response.status_code == 200
+    assert _reload(first).form == {"tp": "comprimido"}
+    assert _reload(second).form == {"tp": "gotas"}
+
+
+def test_update_form_overwrites_a_previous_form(client, dispensing_headers):
+    """The stored form is replaced, not merged, so a stale key does not survive"""
+    id_pd = _create_drug(form={"tp": "capsula", "obsoleto": True})
+
+    response = client.put(
+        URL, json={str(id_pd): {"tp": "comprimido"}}, headers=dispensing_headers
+    )
+
+    assert response.status_code == 200
+    assert _reload(id_pd).form == {"tp": "comprimido"}
+
+
+def test_update_form_accepts_a_null_form(client, dispensing_headers):
+    """Sending null clears the form of a drug that had one"""
+    id_pd = _create_drug(form=A_FORM)
+
+    response = client.put(URL, json={str(id_pd): None}, headers=dispensing_headers)
+
+    assert response.status_code == 200
+    assert _reload(id_pd).form is None
+
+
+def test_update_form_accepts_an_empty_payload(client, dispensing_headers):
+    """An empty map is a no-op rather than an error"""
+    response = client.put(URL, json={}, headers=dispensing_headers)
+
+    assert response.status_code == 200
+    assert response.get_json()["data"] is True
+
+
+def test_update_form_rejects_an_unknown_drug(client, dispensing_headers):
+    """An id with no presmed row behind it is a validation error"""
+    response = client.put(
+        URL, json={str(UNKNOWN_PD_ID): A_FORM}, headers=dispensing_headers
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.invalidRegister"
+
+
+def test_update_form_rejects_an_unauthorized_segment(client, dispensing_headers):
+    """A drug on a segment the caller is not authorized on cannot be written"""
+    id_pd = _create_drug(id_segment=UNAUTHORIZED_SEGMENT)
+
+    response = client.put(URL, json={str(id_pd): A_FORM}, headers=dispensing_headers)
+
+    assert response.status_code == 401
+    assert response.get_json()["code"] == "errors.businessRules"
+    assert _reload(id_pd).form is None
+
+
+def test_update_form_discards_the_whole_payload_when_one_entry_fails(
+    client, dispensing_headers
+):
+    """A rejected entry rolls back the entries already written in the same request"""
+    valid = _create_drug()
+
+    response = client.put(
+        URL,
+        json={str(valid): A_FORM, str(UNKNOWN_PD_ID): A_FORM},
+        headers=dispensing_headers,
+    )
+
+    assert response.status_code == 400
+    assert _reload(valid).form is None
+
+
+def test_update_form_requires_write_dispensation_permission(client, analyst_headers):
+    """A PRESCRIPTION_ANALYST holds no WRITE_DISPENSATION, so the write is denied"""
+    id_pd = _create_drug()
+
+    response = client.put(URL, json={str(id_pd): A_FORM}, headers=analyst_headers)
+
+    assert response.status_code == 401
+    assert _reload(id_pd).form is None

--- a/tests/integration/test_prescription_pep_link.py
+++ b/tests/integration/test_prescription_pep_link.py
@@ -1,0 +1,183 @@
+"""Tests: PEP deep link (GET /prescriptions/pep-link)
+
+The endpoint hands the frontend a link back into the client's own electronic
+patient record (PEP). The template lives in the tenant's schema_config and
+carries three placeholders, which the service fills from the caller and from
+the prescription:
+
+- ``{USER_EXTERNAL_ID}``: the caller's id in the client's own system
+- ``{ADMISSION_NUMBER}``: the prescription's admission
+- ``{FKHOSPITAL}``: the prescription's hospital
+
+Every piece has to be configured for a link to come back, so the tests below
+cover the happy path plus each missing-configuration branch.
+"""
+
+import pytest
+
+from models.appendix import SchemaConfig
+from models.main import User
+from security.role import Role
+from tests.conftest import get_access, make_headers, session, session_commit
+from tests.utils.utils_test_prescription import create_basic_prescription
+
+URL = "/prescriptions/pep-link"
+
+# the schema and the user behind tests.conftest.get_access defaults
+SCHEMA = "demo"
+DEMO_USER_ID = 1
+
+# stands in for the caller's id inside the client's own system
+EXTERNAL_ID = "ZZTEST-PEP-EXTERNAL"
+
+PEP_TEMPLATE = (
+    "https://pep.example.com/atendimento"
+    "?usuario={USER_EXTERNAL_ID}&atendimento={ADMISSION_NUMBER}&hospital={FKHOSPITAL}"
+)
+
+
+def _set_schema_config(config):
+    """Replace the tenant's schema_config payload"""
+    session.query(SchemaConfig).filter(SchemaConfig.schemaName == SCHEMA).update(
+        {"config": config}, synchronize_session=False
+    )
+    session_commit()
+
+
+def _set_user_external(external):
+    """Set (or clear) the caller's external id"""
+    session.query(User).filter(User.id == DEMO_USER_ID).update(
+        {"external": external}, synchronize_session=False
+    )
+    session_commit()
+
+
+@pytest.fixture(autouse=True)
+def restore_pep_setup():
+    """Snapshot the schema config and the caller's external id, then restore them.
+
+    Both are seed-level records shared with every other test, so each test here
+    puts them back exactly as it found them.
+    """
+    original_config = (
+        session.query(SchemaConfig)
+        .filter(SchemaConfig.schemaName == SCHEMA)
+        .first()
+        .config
+    )
+    original_external = session.query(User).filter(User.id == DEMO_USER_ID).first().external
+
+    # the setup a configured tenant has; individual tests narrow it down
+    _set_schema_config({"pepLink": PEP_TEMPLATE})
+    _set_user_external(EXTERNAL_ID)
+
+    yield
+
+    _set_schema_config(original_config)
+    _set_user_external(original_external)
+
+
+def test_pep_link_fills_every_placeholder(client, analyst_headers):
+    """GET /prescriptions/pep-link - substitui usuário, atendimento e hospital no template"""
+    prescription = create_basic_prescription()
+
+    response = client.get(
+        URL, query_string={"idPrescription": prescription.id}, headers=analyst_headers
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["pepLink"] == (
+        "https://pep.example.com/atendimento"
+        f"?usuario={EXTERNAL_ID}"
+        f"&atendimento={prescription.admissionNumber}"
+        f"&hospital={prescription.idHospital}"
+    )
+
+
+def test_pep_link_replaces_repeated_placeholders(client, analyst_headers):
+    """A placeholder used twice in the template is filled at both positions"""
+    prescription = create_basic_prescription()
+    _set_schema_config(
+        {"pepLink": "https://pep.example.com/{ADMISSION_NUMBER}/x/{ADMISSION_NUMBER}"}
+    )
+
+    response = client.get(
+        URL, query_string={"idPrescription": prescription.id}, headers=analyst_headers
+    )
+
+    assert response.status_code == 200
+
+    admission = prescription.admissionNumber
+    assert (
+        response.get_json()["data"]["pepLink"]
+        == f"https://pep.example.com/{admission}/x/{admission}"
+    )
+
+
+def test_pep_link_keeps_a_template_without_placeholders(client, analyst_headers):
+    """A template with nothing to substitute comes back verbatim"""
+    prescription = create_basic_prescription()
+    _set_schema_config({"pepLink": "https://pep.example.com/home"})
+
+    response = client.get(
+        URL, query_string={"idPrescription": prescription.id}, headers=analyst_headers
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["pepLink"] == "https://pep.example.com/home"
+
+
+def test_pep_link_rejects_unknown_prescription(client, analyst_headers):
+    """An id with no prescription behind it is a validation error"""
+    response = client.get(
+        URL, query_string={"idPrescription": 100999999}, headers=analyst_headers
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_pep_link_requires_the_prescription_param(client, analyst_headers):
+    """Calling without idPrescription is rejected instead of returning a broken link"""
+    response = client.get(URL, headers=analyst_headers)
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_pep_link_requires_the_user_external_id(client, analyst_headers):
+    """A caller with no external id cannot be identified to the PEP"""
+    prescription = create_basic_prescription()
+    _set_user_external(None)
+
+    response = client.get(
+        URL, query_string={"idPrescription": prescription.id}, headers=analyst_headers
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_pep_link_requires_a_configured_schema(client, analyst_headers):
+    """A tenant whose schema_config carries no pepLink gets a validation error"""
+    prescription = create_basic_prescription()
+    _set_schema_config({})
+
+    response = client.get(
+        URL, query_string={"idPrescription": prescription.id}, headers=analyst_headers
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_pep_link_requires_read_prescription_permission(client):
+    """A DISPENSING_MANAGER holds no READ_PRESCRIPTION, so the link is denied"""
+    prescription = create_basic_prescription()
+    headers = make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+
+    response = client.get(
+        URL, query_string={"idPrescription": prescription.id}, headers=headers
+    )
+
+    assert response.status_code == 401

--- a/tests/integration/test_prescription_pep_link.py
+++ b/tests/integration/test_prescription_pep_link.py
@@ -59,13 +59,18 @@ def restore_pep_setup():
     Both are seed-level records shared with every other test, so each test here
     puts them back exactly as it found them.
     """
-    original_config = (
-        session.query(SchemaConfig)
-        .filter(SchemaConfig.schemaName == SCHEMA)
-        .first()
-        .config
+    schema_config = (
+        session.query(SchemaConfig).filter(SchemaConfig.schemaName == SCHEMA).first()
     )
-    original_external = session.query(User).filter(User.id == DEMO_USER_ID).first().external
+    user = session.query(User).filter(User.id == DEMO_USER_ID).first()
+
+    # both are seeded by noharm-ai/database; say so plainly rather than failing
+    # on an attribute of None if the test database was loaded incompletely
+    assert schema_config is not None, f"missing seed data: schema_config '{SCHEMA}'"
+    assert user is not None, f"missing seed data: user {DEMO_USER_ID}"
+
+    original_config = schema_config.config
+    original_external = user.external
 
     # the setup a configured tenant has; individual tests narrow it down
     _set_schema_config({"pepLink": PEP_TEMPLATE})


### PR DESCRIPTION
Adds integration tests for two features that were reachable but never exercised by the suite.

## `GET /prescriptions/pep-link` — `prescription_service.get_pep_link`

Builds the deep link back into the client's own electronic patient record from the `pepLink` template in the tenant's `schema_config`. `tests/integration/test_prescription_pep_link.py` covers:

- substitution of `{USER_EXTERNAL_ID}`, `{ADMISSION_NUMBER}` and `{FKHOSPITAL}`, a placeholder used twice, and a template with none
- each piece of configuration that has to be present: the prescription (including a missing `idPrescription` param), the caller's external id, and the tenant's `pepLink`
- the `READ_PRESCRIPTION` gate

The schema config and the caller's external id are seed-level records, so an autouse fixture snapshots and restores both.

## `PUT /prescriptions/drug/form` — `prescription_drug_service.update_pd_form`

Stores the pharmacy form of prescribed drugs, gated by `WRITE_DISPENSATION` and by the caller's authorization on each drug's segment. `tests/integration/test_prescription_drug_form.py` covers:

- a single-entry and a multi-entry payload, plus the author/timestamp stamped on the row
- the overwrite (replace, not merge) and null-clearing semantics, and the empty no-op payload
- the unknown-drug (400) and unauthorized-segment (401) rejections
- rollback of the entries already written when a later entry in the same payload fails
- the `WRITE_DISPENSATION` gate

The unauthorized-segment case writes `idsegmento` with an `UPDATE`, because the `presmed` `BEFORE INSERT` trigger recomputes it from the department and would otherwise pull the row back to the seeded segment.

## Verification

- full suite: 2547 passed (2529 before, +18 new)
- `ruff check .`: clean
- statement coverage: `services/prescription_service.py` 57% → 66%, `services/prescription_drug_service.py` 61% → 67%; `get_pep_link` and `update_pd_form` now fully covered
- both features were mutation-checked (dropping the `{FKHOSPITAL}` substitution and dropping the segment-authorization guard each make the new tests fail)

Tests only — no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4dHAcWRWExmKLdUNsLpuo

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4dHAcWRWExmKLdUNsLpuo)_