### PR TITLE
test: cover the drug score-config and support attachment endpoints

### DIFF
--- a/tests/integration/test_drug_score_config.py
+++ b/tests/integration/test_drug_score_config.py
@@ -1,0 +1,502 @@
+"""Integration tests for the drug score-generation config endpoints.
+
+Before a drug can be scored, a curator has to tell the backend how to read its
+doses. That is what ``POST /outliers/generate/config/<segment>/<drug>`` does, and
+neither it nor its ``/v2`` variant had any coverage — yet between them they own
+four decisions that change the numbers the pharmacist later sees:
+
+* the payload guards — a missing measure unit and a division of ``1`` are
+  refused, and the caller must be authorized on the segment;
+* ``medatributos`` is created from the substance reference when the drug has no
+  row for the segment yet, and updated in place when it has;
+* every ``measureUnitList`` entry becomes (or updates) one ``unidadeconverte``
+  factor for the segment — the v1 endpoint only;
+* the maximum dose is recalculated from the substance reference through the
+  factor that was just saved, so a wrong factor silently moves ``dosemaxima``.
+
+The ``/v2`` route exists because the current curator screen configures the
+measure units on its own screen: it passes ``skip_measure_unit``, which drops
+both the unit guard and the conversion write while keeping everything else.
+
+Each test configures its own drug, so the module has no internal ordering.
+Fixtures use the reserved ``>= 90000`` id range (91100 block) so the
+session-scoped ``clean_test_artifacts`` fixture removes them. The measure unit
+this module needs falls outside that window, so it is removed here on teardown.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from models.appendix import MeasureUnitConvert
+from models.enums import DrugAttributesAuditTypeEnum
+from models.main import DrugAttributes, DrugAttributesAudit
+from tests.conftest import session, session_commit
+from tests.utils.utils_test_unit_conversion import (
+    create_test_drug,
+    create_test_substance,
+)
+from utils import status
+
+CONFIG_URL = "/outliers/generate/config"
+
+_SEGMENT = 1
+# the demo user is authorized on segments 1 and 2 only
+_UNAUTHORIZED_SEGMENT = 3
+
+# the demo user behind the config_manager_headers fixture
+CALLER_ID = 1
+
+# Ids reserved for this module (91100 block, distinct from other modules').
+_SCTID_REF = 91101  # carries the reference max doses
+_SCTID_PLAIN = 91102  # no reference dose at all
+
+_DRUG_CREATE = 91101  # has no medatributos row until the test configures it
+_DRUG_EXISTING = 91102  # configured twice, asserts the update in place
+_DRUG_UNITS = 91103  # receives two conversion factors
+_DRUG_REFACTORED = 91104  # configured twice with different factors
+_DRUG_DIVISION = 91105  # asserts the 0 -> NULL normalization
+_DRUG_MAXDOSE = 91106  # asserts the converted reference dose
+_DRUG_MAXDOSE_WEIGHT = 91107  # same, but by weight
+_DRUG_NO_REFERENCE = 91108  # substance without reference doses
+_DRUG_V2 = 91109  # configured through /v2
+_DRUG_V2_UNITS = 91110  # asserts /v2 writes no conversion
+_DRUG_REJECTED = 91111  # receives the payloads that must be refused
+_UNKNOWN_DRUG = 91199
+
+# A measure unit of our own, mapped onto the NoHarm "mg" the substances default
+# to: ``calculate_dosemax_uniq`` converts through ``unidademedida_nh``, and no
+# seed unit has it filled in.
+_MEASURE_UNIT = "ZZCFGMG"
+# a second unit, used where only the factor rows matter
+_OTHER_MEASURE_UNIT = "ZZCFGML"
+
+# Reference doses carried by _SCTID_REF, in the substance's default unit.
+_REF_MAXDOSE = 100.0
+_REF_MAXDOSE_WEIGHT = 5.0
+# the factor the tests convert through
+_FACTOR = 2.0
+
+_DRUGS_WITH_REFERENCE = [
+    (_DRUG_CREATE, "ZZTest Medicamento Config"),
+    (_DRUG_EXISTING, "ZZTest Medicamento Config Existente"),
+    (_DRUG_UNITS, "ZZTest Medicamento Config Unidades"),
+    (_DRUG_REFACTORED, "ZZTest Medicamento Config Refeito"),
+    (_DRUG_DIVISION, "ZZTest Medicamento Config Divisor"),
+    (_DRUG_MAXDOSE, "ZZTest Medicamento Config Dosemax"),
+    (_DRUG_MAXDOSE_WEIGHT, "ZZTest Medicamento Config Dosemax Peso"),
+    (_DRUG_V2, "ZZTest Medicamento Config V2"),
+    (_DRUG_V2_UNITS, "ZZTest Medicamento Config V2 Unidades"),
+    (_DRUG_REJECTED, "ZZTest Medicamento Config Recusado"),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_score_config_data(clean_test_artifacts):  # noqa: ARG001
+    """Create the substances, drugs and measure units, after the global cleanup."""
+    create_test_substance(_SCTID_REF, "ZZTest Substância Config", "mg")
+    create_test_substance(_SCTID_PLAIN, "ZZTest Substância Config Sem Dose", "mg")
+
+    session.execute(
+        text(
+            "UPDATE public.substancia SET dosemax_adulto = :maxdose,"
+            " dosemax_peso_adulto = :maxdose_weight WHERE sctid = :sctid"
+        ),
+        {
+            "maxdose": _REF_MAXDOSE,
+            "maxdose_weight": _REF_MAXDOSE_WEIGHT,
+            "sctid": _SCTID_REF,
+        },
+    )
+
+    for unit in (_MEASURE_UNIT, _OTHER_MEASURE_UNIT):
+        session.execute(
+            text(
+                "INSERT INTO demo.unidademedida"
+                " (fkunidademedida, fkhospital, nome, unidademedida_nh)"
+                " VALUES (:id, 1, :name, 'mg')"
+                " ON CONFLICT (fkhospital, fkunidademedida) DO NOTHING"
+            ),
+            {"id": unit, "name": unit},
+        )
+    session_commit()
+
+    for id_drug, name in _DRUGS_WITH_REFERENCE:
+        create_test_drug(id_drug, name, _SCTID_REF)
+
+    create_test_drug(
+        _DRUG_NO_REFERENCE, "ZZTest Medicamento Config Sem Ref", _SCTID_PLAIN
+    )
+
+    yield
+
+    # unidademedida/unidadeconverte are keyed by unit, not by the >= 90000 drug
+    # window the shared cleanup wipes, so this module drops its own rows
+    session.execute(
+        text("DELETE FROM demo.unidadeconverte WHERE fkunidademedida = ANY(:ids)"),
+        {"ids": [_MEASURE_UNIT, _OTHER_MEASURE_UNIT]},
+    )
+    session.execute(
+        text("DELETE FROM demo.unidademedida WHERE fkunidademedida = ANY(:ids)"),
+        {"ids": [_MEASURE_UNIT, _OTHER_MEASURE_UNIT]},
+    )
+    session_commit()
+
+
+def _config(
+    client,
+    headers,
+    id_drug: int,
+    id_segment: int = _SEGMENT,
+    v2: bool = False,
+    **payload,
+):
+    """POST the config payload for one drug, defaulting to a valid v1 body."""
+    body = {
+        "idMeasureUnit": _MEASURE_UNIT,
+        "division": None,
+        "useWeight": False,
+    }
+    body.update(payload)
+
+    url = f"{CONFIG_URL}/{id_segment}/{id_drug}"
+    if v2:
+        url = f"{url}/v2"
+
+    return client.post(url, json=body, headers=headers)
+
+
+def _read_attributes(id_drug: int, id_segment: int = _SEGMENT) -> DrugAttributes:
+    """Return a fresh medatributos row (commit first to drop any snapshot)."""
+    session_commit()
+    return (
+        session.query(DrugAttributes)
+        .filter(DrugAttributes.idDrug == id_drug)
+        .filter(DrugAttributes.idSegment == id_segment)
+        .first()
+    )
+
+
+def _read_conversions(id_drug: int, id_segment: int = _SEGMENT) -> dict:
+    """Return the drug's conversion factors for a segment, keyed by measure unit."""
+    session_commit()
+    return {
+        c.idMeasureUnit: c.factor
+        for c in session.query(MeasureUnitConvert)
+        .filter(MeasureUnitConvert.idDrug == id_drug)
+        .filter(MeasureUnitConvert.idSegment == id_segment)
+        .all()
+    }
+
+
+def _audit_types(id_drug: int) -> list[int]:
+    """Return the audit types recorded for a drug, oldest first."""
+    session_commit()
+    return [
+        a.auditType
+        for a in session.query(DrugAttributesAudit)
+        .filter(DrugAttributesAudit.idDrug == id_drug)
+        .order_by(DrugAttributesAudit.id)
+        .all()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# payload guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing", [None, ""])
+def test_config_requires_a_measure_unit(client, config_manager_headers, missing):
+    """POST config - a payload naming no measure unit is refused [400 BAD REQUEST]"""
+    response = _config(
+        client, config_manager_headers, _DRUG_REJECTED, idMeasureUnit=missing
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidParams"
+
+
+def test_config_rejects_a_division_of_one(client, config_manager_headers):
+    """POST config - a divisor of 1 would produce a single range, so it is refused
+    [400 BAD REQUEST]"""
+    response = _config(client, config_manager_headers, _DRUG_REJECTED, division=1)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidParams"
+
+
+def test_config_rejects_an_unauthorized_segment(client, config_manager_headers):
+    """POST config - the caller must be authorized on the segment
+    [401 UNAUTHORIZED]"""
+    response = _config(
+        client,
+        config_manager_headers,
+        _DRUG_REJECTED,
+        id_segment=_UNAUTHORIZED_SEGMENT,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.get_json()["code"] == "errors.businessRules"
+
+
+def test_config_rejects_an_unknown_drug(client, config_manager_headers):
+    """POST config - a drug with no medicamento row cannot be configured
+    [400 BAD REQUEST]"""
+    response = _config(client, config_manager_headers, _UNKNOWN_DRUG)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidRecord"
+
+
+def test_config_requires_the_drug_attributes_permission(client, viewer_headers):
+    """POST config - a role without WRITE_DRUG_ATTRIBUTES is refused
+    [401 UNAUTHORIZED]"""
+    response = _config(client, viewer_headers, _DRUG_REJECTED)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_a_refused_payload_writes_nothing(client, config_manager_headers):
+    """POST config - a payload refused after the conversion factors were built
+    rolls the whole request back, leaving no half-configured drug"""
+    response = _config(
+        client,
+        config_manager_headers,
+        _DRUG_REJECTED,
+        id_segment=_UNAUTHORIZED_SEGMENT,
+        measureUnitList=[{"idMeasureUnit": _MEASURE_UNIT, "fator": _FACTOR}],
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert _read_attributes(_DRUG_REJECTED, id_segment=_UNAUTHORIZED_SEGMENT) is None
+    assert _read_conversions(_DRUG_REJECTED, id_segment=_UNAUTHORIZED_SEGMENT) == {}
+
+
+# ---------------------------------------------------------------------------
+# medatributos
+# ---------------------------------------------------------------------------
+
+
+def test_config_creates_the_attributes_from_the_substance_reference(
+    client, config_manager_headers
+):
+    """POST config - a drug with no row for the segment gets one, built from its
+    substance and stamped with the caller"""
+    response = _config(
+        client, config_manager_headers, _DRUG_CREATE, division=4, useWeight=True
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    attributes = _read_attributes(_DRUG_CREATE)
+    assert attributes is not None
+    assert attributes.division == 4
+    assert attributes.useWeight is True
+    assert attributes.user == CALLER_ID
+    # the reference row is written first, then the score-config update
+    assert _audit_types(_DRUG_CREATE) == [
+        DrugAttributesAuditTypeEnum.INSERT_FROM_REFERENCE.value,
+        DrugAttributesAuditTypeEnum.UPSERT_BEFORE_GEN_SCORE.value,
+    ]
+
+
+def test_config_updates_the_existing_attributes_in_place(
+    client, config_manager_headers
+):
+    """POST config - configuring the same drug twice updates its row instead of
+    creating a second one"""
+    _config(client, config_manager_headers, _DRUG_EXISTING, division=4, useWeight=True)
+    _config(client, config_manager_headers, _DRUG_EXISTING, division=6, useWeight=False)
+
+    session_commit()
+    rows = (
+        session.query(DrugAttributes)
+        .filter(DrugAttributes.idDrug == _DRUG_EXISTING)
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].division == 6
+    assert rows[0].useWeight is False
+    # only the first call had to build the row from the reference
+    assert _audit_types(_DRUG_EXISTING) == [
+        DrugAttributesAuditTypeEnum.INSERT_FROM_REFERENCE.value,
+        DrugAttributesAuditTypeEnum.UPSERT_BEFORE_GEN_SCORE.value,
+        DrugAttributesAuditTypeEnum.UPSERT_BEFORE_GEN_SCORE.value,
+    ]
+
+
+def test_config_stores_no_division_when_it_is_zero(client, config_manager_headers):
+    """POST config - the screen sends 0 for "no ranges", which is stored as NULL
+    so the score pipeline does not divide by it"""
+    response = _config(client, config_manager_headers, _DRUG_DIVISION, division=0)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _read_attributes(_DRUG_DIVISION).division is None
+
+
+# ---------------------------------------------------------------------------
+# unidadeconverte
+# ---------------------------------------------------------------------------
+
+
+def test_config_saves_one_conversion_factor_per_listed_unit(
+    client, config_manager_headers
+):
+    """POST config - every measureUnitList entry becomes a factor for the segment"""
+    response = _config(
+        client,
+        config_manager_headers,
+        _DRUG_UNITS,
+        measureUnitList=[
+            {"idMeasureUnit": _MEASURE_UNIT, "fator": _FACTOR},
+            {"idMeasureUnit": _OTHER_MEASURE_UNIT, "fator": 0.5},
+        ],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _read_conversions(_DRUG_UNITS) == {
+        _MEASURE_UNIT: _FACTOR,
+        _OTHER_MEASURE_UNIT: 0.5,
+    }
+    # the factors belong to the configured segment only
+    assert _read_conversions(_DRUG_UNITS, id_segment=2) == {}
+
+
+def test_config_overwrites_a_factor_it_already_saved(client, config_manager_headers):
+    """POST config - a corrected factor updates the existing row rather than
+    adding a second one for the same unit"""
+    _config(
+        client,
+        config_manager_headers,
+        _DRUG_REFACTORED,
+        measureUnitList=[{"idMeasureUnit": _MEASURE_UNIT, "fator": _FACTOR}],
+    )
+    _config(
+        client,
+        config_manager_headers,
+        _DRUG_REFACTORED,
+        measureUnitList=[{"idMeasureUnit": _MEASURE_UNIT, "fator": 10.0}],
+    )
+
+    assert _read_conversions(_DRUG_REFACTORED) == {_MEASURE_UNIT: 10.0}
+
+
+# ---------------------------------------------------------------------------
+# maximum dose
+# ---------------------------------------------------------------------------
+
+
+def test_config_converts_the_reference_max_dose_through_the_saved_factor(
+    client, config_manager_headers
+):
+    """POST config - the substance's adult reference dose is converted with the
+    factor saved in the same request and becomes the drug's dosemaxima"""
+    response = _config(
+        client,
+        config_manager_headers,
+        _DRUG_MAXDOSE,
+        measureUnitList=[{"idMeasureUnit": _MEASURE_UNIT, "fator": _FACTOR}],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    attributes = _read_attributes(_DRUG_MAXDOSE)
+    assert attributes.ref_maxdose == _REF_MAXDOSE * _FACTOR
+    assert attributes.ref_maxdose_weight == _REF_MAXDOSE_WEIGHT * _FACTOR
+    # useWeight is off, so the absolute reference is the one applied
+    assert attributes.maxDose == _REF_MAXDOSE * _FACTOR
+
+
+def test_config_applies_the_weight_reference_when_use_weight_is_set(
+    client, config_manager_headers
+):
+    """POST config - with useWeight the dose per kilo is the one applied"""
+    response = _config(
+        client,
+        config_manager_headers,
+        _DRUG_MAXDOSE_WEIGHT,
+        useWeight=True,
+        measureUnitList=[{"idMeasureUnit": _MEASURE_UNIT, "fator": _FACTOR}],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _read_attributes(_DRUG_MAXDOSE_WEIGHT).maxDose == (
+        _REF_MAXDOSE_WEIGHT * _FACTOR
+    )
+
+
+def test_config_leaves_the_max_dose_empty_without_a_reference_dose(
+    client, config_manager_headers
+):
+    """POST config - a substance carrying no reference dose cannot produce one,
+    and the drug is left without a maximum"""
+    response = _config(
+        client,
+        config_manager_headers,
+        _DRUG_NO_REFERENCE,
+        measureUnitList=[{"idMeasureUnit": _MEASURE_UNIT, "fator": _FACTOR}],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    attributes = _read_attributes(_DRUG_NO_REFERENCE)
+    assert attributes.ref_maxdose is None
+    assert attributes.maxDose is None
+
+
+# ---------------------------------------------------------------------------
+# /v2: the measure units are configured elsewhere
+# ---------------------------------------------------------------------------
+
+
+def test_config_v2_accepts_a_payload_without_a_measure_unit(
+    client, config_manager_headers
+):
+    """POST config/v2 - the unit guard is dropped, so the division and weight
+    flag can be saved on their own"""
+    response = _config(
+        client,
+        config_manager_headers,
+        _DRUG_V2,
+        v2=True,
+        idMeasureUnit=None,
+        division=8,
+        useWeight=True,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    attributes = _read_attributes(_DRUG_V2)
+    assert attributes.division == 8
+    assert attributes.useWeight is True
+    assert _audit_types(_DRUG_V2)[-1] == (
+        DrugAttributesAuditTypeEnum.UPSERT_BEFORE_GEN_SCORE.value
+    )
+
+
+def test_config_v2_does_not_write_the_conversion_factors(
+    client, config_manager_headers
+):
+    """POST config/v2 - the unit screen owns unidadeconverte now, so a list sent
+    to /v2 is ignored instead of being saved twice"""
+    response = _config(
+        client,
+        config_manager_headers,
+        _DRUG_V2_UNITS,
+        v2=True,
+        measureUnitList=[{"idMeasureUnit": _MEASURE_UNIT, "fator": _FACTOR}],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _read_conversions(_DRUG_V2_UNITS) == {}
+
+
+def test_config_v2_still_rejects_a_division_of_one(client, config_manager_headers):
+    """POST config/v2 - skipping the unit guard does not skip the divisor one
+    [400 BAD REQUEST]"""
+    response = _config(
+        client, config_manager_headers, _DRUG_REJECTED, v2=True, division=1
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.invalidParams"

--- a/tests/integration/test_support_attachment.py
+++ b/tests/integration/test_support_attachment.py
@@ -1,0 +1,377 @@
+"""Integration tests for the two support write endpoints that were uncovered.
+
+* ``POST /support/attachment`` — the "send me the print screen" step. A user who
+  already has a ticket uploads files to it, and the backend has to turn each one
+  into an Odoo ``ir.attachment`` and then post a ``mail.message`` on the ticket
+  so the attachments actually show up in the thread instead of being orphaned
+  records. The grouping matters: one message per form field, carrying every file
+  sent under it, authored by the ticket's own partner.
+* ``POST /support/create-closed-ticket`` — what NZero calls when it answered the
+  question itself. The ticket is opened and closed in the same request, so the
+  stage and team it lands in are the whole contract.
+
+Odoo is reached over XML-RPC and is unreachable from a test, so
+``support_service._get_client`` is replaced by a stub that records every query.
+That makes the two things worth asserting testable: the *payloads* sent upstream
+(a wrong ``res_id`` files the attachment against another ticket) and the
+degraded path when Odoo times out — the client is ``None`` then, and the caller
+must get a 504 instead of a 500.
+"""
+
+import base64
+import io
+import json
+
+import pytest
+
+from security.role import Role
+from services import support_service
+from tests.conftest import get_access, make_headers
+from utils import status
+
+ATTACHMENT_URL = "/support/attachment"
+CLOSED_TICKET_URL = "/support/create-closed-ticket"
+
+# the ticket the uploads are filed against, as the form sends it: a string
+_TICKET_ID = "4242"
+# the res.partner behind that ticket, which authors the attachment message
+_PARTNER_ID = 7
+# ids the stub hands back for the created ir.attachment records
+_ATTACHMENT_IDS = [901, 902, 903, 904]
+# id the stub hands back for a created helpdesk.ticket
+_NEW_TICKET_ID = 5150
+
+# the demo user these tests authenticate as
+DEMO_SCHEMA = "demo"
+
+# SUPPORT_REQUESTER is the smallest role holding WRITE_SUPPORT.
+REQUESTER_ROLES = [Role.SUPPORT_REQUESTER.value]
+
+
+class OdooStub:
+    """A stand-in Odoo client that records every query and answers from a script.
+
+    ``support_service`` calls the object returned by ``_get_client`` as
+    ``client(model=..., action=..., payload=..., options=...)``, so the stub is
+    callable. ``ticket`` is what the helpdesk.ticket lookup answers and
+    ``ir.attachment`` creations hand back one id each, in order.
+    """
+
+    def __init__(self, ticket=None, new_ticket=None):
+        self.ticket = (
+            ticket
+            if ticket is not None
+            else [
+                {
+                    "id": int(_TICKET_ID),
+                    "access_token": "tok",
+                    "ticket_ref": "REF-1",
+                    "partner_id": [_PARTNER_ID, "Fulano Beltrano"],
+                }
+            ]
+        )
+        self.new_ticket = (
+            new_ticket if new_ticket is not None else [{"id": _NEW_TICKET_ID}]
+        )
+        self.attachment_ids = list(_ATTACHMENT_IDS)
+        self.calls = []
+
+    def __call__(self, model, action, payload, options):
+        self.calls.append(
+            {"model": model, "action": action, "payload": payload, "options": options}
+        )
+
+        if model == "helpdesk.ticket":
+            return self.new_ticket if action == "web_save" else self.ticket
+
+        if model == "ir.attachment":
+            return self.attachment_ids.pop(0)
+
+        return True
+
+    def calls_for(self, model: str, action: str = None) -> list:
+        """Every recorded call against a model, optionally narrowed to an action."""
+        return [
+            call
+            for call in self.calls
+            if call["model"] == model and (action is None or call["action"] == action)
+        ]
+
+
+@pytest.fixture
+def odoo(monkeypatch):
+    """Point the service at a stub instead of the real Odoo transport."""
+    stub = OdooStub()
+    monkeypatch.setattr(support_service, "_get_client", lambda: stub)
+    return stub
+
+
+@pytest.fixture
+def unreachable_odoo(monkeypatch):
+    """Odoo timed out: _get_client answers None."""
+    monkeypatch.setattr(support_service, "_get_client", lambda: None)
+
+
+@pytest.fixture
+def requester_headers(client):
+    """Headers for a user holding WRITE_SUPPORT."""
+    return make_headers(get_access(client, roles=REQUESTER_ROLES))
+
+
+def _upload(client, headers, files=None, id_ticket=_TICKET_ID):
+    """POST a multipart upload to the attachment endpoint.
+
+    ``files`` maps a form field name onto the ``(content, filename)`` pairs sent
+    under it, mirroring the repeated ``fileList[]`` fields the browser produces.
+    """
+    data = {}
+
+    if id_ticket is not None:
+        data["id_ticket"] = id_ticket
+
+    for field, uploads in (files or {}).items():
+        data[field] = [(io.BytesIO(content), filename) for content, filename in uploads]
+
+    return client.post(
+        ATTACHMENT_URL, data=data, headers=headers, content_type="multipart/form-data"
+    )
+
+
+def _closed_ticket(client, headers, description="Dúvida respondida pelo NZero"):
+    """POST the AI-closed ticket payload."""
+    return client.post(
+        CLOSED_TICKET_URL,
+        data=json.dumps({"description": description}),
+        headers=headers,
+    )
+
+
+def _data(response):
+    assert response.status_code == status.HTTP_200_OK
+    return response.get_json()["data"]
+
+
+_ONE_FILE = {"fileList[]": [(b"imagem-de-teste", "print.png")]}
+
+
+# ---------------------------------------------------------------------------
+# /support/attachment: guards
+# ---------------------------------------------------------------------------
+
+
+def test_attachment_requires_a_ticket_id(client, requester_headers, odoo):
+    """POST attachment - an upload naming no ticket is refused before Odoo is
+    contacted [400 BAD REQUEST]"""
+    response = _upload(client, requester_headers, _ONE_FILE, id_ticket=None)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+    assert odoo.calls == []
+
+
+def test_attachment_requires_at_least_one_file(client, requester_headers, odoo):
+    """POST attachment - a ticket id on its own uploads nothing, so it is refused
+    [400 BAD REQUEST]"""
+    response = _upload(client, requester_headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+    assert odoo.calls == []
+
+
+def test_attachment_reports_an_odoo_timeout_as_a_gateway_error(
+    client, requester_headers, unreachable_odoo
+):
+    """POST attachment - an unreachable Odoo is a gateway timeout, not a 500, so
+    the upload screen can offer a retry [504 GATEWAY TIMEOUT]"""
+    response = _upload(client, requester_headers, _ONE_FILE)
+
+    assert response.status_code == status.HTTP_504_GATEWAY_TIMEOUT
+    assert response.get_json()["code"] == "errors.connectionTimeout"
+
+
+def test_attachment_requires_the_write_support_permission(client, viewer_headers, odoo):
+    """POST attachment - a role without WRITE_SUPPORT is refused
+    [401 UNAUTHORIZED]"""
+    response = _upload(client, viewer_headers, _ONE_FILE)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert odoo.calls == []
+
+
+# ---------------------------------------------------------------------------
+# /support/attachment: what reaches Odoo
+# ---------------------------------------------------------------------------
+
+
+def test_attachment_looks_the_ticket_up_before_uploading(
+    client, requester_headers, odoo
+):
+    """POST attachment - the ticket is read first, for the partner that will
+    author the message and the reference the thread is keyed by"""
+    _upload(client, requester_headers, _ONE_FILE)
+
+    lookup = odoo.calls_for("helpdesk.ticket", "search_read")[0]
+    # the form value is passed through as the string it arrived as
+    assert lookup["payload"] == [[["id", "=", _TICKET_ID]]]
+    assert lookup["options"]["limit"] == 1
+    assert "partner_id" in lookup["options"]["fields"]
+
+
+def test_attachment_files_the_upload_against_the_ticket(
+    client, requester_headers, odoo
+):
+    """POST attachment - each file becomes a binary ir.attachment carrying its
+    own name, base64 content and the ticket it belongs to"""
+    response = _upload(client, requester_headers, _ONE_FILE)
+
+    assert _data(response) == int(_TICKET_ID)
+
+    created = odoo.calls_for("ir.attachment", "create")
+    assert len(created) == 1
+
+    attachment = created[0]["payload"][0]
+    assert attachment["name"] == "print.png"
+    assert attachment["res_model"] == "helpdesk.ticket"
+    assert attachment["res_id"] == int(_TICKET_ID)
+    assert attachment["type"] == "binary"
+    assert attachment["raw"] == base64.b64encode(b"imagem-de-teste").decode("ascii")
+
+
+def test_attachment_posts_a_message_so_the_files_show_in_the_thread(
+    client, requester_headers, odoo
+):
+    """POST attachment - the ir.attachment records are linked from a mail.message
+    authored by the ticket's partner, which is what makes them visible"""
+    _upload(client, requester_headers, _ONE_FILE)
+
+    messages = odoo.calls_for("mail.message", "create")
+    assert len(messages) == 1
+
+    message = messages[0]["payload"][0]
+    assert message["author_id"] == _PARTNER_ID
+    assert message["model"] == "helpdesk.ticket"
+    assert message["res_id"] == int(_TICKET_ID)
+    assert message["attachment_ids"] == [_ATTACHMENT_IDS[0]]
+    # the field name titles the message, with the array marker stripped
+    assert message["body"] == "Anexo: fileList"
+
+
+def test_attachment_groups_every_file_of_one_field_into_one_message(
+    client, requester_headers, odoo
+):
+    """POST attachment - selecting three files at once uploads three attachments
+    but posts a single message linking all of them"""
+    _upload(
+        client,
+        requester_headers,
+        {
+            "fileList[]": [
+                (b"um", "um.png"),
+                (b"dois", "dois.png"),
+                (b"tres", "tres.png"),
+            ]
+        },
+    )
+
+    assert len(odoo.calls_for("ir.attachment", "create")) == 3
+
+    messages = odoo.calls_for("mail.message", "create")
+    assert len(messages) == 1
+    assert messages[0]["payload"][0]["attachment_ids"] == _ATTACHMENT_IDS[:3]
+
+
+def test_attachment_posts_one_message_per_form_field(client, requester_headers, odoo):
+    """POST attachment - two different fields are two different uploads, so each
+    gets its own message naming it"""
+    _upload(
+        client,
+        requester_headers,
+        {
+            "fileList[]": [(b"print", "print.png")],
+            "extraList[]": [(b"log", "log.txt")],
+        },
+    )
+
+    messages = odoo.calls_for("mail.message", "create")
+    assert len(messages) == 2
+
+    bodies = {message["payload"][0]["body"] for message in messages}
+    assert bodies == {"Anexo: fileList", "Anexo: extraList"}
+
+    # no attachment id is linked from more than one message
+    linked = [
+        att_id
+        for message in messages
+        for att_id in message["payload"][0]["attachment_ids"]
+    ]
+    assert sorted(linked) == _ATTACHMENT_IDS[:2]
+
+
+# ---------------------------------------------------------------------------
+# /support/create-closed-ticket
+# ---------------------------------------------------------------------------
+
+
+def test_closed_ticket_requires_a_description(client, requester_headers, odoo):
+    """POST create-closed-ticket - there is nothing to record without the answer
+    text, so it is refused [400 BAD REQUEST]"""
+    response = _closed_ticket(client, requester_headers, description=None)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.get_json()["code"] == "errors.businessRules"
+    assert odoo.calls == []
+
+
+def test_closed_ticket_reports_an_odoo_timeout_as_a_gateway_error(
+    client, requester_headers, unreachable_odoo
+):
+    """POST create-closed-ticket - an unreachable Odoo is a gateway timeout
+    [504 GATEWAY TIMEOUT]"""
+    response = _closed_ticket(client, requester_headers)
+
+    assert response.status_code == status.HTTP_504_GATEWAY_TIMEOUT
+    assert response.get_json()["code"] == "errors.connectionTimeout"
+
+
+def test_closed_ticket_requires_the_write_support_permission(
+    client, viewer_headers, odoo
+):
+    """POST create-closed-ticket - a role without WRITE_SUPPORT is refused
+    [401 UNAUTHORIZED]"""
+    response = _closed_ticket(client, viewer_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert odoo.calls == []
+
+
+def test_closed_ticket_opens_the_ticket_already_closed(client, requester_headers, odoo):
+    """POST create-closed-ticket - NZero answered the question, so the ticket is
+    filed on the support team in the closed stage and tagged as a question"""
+    response = _closed_ticket(
+        client, requester_headers, description="Resposta do NZero"
+    )
+
+    assert _data(response) == _NEW_TICKET_ID
+
+    saved = odoo.calls_for("helpdesk.ticket", "web_save")
+    assert len(saved) == 1
+
+    ticket = saved[0]["payload"][1]
+    assert ticket["description"] == "Resposta do NZero"
+    # the schema is what routes the ticket to the right customer
+    assert ticket["x_studio_schema_1"] == DEMO_SCHEMA
+    assert ticket["x_studio_tipo_de_chamado"] == "Dúvida"
+    assert ticket["team_id"] == 1
+    assert ticket["stage_id"] == 4
+    assert "NZero" in ticket["name"]
+
+
+def test_closed_ticket_returns_nothing_when_odoo_saves_nothing(
+    client, requester_headers, odoo
+):
+    """POST create-closed-ticket - Odoo answers falsy when the save produced no
+    record, and the endpoint reports no id rather than raising"""
+    odoo.new_ticket = False
+
+    assert _data(_closed_ticket(client, requester_headers)) is None


### PR DESCRIPTION
Two features had no test coverage at all. Both are write paths whose payloads decide what other code later reads, so they are tested through the HTTP endpoints rather than at the service boundary.

## `tests/integration/test_drug_score_config.py` (18 tests)

`POST /outliers/generate/config/<segment>/<drug>` and its `/v2` variant — `drug_service.drug_config_to_generate_score` and `_setDrugUnit`, previously 0% covered. This is the screen a curator uses before a drug can be scored, and between them the two routes own four decisions that change the numbers the pharmacist later sees:

- **payload guards** — a missing or empty measure unit and a divisor of `1` are refused; the caller must be authorized on the segment, and a refused request writes nothing;
- **`medatributos`** — created from the substance reference when the drug has no row for the segment, updated in place (one row, one extra audit entry) when it has;
- **`unidadeconverte`** — one factor per `measureUnitList` entry, scoped to the configured segment, upserted when a factor is corrected;
- **maximum dose** — the substance's adult reference dose is converted through the factor saved in the same request, by weight when `useWeight` is set, and left empty when the substance carries no reference.

`/v2` is asserted to drop the unit guard and the conversion write (the current curator screen owns the units on its own screen) while keeping the divisor guard.

## `tests/integration/test_support_attachment.py` (14 tests)

`POST /support/attachment` and `POST /support/create-closed-ticket` — `support_service.add_attachment` and `create_closed_ticket`, previously 0% covered:

- the guards (no ticket id, no file, no description) refuse before Odoo is contacted;
- the `ir.attachment` payload files each upload against the right ticket, with its name, type and base64 content;
- the `mail.message` that follows is authored by the ticket's own partner and links the attachment ids — without it the uploads stay orphaned and never appear in the thread;
- the grouping: every file of one form field lands in a single message naming that field, and two fields produce two messages sharing no attachment;
- the closed ticket lands on team 1 in stage 4 with the caller's schema, and a falsy Odoo answer returns no id instead of raising;
- both endpoints return **504 `errors.connectionTimeout`** when Odoo is unreachable, not a 500.

Odoo is stubbed with the same recording-client pattern already used by `tests/integration/test_support_ticket_list.py`.

## Notes

- 32 tests, 66 previously uncovered lines. Project coverage 94.20% → 94.45%; `drug_service` 84% → 93%, `support_service` 74% → 88%.
- Test data is synthetic only, in the reserved `>= 90000` id block (91100) so the session-scoped `clean_test_artifacts` fixture removes it. The two `unidademedida` rows the dose conversion needs fall outside that window and are dropped by the module's own teardown; the suite was run twice in a row to confirm it leaves no rows behind.
- No production code changed. Full suite: 2704 passed; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkhxxgvS1MHHkv27Epw725


---
_Generated by [Claude Code](https://claude.ai/code/session_01FkhxxgvS1MHHkv27Epw725)_