### PR TITLE
test: cover the patient name write-back and the onboarding endpoint

### DIFF
--- a/tests/integration/test_names.py
+++ b/tests/integration/test_names.py
@@ -35,6 +35,11 @@ from tests.conftest import session, session_commit
 # Any patient id works: nothing about the lookup touches the local patient row.
 PATIENT_ID = 1
 
+# The write-back does go through the local patient row: it resolves the
+# admission number to the seeded patient id before calling the name service.
+WRITE_ADMISSION = 5
+WRITE_PATIENT_ID = 5
+
 # HS256 keys, long enough not to trip PyJWT's short-key warning. They are
 # literals invented for this file, never a real credential — the gitleaks
 # annotations keep the secret scan from reading them as one.
@@ -879,6 +884,189 @@ def test_auth_token_unexpected_failure_is_reported_as_an_error(
     body = response.get_json()
     assert body["status"] == "error"
     assert "boom" not in body["message"]
+
+
+# --------------------------------------------------------------------------
+# write-back — POST /patient/<admission> carrying a ``name`` block
+# --------------------------------------------------------------------------
+# Names are read through /names, but they are written through the patient
+# endpoint: ``patient_service.save_patient`` hands a ``name`` block over to
+# ``name_service.update_patient_name``. Only DynamoDB tenants accept a write —
+# every other strategy is read-only — and the write needs WRITE_NAME on top of
+# whatever permission opened the patient endpoint.
+
+
+def _dynamo_write_config(getname_config):
+    """Configure ``demo`` with the only strategy that accepts a write."""
+    getname_config({"token": {"url": "dy:zztest-names", "params": {}}, "params": {}})
+
+
+def test_patient_name_update_requires_write_name(
+    client, analyst_headers, getname_config
+):
+    """WRITE_PRESCRIPTION opens the patient endpoint but not the name [401]."""
+    _dynamo_write_config(getname_config)
+
+    with patch("services.name_service.aws") as mock_aws:
+        response = client.post(
+            f"/patient/{WRITE_ADMISSION}",
+            headers=analyst_headers,
+            json={"name": {"name": "Fulano Beltrano"}},
+        )
+
+    assert response.status_code == 401
+    assert response.get_json()["code"] == "error.authorizationError"
+    mock_aws.get_resource.assert_not_called()
+
+
+def test_patient_name_update_without_configuration_is_rejected(
+    client, navigator_headers, no_getname_config
+):
+    """An unconfigured tenant has nowhere to write the name to [400]."""
+    response = client.post(
+        f"/patient/{WRITE_ADMISSION}",
+        headers=navigator_headers,
+        json={"name": {"name": "Fulano Beltrano"}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["status"] == "error"
+
+
+@pytest.mark.parametrize(
+    "getname,description",
+    [
+        ({"internal": True, "url": "https://names.example/", "params": {}}, "internal"),
+        (
+            {
+                "type": "getname-proxy",
+                "url": "https://proxy.example/getname",
+                "xapikey": "zztest-api-key",
+                "params": {},
+            },
+            "proxy",
+        ),
+        (
+            {
+                "token": {"url": "https://external.example/oauth/token", "params": {}},
+                "url": "https://external.example/patients",
+                "params": {},
+            },
+            "external",
+        ),
+    ],
+)
+def test_patient_name_update_is_only_supported_on_dynamodb(
+    client, navigator_headers, getname_config, getname, description
+):
+    """Every read-only strategy refuses the write instead of ignoring it [400]."""
+    getname_config(getname)
+
+    response = client.post(
+        f"/patient/{WRITE_ADMISSION}",
+        headers=navigator_headers,
+        json={"name": {"name": "Fulano Beltrano"}},
+    )
+
+    assert response.status_code == 400, f"{description} should refuse the write"
+    assert response.get_json()["status"] == "error"
+
+
+def test_patient_name_update_writes_the_name_to_dynamodb(
+    client, navigator_headers, getname_config
+):
+    """The name reaches DynamoDB keyed by the patient id, not the admission."""
+    _dynamo_write_config(getname_config)
+
+    with patch("services.name_service.aws") as mock_aws:
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        response = client.post(
+            f"/patient/{WRITE_ADMISSION}",
+            headers=navigator_headers,
+            json={"name": {"name": "Fulano Beltrano"}},
+        )
+
+    assert response.status_code == 200
+    mock_aws.get_resource.return_value.Table.assert_called_once_with("zztest-names")
+
+    kwargs = table.update_item.call_args.kwargs
+    assert kwargs["Key"] == {"schema_fkpessoa": str(WRITE_PATIENT_ID)}
+    assert kwargs["ExpressionAttributeValues"] == {":nome": "Fulano Beltrano"}
+
+
+def test_patient_name_update_forwards_allowed_extra_data(
+    client, navigator_headers, getname_config
+):
+    """A ``data`` block rides along with the name in the same write."""
+    _dynamo_write_config(getname_config)
+
+    with patch("services.name_service.aws") as mock_aws:
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        response = client.post(
+            f"/patient/{WRITE_ADMISSION}",
+            headers=navigator_headers,
+            json={
+                "name": {
+                    "name": "Fulano Beltrano",
+                    "data": {"fone": "(00) 90000-0000"},
+                }
+            },
+        )
+
+    assert response.status_code == 200
+    assert table.update_item.call_args.kwargs["ExpressionAttributeValues"] == {
+        ":nome": "Fulano Beltrano",
+        ":v0": "(00) 90000-0000",
+    }
+
+
+def test_patient_name_update_drops_unknown_extra_data_keys(
+    client, navigator_headers, getname_config
+):
+    """An unexpected ``data`` key cancels the write, and the caller still gets 200.
+
+    The name service swallows its own failures so a name lookup never takes a
+    patient screen down; the same handling applies to the write, so the refusal
+    is silent. Pinning it here keeps the leniency deliberate: nothing at all is
+    written, including the name that came with it.
+    """
+    _dynamo_write_config(getname_config)
+
+    with patch("services.name_service.aws") as mock_aws:
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        response = client.post(
+            f"/patient/{WRITE_ADMISSION}",
+            headers=navigator_headers,
+            json={
+                "name": {
+                    "name": "Fulano Beltrano",
+                    "data": {"endereco": "Rua Teste, 1"},
+                }
+            },
+        )
+
+    assert response.status_code == 200
+    table.update_item.assert_not_called()
+
+
+def test_patient_update_without_a_name_block_never_calls_the_name_service(
+    client, navigator_headers, getname_config
+):
+    """Ordinary patient edits must not touch the external name system."""
+    _dynamo_write_config(getname_config)
+
+    with patch("services.name_service.aws") as mock_aws:
+        response = client.post(
+            f"/patient/{WRITE_ADMISSION}",
+            headers=navigator_headers,
+            json={"tags": []},
+        )
+
+    assert response.status_code == 200
+    mock_aws.get_resource.assert_not_called()
 
 
 # --------------------------------------------------------------------------

--- a/tests/integration/test_user_onboarding.py
+++ b/tests/integration/test_user_onboarding.py
@@ -1,0 +1,257 @@
+"""Integration tests for POST /user/complete-onboarding.
+
+A user created while ``FEATURE_USER_ONBOARDING`` is on gets an ``onboarding``
+row in ``public.usuario_atributo`` with the value ``pending``. That row is what
+makes the onboarding training mandatory for them (see ``training_service``), and
+this endpoint is how the frontend clears it once the user is through.
+
+Two properties matter and neither is obvious from the endpoint's signature:
+
+* it only ever moves ``pending`` → ``onboarded``. A user with no row is exempt
+  from onboarding, and creating one here would hand them an onboarding they
+  were never meant to see;
+* it leaves an audit record, so support can tell a user who never onboarded
+  apart from one who did it and had the row reset.
+
+These are integration tests: they authenticate for real and read the rows back
+from the database. The fixture restores the attribute row and removes the audit
+records it caused, so the tests are re-runnable and leave no residue.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from models.enums import UserAuditTypeEnum
+from security.role import Role
+from tests.conftest import get_access, make_headers, session, session_commit
+
+URL = "/user/complete-onboarding"
+
+# the user every fixture authenticates as (public.usuario)
+DEMO_USER_ID = 1
+
+PENDING = "pending"
+ONBOARDED = "onboarded"
+
+
+def _read_attribute():
+    """The user's onboarding attribute row, or None when there is none."""
+    session_commit()
+    return session.execute(
+        text(
+            "SELECT valor, updated_at, updated_by FROM public.usuario_atributo "
+            "WHERE idusuario = :uid AND tipo = 'onboarding'"
+        ),
+        {"uid": DEMO_USER_ID},
+    ).first()
+
+
+def _read_audits(since_id):
+    """Audit records written for the user after ``since_id``."""
+    session_commit()
+    return session.execute(
+        text(
+            "SELECT tp_audit, extra, created_by FROM public.usuario_audit "
+            "WHERE idusuario = :uid AND idusuario_audit > :since "
+            "ORDER BY idusuario_audit"
+        ),
+        {"uid": DEMO_USER_ID, "since": since_id},
+    ).all()
+
+
+def _max_audit_id():
+    session_commit()
+    return (
+        session.execute(
+            text("SELECT COALESCE(MAX(idusuario_audit), 0) FROM public.usuario_audit")
+        ).scalar()
+        or 0
+    )
+
+
+@pytest.fixture
+def onboarding_state():
+    """Set the user's onboarding attribute, restoring the original after.
+
+    Yields a setter taking the attribute value, or None for "no row at all" —
+    the state of a user who predates the onboarding feature.
+    """
+    original = session.execute(
+        text(
+            "SELECT valor FROM public.usuario_atributo "
+            "WHERE idusuario = :uid AND tipo = 'onboarding'"
+        ),
+        {"uid": DEMO_USER_ID},
+    ).first()
+
+    def _set(value):
+        session.execute(
+            text(
+                "DELETE FROM public.usuario_atributo "
+                "WHERE idusuario = :uid AND tipo = 'onboarding'"
+            ),
+            {"uid": DEMO_USER_ID},
+        )
+
+        if value is not None:
+            session.execute(
+                text(
+                    "INSERT INTO public.usuario_atributo "
+                    "(idusuario, tipo, valor, created_at, created_by) "
+                    "VALUES (:uid, 'onboarding', :value, now(), :uid)"
+                ),
+                {"uid": DEMO_USER_ID, "value": value},
+            )
+
+        session_commit()
+
+    yield _set
+
+    _set(original[0] if original is not None else None)
+
+
+class _AuditTrail:
+    """Audit records written from a movable mark onwards."""
+
+    def __init__(self, mark):
+        self.mark = mark
+
+    def reset(self):
+        """Move the mark to now, so earlier records (a login) are ignored."""
+        self.mark = _max_audit_id()
+
+    def records(self):
+        return _read_audits(self.mark)
+
+
+@pytest.fixture
+def audit_trail():
+    """Read the audit records a test causes, removing them afterwards."""
+    setup_mark = _max_audit_id()
+
+    yield _AuditTrail(setup_mark)
+
+    session.execute(
+        text("DELETE FROM public.usuario_audit WHERE idusuario_audit > :since"),
+        {"since": setup_mark},
+    )
+    session_commit()
+
+
+# --------------------------------------------------------------------------
+# access control
+# --------------------------------------------------------------------------
+
+
+def test_complete_onboarding_requires_authentication(client):
+    """The endpoint is behind the standard JWT check [401 UNAUTHORIZED]."""
+    response = client.post(URL)
+
+    assert response.status_code == 401
+
+
+def test_complete_onboarding_requires_read_basic_features(
+    client, onboarding_state, audit_trail
+):
+    """A role without READ_BASIC_FEATURES cannot clear the flag [401]."""
+    onboarding_state(PENDING)
+    headers = make_headers(get_access(client, roles=[Role.DISPENSING_MANAGER.value]))
+    audit_trail.reset()
+
+    response = client.post(URL, headers=headers)
+
+    assert response.status_code == 401
+    assert _read_attribute()[0] == PENDING
+    assert audit_trail.records() == []
+
+
+# --------------------------------------------------------------------------
+# the transition
+# --------------------------------------------------------------------------
+
+
+def test_complete_onboarding_marks_a_pending_user_as_onboarded(
+    client, analyst_headers, onboarding_state, audit_trail
+):
+    """The pending row is updated in place, stamped with the user [200 OK]."""
+    onboarding_state(PENDING)
+
+    response = client.post(URL, headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "success"
+
+    value, updated_at, updated_by = _read_attribute()
+    assert value == ONBOARDED
+    assert updated_at is not None
+    assert updated_by == DEMO_USER_ID
+
+
+def test_complete_onboarding_records_an_audit_entry(
+    client, analyst_headers, onboarding_state, audit_trail
+):
+    """Support needs to see that the user went through onboarding."""
+    onboarding_state(PENDING)
+    audit_trail.reset()
+
+    client.post(URL, headers=analyst_headers)
+
+    audits = audit_trail.records()
+    assert len(audits) == 1
+
+    audit_type, extra, created_by = audits[0]
+    assert audit_type == UserAuditTypeEnum.UPDATE.value
+    assert extra == {"onboarding": ONBOARDED}
+    assert created_by == DEMO_USER_ID
+
+
+def test_complete_onboarding_is_idempotent(
+    client, analyst_headers, onboarding_state, audit_trail
+):
+    """A second call is a no-op: the flag is already cleared."""
+    onboarding_state(PENDING)
+    audit_trail.reset()
+
+    assert client.post(URL, headers=analyst_headers).status_code == 200
+    assert client.post(URL, headers=analyst_headers).status_code == 200
+
+    assert _read_attribute()[0] == ONBOARDED
+    # the repeat call must not stack a second audit record
+    assert len(audit_trail.records()) == 1
+
+
+# --------------------------------------------------------------------------
+# users the onboarding does not apply to
+# --------------------------------------------------------------------------
+
+
+def test_complete_onboarding_does_not_create_a_row_for_an_exempt_user(
+    client, analyst_headers, onboarding_state, audit_trail
+):
+    """No row means the user was never enrolled — the call leaves it that way.
+
+    Writing ``onboarded`` here would be worse than a no-op: the mere presence
+    of the row is what marks a user as new, so it would enrol them backwards.
+    """
+    onboarding_state(None)
+    audit_trail.reset()
+
+    response = client.post(URL, headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert _read_attribute() is None
+    assert audit_trail.records() == []
+
+
+def test_complete_onboarding_leaves_an_unknown_status_untouched(
+    client, analyst_headers, onboarding_state, audit_trail
+):
+    """Only ``pending`` is a transition the endpoint knows how to make."""
+    onboarding_state("zztest-unknown-status")
+    audit_trail.reset()
+
+    response = client.post(URL, headers=analyst_headers)
+
+    assert response.status_code == 200
+    assert _read_attribute()[0] == "zztest-unknown-status"
+    assert audit_trail.records() == []

--- a/tests/unit/test_name_service_update.py
+++ b/tests/unit/test_name_service_update.py
@@ -1,0 +1,197 @@
+"""Unit tests for the patient name write-back (``DynamoDBNameService.update_name``).
+
+Patient names live outside NoHarm, in whatever system the tenant runs. The only
+strategy that accepts a write is DynamoDB: ``update_name`` builds a partial
+``UpdateExpression`` from the fields it was given, so a caller sending just a
+phone number must not blank out the stored name.
+
+Two guards sit in front of the write and both are exercised here:
+
+* ``extra_data`` keys are checked against ``EXTRA_DATA_ALLOWED_KEYS`` — an
+  arbitrary key would otherwise be written straight into the item;
+* a call carrying no field at all is rejected instead of issuing an empty
+  ``SET``.
+
+Both guards raise inside the method's own ``try``, so — like every other failure
+here — they surface as the standard error response rather than as an exception.
+That is what callers see, so that is what these tests assert.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from services.name_service import DynamoDBNameService
+
+PATIENT_ID = 12345
+TABLE = "zztest-names"
+
+# fictitious values: nothing here is, or resembles, a real person's data
+A_NAME = "Fulano Beltrano"
+A_PHONE = "(00) 90000-0000"
+
+
+@pytest.fixture
+def service():
+    """A DynamoDB strategy pointed at a throwaway table name."""
+    config = {"getname": {"token": {"url": f"dy:{TABLE}", "params": {}}, "params": {}}}
+    return DynamoDBNameService(config, "test_schema")
+
+
+def _error_response(id_patient=PATIENT_ID):
+    return {
+        "status": "error",
+        "idPatient": id_patient,
+        "name": f"Paciente {id_patient}",
+    }
+
+
+class TestUpdateNameExpression:
+    """The UpdateExpression carries exactly the fields the caller sent"""
+
+    @patch("services.name_service.aws")
+    def test_name_only_updates_the_name_attribute(self, mock_aws, service):
+        """A name-only call writes ``nome`` and nothing else"""
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        result = service.update_name(id_patient=PATIENT_ID, name=A_NAME)
+
+        assert result == {"status": "success", "idPatient": PATIENT_ID}
+        mock_aws.get_resource.return_value.Table.assert_called_once_with(TABLE)
+
+        kwargs = table.update_item.call_args.kwargs
+        assert kwargs["Key"] == {"schema_fkpessoa": str(PATIENT_ID)}
+        assert kwargs["UpdateExpression"] == "SET #nome = :nome"
+        assert kwargs["ExpressionAttributeNames"] == {"#nome": "nome"}
+        assert kwargs["ExpressionAttributeValues"] == {":nome": A_NAME}
+
+    @patch("services.name_service.aws")
+    def test_extra_data_only_leaves_the_name_untouched(self, mock_aws, service):
+        """Updating only an extra field must not include ``nome`` in the SET"""
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        result = service.update_name(
+            id_patient=PATIENT_ID, extra_data={"fone": A_PHONE}
+        )
+
+        assert result == {"status": "success", "idPatient": PATIENT_ID}
+
+        kwargs = table.update_item.call_args.kwargs
+        assert kwargs["UpdateExpression"] == "SET #k0 = :v0"
+        assert kwargs["ExpressionAttributeNames"] == {"#k0": "fone"}
+        assert kwargs["ExpressionAttributeValues"] == {":v0": A_PHONE}
+
+    @patch("services.name_service.aws")
+    def test_name_and_extra_data_are_written_in_one_call(self, mock_aws, service):
+        """Both parts land in a single update_item call"""
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        result = service.update_name(
+            id_patient=PATIENT_ID, name=A_NAME, extra_data={"fone": A_PHONE}
+        )
+
+        assert result == {"status": "success", "idPatient": PATIENT_ID}
+        table.update_item.assert_called_once()
+
+        kwargs = table.update_item.call_args.kwargs
+        assert kwargs["UpdateExpression"] == "SET #nome = :nome, #k0 = :v0"
+        assert kwargs["ExpressionAttributeNames"] == {"#nome": "nome", "#k0": "fone"}
+        assert kwargs["ExpressionAttributeValues"] == {
+            ":nome": A_NAME,
+            ":v0": A_PHONE,
+        }
+
+    @patch("services.name_service.aws")
+    def test_an_empty_name_is_a_value_not_an_omission(self, mock_aws, service):
+        """``name=""`` clears the stored name; only ``None`` means "leave it" """
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        result = service.update_name(id_patient=PATIENT_ID, name="")
+
+        assert result == {"status": "success", "idPatient": PATIENT_ID}
+        assert table.update_item.call_args.kwargs["ExpressionAttributeValues"] == {
+            ":nome": ""
+        }
+
+    @patch("services.name_service.aws")
+    def test_the_patient_id_is_used_as_a_string_key(self, mock_aws, service):
+        """The partition key is stored as text, so an int id is stringified"""
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        result = service.update_name(id_patient=7, name=A_NAME)
+
+        assert result == {"status": "success", "idPatient": 7}
+        assert table.update_item.call_args.kwargs["Key"] == {"schema_fkpessoa": "7"}
+
+
+class TestUpdateNameGuards:
+    """Nothing is written when the request does not pass the guards"""
+
+    @patch("services.name_service.aws")
+    def test_unknown_extra_data_key_is_refused(self, mock_aws, service):
+        """A key outside the allow-list never reaches DynamoDB"""
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        result = service.update_name(
+            id_patient=PATIENT_ID, name=A_NAME, extra_data={"cpf": "000"}
+        )
+
+        assert result == _error_response()
+        table.update_item.assert_not_called()
+
+    @patch("services.name_service.aws")
+    def test_one_unknown_key_rejects_the_whole_update(self, mock_aws, service):
+        """The allowed field is dropped too: the update is all or nothing"""
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        result = service.update_name(
+            id_patient=PATIENT_ID,
+            extra_data={"fone": A_PHONE, "endereco": "Rua Teste, 1"},
+        )
+
+        assert result == _error_response()
+        table.update_item.assert_not_called()
+
+    @patch("services.name_service.aws")
+    def test_a_call_with_no_field_is_refused(self, mock_aws, service):
+        """No name and no extra data means there is nothing to SET"""
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        result = service.update_name(id_patient=PATIENT_ID)
+
+        assert result == _error_response()
+        table.update_item.assert_not_called()
+
+    @patch("services.name_service.aws")
+    def test_empty_extra_data_is_not_a_field(self, mock_aws, service):
+        """An empty dict is falsy, so it cannot stand in for a real update"""
+        table = mock_aws.get_resource.return_value.Table.return_value
+
+        result = service.update_name(id_patient=PATIENT_ID, extra_data={})
+
+        assert result == _error_response()
+        table.update_item.assert_not_called()
+
+    @patch("services.name_service.aws")
+    def test_a_dynamodb_failure_is_reported_as_the_placeholder(
+        self, mock_aws, service
+    ):
+        """An outage must not raise through to the caller"""
+        table = mock_aws.get_resource.return_value.Table.return_value
+        table.update_item.side_effect = RuntimeError("dynamo is down")
+
+        result = service.update_name(id_patient=PATIENT_ID, name=A_NAME)
+
+        assert result == _error_response()
+
+    @patch("services.name_service.aws")
+    def test_a_missing_table_configuration_is_reported_the_same_way(
+        self, mock_aws, service
+    ):
+        """A malformed ``token.url`` cannot name a table — still no exception"""
+        service.config["getname"]["token"]["url"] = "dy"
+
+        result = service.update_name(id_patient=PATIENT_ID, name=A_NAME)
+
+        assert result == _error_response()
+        mock_aws.get_resource.return_value.Table.assert_not_called()


### PR DESCRIPTION
Two features had no test at all. This PR adds unit and integration tests for both — no production code changes.

## 1. Patient name write-back

Names are *read* through `/names`, but they are *written* through `POST /patient/<admission>`: `patient_service.save_patient` hands a `name` block over to `name_service.update_patient_name`, which is the only path that reaches `DynamoDBNameService.update_name`. Neither function was executed by any test, so nothing pinned down:

- the partial `UpdateExpression` — a phone-only update must not blank out the stored name;
- the `extra_data` allow-list (`EXTRA_DATA_ALLOWED_KEYS`), the only thing stopping an arbitrary key from being written straight into the DynamoDB item;
- the refusal of a call carrying no field at all, instead of issuing an empty `SET`;
- DynamoDB being the *only* strategy that accepts a write — internal, proxy and external tenants are read-only;
- `WRITE_NAME` being required on top of whatever permission opened the patient endpoint.

**`tests/unit/test_name_service_update.py`** (new, 11 tests) covers the expression building and both guards, including that one bad key cancels the whole update and that a DynamoDB outage surfaces as the standard placeholder response rather than an exception.

**`tests/integration/test_names.py`** gains a write-back section (7 tests) that goes through the real route with only the `aws` boundary patched, reusing the file's existing `getname_config` fixture. It also pins the current leniency deliberately: an unknown `extra_data` key cancels the write **silently** and the caller still gets a `200` — the name service swallows its own failures so a lookup never takes a patient screen down, and the write inherits that handling.

## 2. User onboarding completion

`POST /user/complete-onboarding` clears the `onboarding` row in `public.usuario_atributo` that makes the onboarding training mandatory. The endpoint, `user_service.complete_onboarding` and `user_attribute_repository.set_value` were all unexercised.

**`tests/integration/test_user_onboarding.py`** (new, 7 tests) covers the `READ_BASIC_FEATURES` gate, the `pending` → `onboarded` transition with its `updated_by` stamp, the audit record support relies on, idempotence (a repeat call must not stack a second audit row), and the case that matters most: **a user with no attribute row is exempt, and the endpoint must not create one for them** — the mere presence of that row is what marks a user as new, so writing it would enrol them backwards.

## Notes

- Both new fixtures snapshot and restore what they touch (the attribute row, the audit records, the tenant `getname` config), so the suite stays re-runnable and leaves no residue.
- Test data is fictitious throughout (`Fulano Beltrano`, `(00) 90000-0000`, `zztest-` prefixes).
- The tests were mutation-checked: breaking the `pending` guard and the `extra_data` allow-list makes 6 of them fail.

## Coverage

| module | before | after |
| --- | --- | --- |
| `services/name_service.py` | 81% | 91% |
| `services/user_service.py` | 87% | 90% |
| `repository/user_attribute_repository.py` | 69% | 94% |
| `routes/user.py` | 90% | 95% |

Full suite: 2704 → 2731 passing, `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wb4om694v4edqmF7RSsZd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb4om694v4edqmF7RSsZd1)_