### PR TITLE
test: cover the clinical-note PDF renderer and the protocol co-pilot tools

### DIFF
--- a/tests/unit/test_clinical_notes_pdf_service.py
+++ b/tests/unit/test_clinical_notes_pdf_service.py
@@ -1,0 +1,495 @@
+"""Unit tests for the clinical-note PDF renderer.
+
+``clinical_notes_pdf_service`` turns a clinical note into the PDF that gets
+sent to ODOO for digital signature. Two shapes of note reach it: the free-text
+note (HTML) and the primary-care custom form (a ``template`` describing groups
+of questions plus a ``form`` holding the answers). Both are flattened into
+``(text, bold)`` runs so the emphasis of the original note survives into the
+document.
+
+The renderer also decides where the signature field lands: ``build_note_pdf``
+returns the page number and the vertical position (as a fraction of the A4
+height) right where the body ended, and the sign service feeds those straight
+to ODOO — a wrong value puts the signature on top of the text.
+
+These are unit tests: ``db`` is replaced with a mock session for the
+institution-header lookup, and the produced PDF is inspected as bytes.
+"""
+
+from unittest import mock
+
+import pytest
+
+from models.appendix import Memory
+from models.notes import ClinicalNotes
+from services import clinical_notes_pdf_service
+from services.clinical_notes_pdf_service import (
+    _format_form_value,
+    _get_institution_header_runs,
+    _get_note_runs,
+    _runs_to_markdown,
+    _to_latin1,
+    build_note_pdf,
+)
+
+
+def _note(text=None, template=None, form=None):
+    """Build a transient ClinicalNotes row with only the printable columns set."""
+    note = ClinicalNotes()
+    note.id = 1
+    note.admissionNumber = 1
+    note.text = text
+    note.template = template
+    note.form = form
+    return note
+
+
+def _mock_db(header=None):
+    """A mock ``db`` whose Memory lookup returns the given nav-header record."""
+    mock_db = mock.MagicMock()
+    memory = None
+
+    if header is not None:
+        memory = Memory()
+        memory.kind = "nav-header"
+        memory.value = {"header": header}
+
+    mock_db.session.query.return_value.filter.return_value.first.return_value = memory
+
+    return mock_db
+
+
+# --------------------------------------------------------------------------
+# _to_latin1
+# --------------------------------------------------------------------------
+
+
+def test_latin1_keeps_accented_characters():
+    """Portuguese accents are inside latin-1, so they must survive untouched"""
+    assert _to_latin1("Avaliação diária não concluída") == (
+        "Avaliação diária não concluída"
+    )
+
+
+def test_latin1_replaces_unsupported_characters():
+    """Characters outside latin-1 are replaced instead of raising"""
+    result = _to_latin1("dose 10 mg — ok ✓")
+
+    assert "?" in result
+    # the replacement is per character, so the surrounding text is preserved
+    assert result.startswith("dose 10")
+    assert result.endswith("ok ?")
+
+
+def test_latin1_of_none_is_empty():
+    """A note without text must not blow up the renderer"""
+    assert _to_latin1(None) == ""
+
+
+# --------------------------------------------------------------------------
+# _runs_to_markdown
+# --------------------------------------------------------------------------
+
+
+def test_runs_to_markdown_wraps_only_the_bold_runs():
+    """Bold runs get FPDF's markdown markers; plain runs are emitted as-is"""
+    assert _runs_to_markdown([("Hospital ", False), ("Central", True)]) == (
+        "Hospital **Central**"
+    )
+
+
+def test_runs_to_markdown_escapes_markers_present_in_the_text():
+    """Marker sequences in the source text are printed, not interpreted"""
+    for marker in ("**", "__", "~~", "--"):
+        assert _runs_to_markdown([(f"a{marker}b", False)]) == f"a\\{marker}b"
+
+
+def test_runs_to_markdown_escapes_markers_inside_a_bold_run():
+    """Escaping happens before the bold wrapping, so both survive"""
+    assert _runs_to_markdown([("x--y", True)]) == "**x\\--y**"
+
+
+def test_runs_to_markdown_of_no_runs_is_empty():
+    """An empty header must not produce a stray marker"""
+    assert _runs_to_markdown([]) == ""
+
+
+# --------------------------------------------------------------------------
+# _format_form_value
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_form_value_without_an_answer_is_labeled(value):
+    """An unanswered question is printed as "Sem resposta", like the frontend"""
+    assert _format_form_value(value) == "Sem resposta"
+
+
+def test_form_value_list_is_joined():
+    """Multiple-choice answers are joined with a comma"""
+    assert _format_form_value(["Dor", "Febre"]) == "Dor, Febre"
+
+
+def test_form_value_list_of_numbers_is_stringified():
+    """A numeric multiple-choice answer is coerced before joining"""
+    assert _format_form_value([1, 2]) == "1, 2"
+
+
+def test_form_value_dict_uses_the_label():
+    """A select answer carries {value,label}: the label is what gets printed"""
+    assert _format_form_value({"value": 3, "label": "Moderado"}) == "Moderado"
+
+
+def test_form_value_dict_without_a_label_is_empty():
+    """A malformed select answer prints nothing instead of its raw dict"""
+    assert _format_form_value({"value": 3}) == ""
+
+
+def test_form_value_scalar_is_stringified():
+    """Numbers and booleans are printed as text"""
+    assert _format_form_value(72) == "72"
+    assert _format_form_value(False) == "False"
+
+
+def test_form_value_zero_is_printed_not_treated_as_missing():
+    """0 is a real answer: the "no answer" check must not swallow it"""
+    assert _format_form_value(0) == "0"
+
+
+# --------------------------------------------------------------------------
+# _get_note_runs — free text
+# --------------------------------------------------------------------------
+
+
+def test_note_runs_convert_the_free_text_html():
+    """A free-text note is rendered from its HTML, keeping the emphasis"""
+    runs = _get_note_runs(_note(text="<p>Paciente <b>estável</b></p>"))
+
+    assert runs == [("Paciente ", False), ("estável", True)]
+
+
+def test_note_runs_prefer_the_text_over_the_template():
+    """A note holding both columns is a free-text note: the form is ignored"""
+    runs = _get_note_runs(
+        _note(
+            text="<p>texto livre</p>",
+            template=[{"group": "G", "questions": [{"id": "1", "label": "L"}]}],
+            form={"1": "valor"},
+        )
+    )
+
+    assert runs == [("texto livre", False)]
+
+
+def test_note_runs_of_an_empty_note_are_empty():
+    """A note with neither text nor template renders an empty body"""
+    assert _get_note_runs(_note()) == []
+
+
+# --------------------------------------------------------------------------
+# _get_note_runs — custom form
+# --------------------------------------------------------------------------
+
+
+def test_note_runs_render_a_single_group_without_its_name():
+    """One group carries no grouping information, so its name is omitted"""
+    note = _note(
+        template=[
+            {
+                "group": "Anamnese",
+                "questions": [
+                    {"id": "q1", "label": "Queixa"},
+                    {"id": "q2", "label": "Duração"},
+                ],
+            }
+        ],
+        form={"q1": "Dor de cabeça", "q2": "3 dias"},
+    )
+
+    text = "".join([run for run, _ in _get_note_runs(note)])
+
+    assert "Anamnese" not in text
+    assert "Queixa: Dor de cabeça" in text
+    assert "Duração: 3 dias" in text
+
+
+def test_note_runs_print_the_group_names_when_there_is_more_than_one():
+    """With several groups the names are the only way to read the form"""
+    note = _note(
+        template=[
+            {"group": "Anamnese", "questions": [{"id": "q1", "label": "Queixa"}]},
+            {"group": "Exame físico", "questions": [{"id": "q2", "label": "PA"}]},
+        ],
+        form={"q1": "Dor", "q2": "120/80"},
+    )
+
+    text = "".join([run for run, _ in _get_note_runs(note)])
+
+    assert "Anamnese" in text
+    assert "Exame físico" in text
+    assert text.index("Anamnese") < text.index("Exame físico")
+
+
+def test_note_runs_skip_an_unnamed_group():
+    """A group without a name contributes only its questions"""
+    note = _note(
+        template=[
+            {"group": "", "questions": [{"id": "q1", "label": "Queixa"}]},
+            {"group": "Exame físico", "questions": [{"id": "q2", "label": "PA"}]},
+        ],
+        form={"q1": "Dor", "q2": "120/80"},
+    )
+
+    text = "".join([run for run, _ in _get_note_runs(note)])
+
+    assert text.startswith("Queixa: Dor")
+    assert "Exame físico" in text
+
+
+def test_note_runs_omit_the_prefix_of_an_unlabeled_question():
+    """Free letters have no label: printing "': '" would be noise"""
+    note = _note(
+        template=[
+            {
+                "group": "Conduta",
+                "questions": [
+                    {"id": "q1", "label": ""},
+                    {"id": "q2", "label": "Retorno"},
+                ],
+            }
+        ],
+        form={"q1": "Mantida a conduta", "q2": "30 dias"},
+    )
+
+    text = "".join([run for run, _ in _get_note_runs(note)])
+
+    assert text.startswith("Mantida a conduta")
+    assert ": Mantida" not in text
+    assert "Retorno: 30 dias" in text
+
+
+def test_note_runs_label_the_unanswered_questions():
+    """A question missing from the answers is printed as unanswered"""
+    note = _note(
+        template=[
+            {
+                "group": "Anamnese",
+                "questions": [
+                    {"id": "q1", "label": "Queixa"},
+                    {"id": "q2", "label": "Duração"},
+                ],
+            }
+        ],
+        form={"q1": "Dor"},
+    )
+
+    text = "".join([run for run, _ in _get_note_runs(note)])
+
+    assert "Duração: Sem resposta" in text
+
+
+def test_note_runs_convert_the_html_of_a_form_answer():
+    """Answers are HTML too, so the emphasis inside them is preserved"""
+    note = _note(
+        template=[{"group": "Conduta", "questions": [{"id": "q1", "label": "Plano"}]}],
+        form={"q1": "manter <b>jejum</b>"},
+    )
+
+    runs = _get_note_runs(note)
+
+    assert ("jejum", True) in runs
+
+
+def test_note_runs_of_a_form_are_normalized():
+    """normalize_runs trims the body and collapses the group separators"""
+    note = _note(
+        template=[{"group": "Conduta", "questions": [{"id": "q1", "label": "Plano"}]}],
+        form={"q1": "jejum"},
+    )
+
+    runs = _get_note_runs(note)
+
+    assert runs[0][0].startswith("Plano")
+    # no trailing blank lines left by the per-group "\n"
+    assert not runs[-1][0].endswith("\n")
+    # same-styled neighbours are merged into a single run
+    assert len(runs) == 1
+
+
+def test_note_runs_of_a_template_without_questions_are_empty():
+    """A template holding a single unnamed empty group renders nothing"""
+    assert _get_note_runs(_note(template=[{"group": "", "questions": []}])) == []
+
+
+def test_note_runs_tolerate_a_form_answered_with_a_select():
+    """A select answer is read through its label, not printed as a dict"""
+    note = _note(
+        template=[{"group": "Triagem", "questions": [{"id": "q1", "label": "Risco"}]}],
+        form={"q1": {"value": 2, "label": "Amarelo"}},
+    )
+
+    text = "".join([run for run, _ in _get_note_runs(note)])
+
+    assert text == "Risco: Amarelo"
+
+
+def test_note_runs_tolerate_a_missing_form():
+    """A template without any answers still renders its labels"""
+    note = _note(
+        template=[{"group": "Triagem", "questions": [{"id": "q1", "label": "Risco"}]}]
+    )
+
+    text = "".join([run for run, _ in _get_note_runs(note)])
+
+    assert text == "Risco: Sem resposta"
+
+
+# --------------------------------------------------------------------------
+# _get_institution_header_runs
+# --------------------------------------------------------------------------
+
+
+def test_institution_header_is_read_from_the_nav_header_memory():
+    """The header printed above the note comes from the nav-header record"""
+    with mock.patch.object(clinical_notes_pdf_service, "db", _mock_db("<b>HC</b>")):
+        assert _get_institution_header_runs() == [("HC", True)]
+
+
+def test_institution_header_is_empty_without_the_memory_record():
+    """A schema that never configured a header prints none"""
+    with mock.patch.object(clinical_notes_pdf_service, "db", _mock_db()):
+        assert _get_institution_header_runs() == []
+
+
+def test_institution_header_is_empty_when_the_record_has_no_value():
+    """A blank record is treated like a missing one"""
+    mock_db = _mock_db("x")
+    mock_db.session.query.return_value.filter.return_value.first.return_value.value = (
+        None
+    )
+
+    with mock.patch.object(clinical_notes_pdf_service, "db", mock_db):
+        assert _get_institution_header_runs() == []
+
+
+def test_institution_header_is_empty_when_the_value_has_no_header_key():
+    """A record shaped for another purpose contributes no header"""
+    mock_db = _mock_db("x")
+    mock_db.session.query.return_value.filter.return_value.first.return_value.value = {
+        "other": "y"
+    }
+
+    with mock.patch.object(clinical_notes_pdf_service, "db", mock_db):
+        assert _get_institution_header_runs() == []
+
+
+# --------------------------------------------------------------------------
+# _add_logo
+# --------------------------------------------------------------------------
+
+
+def test_a_missing_logo_only_costs_the_document_its_logo():
+    """Rendering must not fail because the logo file cannot be read"""
+    with (
+        mock.patch.object(clinical_notes_pdf_service, "db", _mock_db()),
+        mock.patch.object(
+            clinical_notes_pdf_service, "_LOGO_PATH", "/does/not/exist.png"
+        ),
+    ):
+        pdf_bytes, sign_page, _ = build_note_pdf(_note(text="<p>ok</p>"))
+
+    assert pdf_bytes.startswith(b"%PDF")
+    assert sign_page == 1
+
+
+# --------------------------------------------------------------------------
+# build_note_pdf
+# --------------------------------------------------------------------------
+
+
+def test_build_note_pdf_returns_a_pdf_and_the_signature_anchor():
+    """The bytes are a PDF and the signature lands on the first page"""
+    with mock.patch.object(clinical_notes_pdf_service, "db", _mock_db()):
+        pdf_bytes, sign_page, sign_pos_y = build_note_pdf(_note(text="<p>Nota</p>"))
+
+    assert pdf_bytes.startswith(b"%PDF")
+    assert sign_page == 1
+    assert 0 < sign_pos_y < 1
+
+
+def test_build_note_pdf_declares_the_modern_spec_version():
+    """Some PDF validators refuse files declaring the ancient 1.3 spec"""
+    with mock.patch.object(clinical_notes_pdf_service, "db", _mock_db()):
+        pdf_bytes, _, _ = build_note_pdf(_note(text="<p>Nota</p>"))
+
+    assert pdf_bytes.startswith(b"%PDF-1.7")
+
+
+def test_build_note_pdf_renders_a_custom_form_note():
+    """A primary-care note has no text column: the form is what gets printed"""
+    note = _note(
+        template=[
+            {
+                "group": "Anamnese",
+                "questions": [{"id": "q1", "label": "Queixa"}],
+            },
+            {
+                "group": "Conduta",
+                "questions": [{"id": "q2", "label": "Plano"}],
+            },
+        ],
+        form={"q1": "Dor", "q2": "Repouso"},
+    )
+
+    with mock.patch.object(clinical_notes_pdf_service, "db", _mock_db()):
+        pdf_bytes, sign_page, sign_pos_y = build_note_pdf(note)
+
+    assert pdf_bytes.startswith(b"%PDF")
+    assert sign_page == 1
+    assert 0 < sign_pos_y < 1
+
+
+def test_build_note_pdf_of_an_empty_note_still_produces_a_document():
+    """An empty body must not break the signature flow"""
+    with mock.patch.object(clinical_notes_pdf_service, "db", _mock_db()):
+        pdf_bytes, sign_page, sign_pos_y = build_note_pdf(_note())
+
+    assert pdf_bytes.startswith(b"%PDF")
+    assert sign_page == 1
+    assert 0 < sign_pos_y < 1
+
+
+def test_build_note_pdf_prints_the_institution_header():
+    """The configured header adds content above the note body"""
+    with mock.patch.object(clinical_notes_pdf_service, "db", _mock_db()):
+        _, _, without_header = build_note_pdf(_note(text="<p>Nota</p>"))
+
+    with mock.patch.object(
+        clinical_notes_pdf_service, "db", _mock_db("<b>Hospital Teste</b><br>Centro")
+    ):
+        _, _, with_header = build_note_pdf(_note(text="<p>Nota</p>"))
+
+    # the header, its separator line and the spacing push the body down
+    assert with_header > without_header
+
+
+def test_build_note_pdf_pushes_the_signature_to_the_last_page():
+    """A long note breaks into pages: the field goes where the body ended"""
+    long_text = "<p>" + ("Evolução detalhada do paciente. " * 400) + "</p>"
+
+    with mock.patch.object(clinical_notes_pdf_service, "db", _mock_db()):
+        _, sign_page, sign_pos_y = build_note_pdf(_note(text=long_text))
+
+    assert sign_page > 1
+    assert 0 < sign_pos_y < 1
+
+
+def test_build_note_pdf_keeps_the_signature_above_the_bottom_margin():
+    """The auto page break guarantees the field always fits on the page"""
+    with mock.patch.object(clinical_notes_pdf_service, "db", _mock_db()):
+        _, _, sign_pos_y = build_note_pdf(
+            _note(text="<p>" + ("linha<br>" * 60) + "</p>")
+        )
+
+    # 297mm page with a 20mm bottom margin
+    assert sign_pos_y < (297 - 20) / 297

--- a/tests/unit/test_protocol_agent_tools.py
+++ b/tests/unit/test_protocol_agent_tools.py
@@ -1,0 +1,762 @@
+"""Unit tests for the protocol co-pilot tool set.
+
+``protocol_agent_tools.build_tools`` exposes the catalogs of the tenant to the
+protocol-creation agent: substances, classes, hospital drugs, ICDs, exam types,
+global reference exams, departments, segments, routes, patient tags and the
+NoHarm Care indicators, plus the two tools that close the self-correction loop
+(``validate_protocol`` and ``test_protocol``).
+
+The tools are what the model reads before it writes a protocol config, so their
+shape is a correctness concern and not a presentation detail:
+
+* the ids the agent must copy have to come back under the documented key
+  (``examType`` lowercased, ``tpexam`` verbatim, ``statsType``, ...);
+* a truncated listing has to say so — an unreported cap is what pushes the
+  model to invent ids it "could not find";
+* every call re-applies the tenant schema, because the tools run inside the
+  Strands worker thread;
+* a broken lookup becomes an error tool result instead of aborting the turn.
+
+The underlying services are patched: this file tests the tool wrappers, not the
+catalogs themselves.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from models.enums import TagTypeEnum
+from repository import exams_repository, tag_repository
+from services import (
+    clinical_notes_service,
+    drug_service,
+    lists_service,
+    protocol_trace_service,
+    segment_service,
+    substance_service,
+)
+from services.admin import admin_protocol_service
+from services.protocol_agent_tools import (
+    MAX_EXAM_TYPE_RESULTS,
+    MAX_REFERENCE_EXAM_RESULTS,
+    MAX_RESULTS,
+    MAX_TEST_PRESCRIPTIONS,
+    _filter_items,
+    build_tools,
+)
+
+
+def _tools(validate_config=None, normalize_config=None):
+    """Build the tool set keyed by tool name, with the injected callables stubbed."""
+    tools = build_tools(
+        schema="demo",
+        validate_config=validate_config or (lambda config, protocol_type: []),
+        normalize_config=normalize_config or (lambda config: config),
+    )
+
+    return {tool.tool_spec["name"]: tool for tool in tools}
+
+
+def _call(name, **kwargs):
+    """Invoke a tool by name with the tenant schema switch stubbed out."""
+    with mock.patch("services.protocol_agent_tools.dbSession.setSchema") as set_schema:
+        output = _tools()[name]._tool_func(**kwargs)
+
+    return output, set_schema
+
+
+def _result(output):
+    """Unwrap the payload of a successful tool result."""
+    assert output["status"] == "success", output
+    return output["content"][0]["json"]["result"]
+
+
+def _items(output):
+    """Unwrap the items of a successful list tool result."""
+    return _result(output)["items"]
+
+
+def _exam_type(type_exam, name):
+    """Build a get_exam_types() row (typeExam, name)."""
+    return SimpleNamespace(typeExam=type_exam, name=name)
+
+
+def _global_exam(tp_exam, name, initials="", measureunit=""):
+    """Build a get_global_exams() row."""
+    return SimpleNamespace(
+        tp_exam=tp_exam, name=name, initials=initials, measureunit=measureunit
+    )
+
+
+# --------------------------------------------------------------------------
+# the tool set itself
+# --------------------------------------------------------------------------
+
+
+def test_the_documented_tool_set_is_exposed():
+    """The agent prompt names these tools: a rename here breaks the turn"""
+    assert set(_tools()) == {
+        "search_substances",
+        "search_substance_classes",
+        "search_drugs",
+        "search_icds",
+        "search_exam_types",
+        "search_reference_exams",
+        "list_departments",
+        "list_segments",
+        "list_routes",
+        "list_tags",
+        "list_stats_types",
+        "validate_protocol",
+        "test_protocol",
+    }
+
+
+def test_every_tool_is_described_for_the_model():
+    """A tool without a description is invisible to the agent"""
+    for name, tool in _tools().items():
+        assert tool.tool_spec["description"].strip(), name
+
+
+# --------------------------------------------------------------------------
+# _filter_items
+# --------------------------------------------------------------------------
+
+
+def test_filter_without_a_term_keeps_everything():
+    """Omitting the term is how the agent lists a whole catalog"""
+    items = [{"name": "a"}, {"name": "b"}]
+
+    assert _filter_items(items, None, ("name",)) == items
+    assert _filter_items(items, "", ("name",)) == items
+
+
+def test_filter_with_a_blank_term_keeps_everything():
+    """A term the model padded with spaces is not a filter"""
+    items = [{"name": "a"}]
+
+    assert _filter_items(items, "   ", ("name",)) == items
+
+
+def test_filter_matches_a_case_insensitive_substring():
+    """The model rarely reproduces the exact casing of a catalog entry"""
+    items = [{"name": "Potássio"}, {"name": "Sódio"}]
+
+    assert _filter_items(items, "POTÁS", ("name",)) == [{"name": "Potássio"}]
+
+
+def test_filter_searches_every_given_key():
+    """A hit on any of the keys keeps the item"""
+    items = [{"examType": "k", "name": "Potássio"}]
+
+    assert _filter_items(items, "potássio", ("examType", "name")) == items
+    assert _filter_items(items, "k", ("examType", "name")) == items
+
+
+def test_filter_ignores_the_keys_it_was_not_given():
+    """A term matching only an unsearched key is not a hit"""
+    items = [{"examType": "k", "name": "Potássio"}]
+
+    assert _filter_items(items, "potássio", ("examType",)) == []
+
+
+def test_filter_tolerates_missing_and_null_values():
+    """A catalog row with a null column must not break the search"""
+    items = [{"name": None}, {}, {"name": "Sódio"}]
+
+    assert _filter_items(items, "sód", ("name",)) == [{"name": "Sódio"}]
+
+
+def test_filter_trims_the_term_before_matching():
+    """A padded term still matches"""
+    items = [{"name": "Sódio"}]
+
+    assert _filter_items(items, "  sódio  ", ("name",)) == items
+
+
+# --------------------------------------------------------------------------
+# schema handling and error handling (_run)
+# --------------------------------------------------------------------------
+
+
+def test_the_tenant_schema_is_applied_on_every_call():
+    """Tools run in the Strands worker thread, which has no request schema"""
+    with mock.patch.object(substance_service, "find_substance", return_value=[]):
+        _, set_schema = _call("search_substances", term="x")
+
+    set_schema.assert_called_once_with("demo")
+
+
+def test_a_failing_lookup_becomes_an_error_tool_result():
+    """A broken catalog must not abort the chat turn"""
+    with mock.patch.object(
+        substance_service, "find_substance", side_effect=Exception("boom")
+    ):
+        output, _ = _call("search_substances", term="x")
+
+    assert output["status"] == "error"
+    assert "boom" in output["content"][0]["text"]
+
+
+def test_an_error_message_is_truncated():
+    """A stack-trace-sized error would eat the agent context window"""
+    with mock.patch.object(
+        substance_service, "find_substance", side_effect=Exception("x" * 5000)
+    ):
+        output, _ = _call("search_substances", term="x")
+
+    assert len(output["content"][0]["text"]) < 400
+
+
+def test_a_failing_lookup_is_logged():
+    """The failure is invisible in the transcript, so it has to be logged"""
+    with (
+        mock.patch.object(
+            substance_service, "find_substance", side_effect=Exception("boom")
+        ),
+        mock.patch("services.protocol_agent_tools.logger.backend_logger") as log,
+    ):
+        _call("search_substances", term="x")
+
+    log.warning.assert_called_once()
+
+
+def test_a_schema_failure_becomes_an_error_tool_result():
+    """The schema switch itself is inside the guarded block"""
+    with (
+        mock.patch(
+            "services.protocol_agent_tools.dbSession.setSchema",
+            side_effect=Exception("no connection"),
+        ),
+        mock.patch.object(substance_service, "find_substance", return_value=[]),
+    ):
+        output = _tools()["search_substances"]._tool_func(term="x")
+
+    assert output["status"] == "error"
+
+
+# --------------------------------------------------------------------------
+# catalog searches delegated as-is
+# --------------------------------------------------------------------------
+
+
+def test_search_substances_delegates_the_term():
+    """The tool is a thin wrapper over the substance search"""
+    rows = [{"sctid": "111", "name": "Potássio"}]
+
+    with mock.patch.object(
+        substance_service, "find_substance", return_value=rows
+    ) as find:
+        output, _ = _call("search_substances", term="pot")
+
+    find.assert_called_once_with("pot")
+    assert _items(output) == rows
+
+
+def test_search_substance_classes_delegates_the_term():
+    """Class ids feed the `class` variable type"""
+    rows = [{"id": "A10", "name": "Antidiabéticos"}]
+
+    with mock.patch.object(
+        substance_service, "find_substance_class", return_value=rows
+    ) as find:
+        output, _ = _call("search_substance_classes", term="anti")
+
+    find.assert_called_once_with("anti")
+    assert _items(output) == rows
+
+
+def test_search_drugs_delegates_the_term():
+    """Hospital drugs come from the protocol-specific drug search"""
+    rows = [{"idDrug": 1, "name": "Dipirona"}]
+
+    with mock.patch.object(
+        drug_service, "find_protocol_drugs", return_value=rows
+    ) as find:
+        output, _ = _call("search_drugs", term="dipi")
+
+    find.assert_called_once_with("dipi")
+    assert _items(output) == rows
+
+
+def test_search_icds_delegates_the_term():
+    """ICDs are searched by code or description"""
+    rows = [{"id": "C50", "name": "Neoplasia"}]
+
+    with mock.patch.object(lists_service, "find_icds", return_value=rows) as find:
+        output, _ = _call("search_icds", term="c50")
+
+    find.assert_called_once_with("c50")
+    assert _items(output) == rows
+
+
+def test_list_routes_delegates():
+    """Routes take no search term"""
+    rows = [{"id": "IV", "name": "Intravenosa"}]
+
+    with mock.patch.object(lists_service, "list_routes", return_value=rows) as list_fn:
+        output, _ = _call("list_routes")
+
+    list_fn.assert_called_once_with()
+    assert _items(output) == rows
+
+
+def test_list_departments_delegates():
+    """Departments carry the segments they belong to"""
+    rows = [{"idDepartment": 1, "name": "UTI", "segments": [1]}]
+
+    with mock.patch.object(
+        admin_protocol_service, "list_departments", return_value=rows
+    ) as list_fn:
+        output, _ = _call("list_departments")
+
+    list_fn.assert_called_once_with()
+    assert _items(output) == rows
+
+
+# --------------------------------------------------------------------------
+# search_exam_types
+# --------------------------------------------------------------------------
+
+
+def test_exam_types_are_lowercased():
+    """`exam` variables are matched in lowercase at runtime"""
+    with mock.patch.object(
+        exams_repository, "get_exam_types", return_value=[_exam_type("K", "Potássio")]
+    ):
+        output, _ = _call("search_exam_types")
+
+    assert _items(output) == [{"examType": "k", "name": "Potássio"}]
+
+
+def test_exam_types_are_read_from_the_repository_not_the_service():
+    """The service hides the calculated exams, which are valid at runtime"""
+    rows = [_exam_type("ckd21", "CKD-EPI"), _exam_type("mdrd", "MDRD")]
+
+    with mock.patch.object(exams_repository, "get_exam_types", return_value=rows):
+        output, _ = _call("search_exam_types")
+
+    assert [item["examType"] for item in _items(output)] == ["ckd21", "mdrd"]
+
+
+def test_exam_types_can_be_filtered_by_name():
+    """The agent narrows a large catalog with a partial name"""
+    rows = [_exam_type("k", "Potássio"), _exam_type("na", "Sódio")]
+
+    with mock.patch.object(exams_repository, "get_exam_types", return_value=rows):
+        output, _ = _call("search_exam_types", term="sód")
+
+    assert _items(output) == [{"examType": "na", "name": "Sódio"}]
+
+
+def test_exam_types_can_be_filtered_by_the_exam_type_itself():
+    """The model often knows the examType and only wants to confirm it exists"""
+    rows = [_exam_type("K", "Potássio"), _exam_type("NA", "Sódio")]
+
+    with mock.patch.object(exams_repository, "get_exam_types", return_value=rows):
+        output, _ = _call("search_exam_types", term="na")
+
+    assert _items(output) == [{"examType": "na", "name": "Sódio"}]
+
+
+def test_exam_types_report_their_own_cap():
+    """A silently truncated catalog is what makes the agent invent ids"""
+    rows = [_exam_type(f"e{i}", f"Exame {i}") for i in range(MAX_EXAM_TYPE_RESULTS + 5)]
+
+    with mock.patch.object(exams_repository, "get_exam_types", return_value=rows):
+        output, _ = _call("search_exam_types")
+
+    payload = _result(output)
+    assert payload["returned"] == MAX_EXAM_TYPE_RESULTS
+    assert payload["total"] == MAX_EXAM_TYPE_RESULTS + 5
+    assert payload["truncated"] is True
+
+
+def test_exam_types_are_not_capped_at_the_default_list_size():
+    """The exam catalog gets a larger cap than the other listings"""
+    rows = [_exam_type(f"e{i}", f"Exame {i}") for i in range(MAX_RESULTS + 10)]
+
+    with mock.patch.object(exams_repository, "get_exam_types", return_value=rows):
+        output, _ = _call("search_exam_types")
+
+    assert _result(output)["truncated"] is False
+
+
+# --------------------------------------------------------------------------
+# search_reference_exams
+# --------------------------------------------------------------------------
+
+
+def test_reference_exams_keep_the_tpexam_casing():
+    """examRefType is matched verbatim, so the case must survive the tool"""
+    with (
+        mock.patch.object(
+            exams_repository,
+            "get_global_exams",
+            return_value=[_global_exam("creatinina_NH", "Creatinina", "CR", "mg/dL")],
+        ),
+        mock.patch.object(
+            exams_repository, "get_configured_exam_ref_types", return_value=[]
+        ),
+    ):
+        output, _ = _call("search_reference_exams")
+
+    assert _items(output)[0]["tpexam"] == "creatinina_NH"
+
+
+def test_reference_exams_flag_the_ones_configured_in_this_hospital():
+    """A globally valid tpexam no active exam maps to never fires here"""
+    rows = [
+        _global_exam("creatinina_NH", "Creatinina"),
+        _global_exam("ckd21_NH", "CKD"),
+    ]
+
+    with (
+        mock.patch.object(exams_repository, "get_global_exams", return_value=rows),
+        mock.patch.object(
+            exams_repository,
+            "get_configured_exam_ref_types",
+            return_value=["creatinina_NH"],
+        ),
+    ):
+        output, _ = _call("search_reference_exams")
+
+    flags = {
+        item["tpexam"]: item["configuredInThisHospital"] for item in _items(output)
+    }
+    assert flags == {"creatinina_NH": True, "ckd21_NH": False}
+
+
+def test_reference_exams_expose_the_measure_unit_and_initials():
+    """The agent needs the unit to write a plausible threshold"""
+    with (
+        mock.patch.object(
+            exams_repository,
+            "get_global_exams",
+            return_value=[_global_exam("creatinina_NH", "Creatinina", "CR", "mg/dL")],
+        ),
+        mock.patch.object(
+            exams_repository, "get_configured_exam_ref_types", return_value=[]
+        ),
+    ):
+        output, _ = _call("search_reference_exams")
+
+    item = _items(output)[0]
+    assert item["initials"] == "CR"
+    assert item["measureUnit"] == "mg/dL"
+
+
+def test_reference_exams_can_be_filtered_by_the_initials():
+    """Clinicians and the model alike search by abbreviation"""
+    rows = [
+        _global_exam("creatinina_NH", "Creatinina", "CR"),
+        _global_exam("potassio_NH", "Potássio", "K"),
+    ]
+
+    with (
+        mock.patch.object(exams_repository, "get_global_exams", return_value=rows),
+        mock.patch.object(
+            exams_repository, "get_configured_exam_ref_types", return_value=[]
+        ),
+    ):
+        output, _ = _call("search_reference_exams", term="cr")
+
+    assert [item["tpexam"] for item in _items(output)] == ["creatinina_NH"]
+
+
+def test_reference_exams_report_their_own_cap():
+    """The reference catalog is capped tighter than the schema exam types"""
+    rows = [
+        _global_exam(f"e{i}_NH", f"Exame {i}")
+        for i in range(MAX_REFERENCE_EXAM_RESULTS + 3)
+    ]
+
+    with (
+        mock.patch.object(exams_repository, "get_global_exams", return_value=rows),
+        mock.patch.object(
+            exams_repository, "get_configured_exam_ref_types", return_value=[]
+        ),
+    ):
+        output, _ = _call("search_reference_exams")
+
+    payload = _result(output)
+    assert payload["returned"] == MAX_REFERENCE_EXAM_RESULTS
+    assert payload["truncated"] is True
+
+
+# --------------------------------------------------------------------------
+# list_segments / list_tags / list_stats_types
+# --------------------------------------------------------------------------
+
+
+def test_segments_are_mapped_to_id_and_description():
+    """The whole Segment row would be noise in the agent context"""
+    rows = [SimpleNamespace(id=1, description="Adulto", extra="ignored")]
+
+    with mock.patch.object(segment_service, "get_segments", return_value=rows):
+        output, _ = _call("list_segments")
+
+    assert _items(output) == [{"id": 1, "description": "Adulto"}]
+
+
+def test_tags_are_mapped_to_name_and_type():
+    """`tags` variables are written with the tag name"""
+    rows = [SimpleNamespace(name="Sepse", tag_type=TagTypeEnum.PATIENT.value)]
+
+    with mock.patch.object(tag_repository, "list_tags", return_value=rows):
+        output, _ = _call("list_tags")
+
+    assert _items(output) == [{"name": "Sepse", "tagType": TagTypeEnum.PATIENT.value}]
+
+
+def test_tags_are_requested_active_and_for_both_patient_types():
+    """A protocol can key off a navigation tag as well as a patient one"""
+    with mock.patch.object(tag_repository, "list_tags", return_value=[]) as list_fn:
+        _call("list_tags")
+
+    request_data = list_fn.call_args.kwargs["request_data"]
+    assert request_data.active is True
+    assert set(request_data.tagTypeList) == {
+        TagTypeEnum.PATIENT.value,
+        TagTypeEnum.PATIENT_NAVIGATION.value,
+    }
+
+
+def test_stats_types_are_mapped_from_the_clinical_notes_tags():
+    """`cn_stats` variables are written with the indicator key"""
+    rows = [{"name": "sinais", "column": "signs", "key": "signs"}]
+
+    with mock.patch.object(clinical_notes_service, "get_tags", return_value=rows):
+        output, _ = _call("list_stats_types")
+
+    assert _items(output) == [{"statsType": "signs", "name": "sinais"}]
+
+
+# --------------------------------------------------------------------------
+# validate_protocol
+# --------------------------------------------------------------------------
+
+
+def test_validate_protocol_reports_a_valid_config():
+    """An empty error list is the agent's signal to present the proposal"""
+    config = {"variables": [], "trigger": "{{v1}}"}
+
+    with mock.patch("services.protocol_agent_tools.dbSession.setSchema"):
+        output = _tools(validate_config=lambda config, protocol_type: [])[
+            "validate_protocol"
+        ]._tool_func(config=config, protocol_type=2)
+
+    assert _result(output) == {"valid": True, "errors": []}
+
+
+def test_validate_protocol_reports_the_errors_verbatim():
+    """The error text is the only place the agent sees its own mistake"""
+    errors = ["variable v1: unknown examRefType CREAT_FAKE"]
+
+    with mock.patch("services.protocol_agent_tools.dbSession.setSchema"):
+        output = _tools(validate_config=lambda config, protocol_type: errors)[
+            "validate_protocol"
+        ]._tool_func(config={}, protocol_type=2)
+
+    payload = _result(output)
+    assert payload["valid"] is False
+    assert payload["errors"] == errors
+
+
+def test_validate_protocol_result_is_not_wrapped_as_a_list():
+    """A dict result must pass through: `items` would break the loop"""
+    with mock.patch("services.protocol_agent_tools.dbSession.setSchema"):
+        output = _tools()["validate_protocol"]._tool_func(config={}, protocol_type=2)
+
+    assert "items" not in _result(output)
+
+
+def test_validate_protocol_receives_the_config_and_the_protocol_type():
+    """Validation depends on the protocol type, so it must be forwarded"""
+    validate = mock.MagicMock(return_value=[])
+    config = {"trigger": "{{v1}}"}
+
+    with mock.patch("services.protocol_agent_tools.dbSession.setSchema"):
+        _tools(validate_config=validate)["validate_protocol"]._tool_func(
+            config=config, protocol_type=3
+        )
+
+    validate.assert_called_once_with(config=config, protocol_type=3)
+
+
+# --------------------------------------------------------------------------
+# test_protocol
+# --------------------------------------------------------------------------
+
+
+def _valid_config(trigger="{{v1}}"):
+    """A config accepted by ProtocolTestRequest (the evaluator validates it)."""
+    return {
+        "variables": [{"name": "v1", "field": "age", "operator": ">", "value": 60}],
+        "trigger": trigger,
+        "result": {"type": "SHOW_MESSAGE", "level": "high", "message": "Idoso"},
+    }
+
+
+def _test_protocol(config=None, protocol_type=2, ids=None, normalize_config=None):
+    """Invoke the test_protocol tool with the schema switch stubbed out."""
+    with mock.patch("services.protocol_agent_tools.dbSession.setSchema"):
+        return _tools(normalize_config=normalize_config)["test_protocol"]._tool_func(
+            config=config if config is not None else _valid_config(),
+            protocol_type=protocol_type,
+            id_prescription_list=ids,
+        )
+
+
+def test_test_protocol_uses_the_given_prescriptions():
+    """Explicit ids skip the sampling entirely"""
+    with (
+        mock.patch.object(
+            protocol_trace_service, "test_protocol", return_value={"results": []}
+        ) as run,
+        mock.patch.object(protocol_trace_service, "sample_prescriptions") as sample,
+    ):
+        output = _test_protocol(ids=[10, 11])
+
+    sample.assert_not_called()
+    assert run.call_args.kwargs["request_data"].idPrescriptionList == [10, 11]
+    assert _result(output) == {"results": []}
+
+
+def test_test_protocol_caps_the_number_of_prescriptions():
+    """Each prescription is a full evaluation: the cap keeps the turn fast"""
+    given = list(range(1, MAX_TEST_PRESCRIPTIONS + 3))
+
+    with mock.patch.object(
+        protocol_trace_service, "test_protocol", return_value={}
+    ) as run:
+        _test_protocol(ids=given)
+
+    ids = run.call_args.kwargs["request_data"].idPrescriptionList
+    assert ids == given[:MAX_TEST_PRESCRIPTIONS]
+    assert len(ids) == MAX_TEST_PRESCRIPTIONS
+
+
+def test_test_protocol_samples_prescriptions_when_none_are_given():
+    """Omitting the ids is how the agent tests against today's prescriptions"""
+    with (
+        mock.patch.object(
+            protocol_trace_service,
+            "sample_prescriptions",
+            return_value={"idPrescriptionList": ["7", "8"]},
+        ) as sample,
+        mock.patch.object(
+            protocol_trace_service, "test_protocol", return_value={}
+        ) as run,
+    ):
+        _test_protocol(protocol_type=4)
+
+    sample_request = sample.call_args.kwargs["request_data"]
+    assert sample_request.protocolType == 4
+    assert sample_request.limit == MAX_TEST_PRESCRIPTIONS
+    # the sampler returns strings; the evaluator takes ints
+    assert run.call_args.kwargs["request_data"].idPrescriptionList == [7, 8]
+
+
+def test_test_protocol_reports_when_there_is_nothing_to_test():
+    """An empty sample is an answer, not an error"""
+    with (
+        mock.patch.object(
+            protocol_trace_service,
+            "sample_prescriptions",
+            return_value={"idPrescriptionList": []},
+        ),
+        mock.patch.object(protocol_trace_service, "test_protocol") as run,
+    ):
+        output = _test_protocol()
+
+    run.assert_not_called()
+    assert "Nenhuma prescrição" in _result(output)["message"]
+
+
+def test_test_protocol_reports_when_the_sampler_returns_nothing():
+    """A sampler response without the key is treated as an empty sample"""
+    with (
+        mock.patch.object(
+            protocol_trace_service, "sample_prescriptions", return_value={}
+        ),
+        mock.patch.object(protocol_trace_service, "test_protocol") as run,
+    ):
+        output = _test_protocol()
+
+    run.assert_not_called()
+    assert "message" in _result(output)
+
+
+def test_test_protocol_normalizes_the_config_before_evaluating():
+    """A nested combination would be tested as an empty one and match everything"""
+    normalized = _valid_config(trigger="{{v1}} and {{v2}}")
+
+    with mock.patch.object(
+        protocol_trace_service, "test_protocol", return_value={}
+    ) as run:
+        _test_protocol(
+            config=_valid_config(trigger="{{raw}}"),
+            ids=[1],
+            normalize_config=lambda config: normalized,
+        )
+
+    assert run.call_args.kwargs["request_data"].config.trigger == normalized["trigger"]
+
+
+def test_test_protocol_asks_for_the_undetailed_trace():
+    """The detailed trace is far too large for the agent context"""
+    with mock.patch.object(
+        protocol_trace_service, "test_protocol", return_value={}
+    ) as run:
+        _test_protocol(ids=[1])
+
+    assert run.call_args.kwargs["request_data"].detailed is False
+
+
+def test_test_protocol_forwards_the_protocol_type():
+    """The evaluator needs the type to resolve the variables"""
+    with mock.patch.object(
+        protocol_trace_service, "test_protocol", return_value={}
+    ) as run:
+        _test_protocol(protocol_type=5, ids=[1])
+
+    assert run.call_args.kwargs["request_data"].protocolType == 5
+
+
+def test_test_protocol_failure_becomes_an_error_tool_result():
+    """A protocol the evaluator chokes on must not abort the turn"""
+    with mock.patch.object(
+        protocol_trace_service, "test_protocol", side_effect=Exception("bad config")
+    ):
+        output = _test_protocol(ids=[1])
+
+    assert output["status"] == "error"
+    assert "bad config" in output["content"][0]["text"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "search_substances",
+        "search_substance_classes",
+        "search_drugs",
+        "search_icds",
+    ],
+)
+def test_delegated_searches_report_the_default_cap(name):
+    """Every plain catalog search shares the default list size"""
+    rows = [{"id": i} for i in range(MAX_RESULTS + 2)]
+
+    with (
+        mock.patch.object(substance_service, "find_substance", return_value=rows),
+        mock.patch.object(substance_service, "find_substance_class", return_value=rows),
+        mock.patch.object(drug_service, "find_protocol_drugs", return_value=rows),
+        mock.patch.object(lists_service, "find_icds", return_value=rows),
+    ):
+        output, _ = _call(name, term="x")
+
+    payload = _result(output)
+    assert payload["returned"] == MAX_RESULTS
+    assert payload["truncated"] is True


### PR DESCRIPTION
Two features had no dedicated test file. Both were only reached incidentally by other suites, so the branches that actually matter were uncovered. Adds 92 unit tests; no production code changed.

## `services/clinical_notes_pdf_service.py` — 66% → 100%

The PDF sent to ODOO for digital signature. The custom-form branch was entirely untested: a primary-care note has no `text` column, so its body is built from the `template`/`form` pair.

Covered:
- answer formatting: unanswered (`None`/`""` → "Sem resposta"), multiple choice joined, select rendered through its `label`, and `0` treated as a real answer instead of a missing one;
- the group-name rule — omitted for a single group (it carries no grouping information), printed once there is more than one;
- the unlabeled question (free letters), printed without the `"label: "` prefix;
- the HTML inside a form answer, so the emphasis survives;
- the institution header read from the `nav-header` memory, plus its three fallbacks (no record, blank value, value shaped for something else);
- a missing logo costing the document only its logo;
- the signature anchor returned by `build_note_pdf`: page number and vertical fraction, including a note long enough to break onto a second page and the guarantee that the field stays above the bottom margin. The sign service feeds those straight to ODOO, so a wrong value puts the signature on top of the text.

## `services/protocol_agent_tools.py` — 56% → 100%

The catalogs the protocol-creation agent reads before it writes a config. The tool bodies built by `build_tools` had no coverage at all.

Covered:
- the tool set and its names (the agent prompt names them, so a rename breaks the turn);
- `_filter_items`: case-insensitive substring over the given keys, blank/padded terms, null columns;
- the tenant schema re-applied on every call — the tools run in the Strands worker thread;
- a failing lookup becoming a truncated error tool result instead of aborting the chat turn, and being logged;
- the documented output keys the agent has to copy verbatim: `examType` lowercased, `tpexam` case-preserved, `statsType`, `idDepartment`, segment `id`;
- the `configuredInThisHospital` flag, which is what stops the agent proposing a reference exam that never fires in this hospital;
- the per-tool result caps and the `truncated` flag — an unreported cap is what pushes the model to invent ids it "could not find";
- the tag request built for both patient tag types, active only;
- `validate_protocol` (errors passed through verbatim, dict result not wrapped as a list) and `test_protocol` (explicit ids, the three-prescription cap, automatic sampling with string ids coerced to int, the normalization the evaluator depends on, and the empty-sample message).

## Notes

Both are unit tests: `db` and the underlying services are patched, so no new seed data or DDL is needed. Full suite locally: 2671 passed (was 2579); `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjbSXW51Ujc5ZBwJvts9hA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjbSXW51Ujc5ZBwJvts9hA)_